### PR TITLE
fix typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -656,7 +656,7 @@ How to validate TD? RDF validation? Structure validation?
   }
 </pre>
 
-<p>In the above example, a JSON Web Token (JWT) type is assigned ("cat"), along with a corresponding hashing algorithm "HS256" ("alg") and the issuing authority of the security token ("as").</p>
+<p>In the above example, a JSON Web Token (JWT) type is assigned (<code>cat</code>), along with a corresponding hashing algorithm "HS256" (<code>alg</code>) and the issuing authority of the security token (<code>as</code>).</p>
 
       <p class="ednote">Consider the need for a context definition for the above example.
       </p>

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@ The TD must be acquired to use and interact with the Thing, since it describes t
   <section id="introduction">
     <h1>Introduction</h1>
     <p>
-The W3C Thing Desccription (TD) is a central building block in a Web of Things (WoT) enabled system and can be considered as the entry point of a Thing (aka the <i>index.html</i> of the Thing). The TD comprises of semantic metadata for the Thing itself, a narrow-waist interaction model with WoT's Properties, Actions, and Events, a semantic schema to make data models machine-understandable, and features for Web Linking to express relations among Things. 
+The W3C Thing Description (TD) is a central building block in a Web of Things (WoT) enabled system and can be considered as the entry point of a Thing (aka the <i>index.html</i> of the Thing). The TD consists of semantic metadata for the Thing itself, a narrow-waist interaction model with WoT's Properties, Actions, and Events, a semantic schema to make data models machine-understandable, and features for Web Linking to express relations among Things. 
 </p>
 <p>
 Properties can be used for controlling parameters, such as a set point or operation state. Actions model invocation of physical processes, but can also be used to abstract RPC-like calls of existing platforms. Events cover the push model where state change notifications, discrete events, and streams of values are sent asynchronously to the receiver. In general, the TD provides metadata for the different communication bindings (e.g., HTTP, CoAP, (MQTT?), etc.), mediaTypes (e.g., "application/json", "application/xml", "application/cbor", "application/exi" etc.), and security policies (authentication, authorization, etc.). The default serialisation of the TD is JSON-LD.
@@ -169,7 +169,7 @@ Example 1 shows a simple TD instance that describes a lamp Thing with the name <
 
 
 
-<p>Based on this content, we know there exists one Property interaction resource with the name <i>status</i>. In addition, information is provided such as that this Property is accessable over the CoAP protocol with a GET method (see CoAP protocol binding description in the W3C WoT protocol template deliverable [XXX]) at coaps://mylamp.example.com:5683/status (announced within the endoind structure by the <code>href</code> kye), which will return a string status value within a JSON structure (JSON as payload format is announced by the <code>mediaType</code> field).
+<p>Based on this content, we know there exists one Property interaction resource with the name <i>status</i>. In addition, information is provided such as that this Property is accessable over the CoAP protocol with a GET method (see CoAP protocol binding description in the W3C WoT protocol template deliverable [XXX]) at coaps://mylamp.example.com:5683/status (announced within the endoind (SP?) structure by the <code>href</code> key), which will return a string status value within a JSON structure (JSON as payload format is announced by the <code>mediaType</code> field).
 </p>
 
 <p class="ednote">
@@ -241,7 +241,7 @@ How to validate TD? RDF validation? Structure validation?
     <h1>Serialization</h1>
 
 <p>
-  Thing Description instances are modelled on the classes defined in <a href="#vocabularyDefinitionSection" class="sec-ref"></a>, and they are serialized in <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a> by default, using the vocabulary defined there when they are served at run-time.
+  Thing Description instances are modeled on the classes defined in <a href="#vocabularyDefinitionSection" class="sec-ref"></a>, and they are serialized in <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a> by default, using the vocabulary defined there when they are served at run-time.
   JSON-LD is a serialization format that adds a semantic layer on top of the JSON specification: the terms that appear in a JSON document
   should be associated with uniquely identified concepts from shared vocabularies. This principle is part of a set of practices to publish data
   on the Web called Linked Data, where concepts are usually identified with URIs and originate from RDF vocabularies.
@@ -325,7 +325,7 @@ How to validate TD? RDF validation? Structure validation?
 
     <p>
       An interaction in the context of the Web of Things is an exchange of data between a Web client and a Thing.
-      This data can be either given as input by the client, returned as output by the Thing or both.
+      This data can be either given as input by the client, returned as output by the Thing, or both.
       Three interaction patterns are defined: 
       <a href="#property-serialization">Property</a>, 
       <a href="#action-serialization">Action</a>, and 
@@ -360,7 +360,7 @@ How to validate TD? RDF validation? Structure validation?
         }
       </pre>
 
-      <p>JSON-LD representation for a <code>Property</code> interaction definition is a JSON object of which the fields are defined below.</p>
+      <p>The JSON-LD representation for a <code>Property</code> interaction definition is a JSON object of which the fields are defined below.</p>
 
       <table class="def">
         <thead>
@@ -443,7 +443,7 @@ How to validate TD? RDF validation? Structure validation?
       <p>
         The <code>Action</code> interaction pattern (also see <a href="#action">Action vocabulary definition section</a>) targets changes or processes on a Thing that take a certain time to complete (i.e., actions cannot be applied instantaneously like property writes).
         Examples include an LED fade in, moving a robot, brewing a cup of coffee, etc.
-        Usually, ongoing Actions are modelled as Task resources, which are created when an Action invocation is received by the Thing.
+        Usually, ongoing Actions are modeled as Task resources, which are created when an Action invocation is received by the Thing.
       </p>
   
       <pre class="example">
@@ -572,7 +572,7 @@ How to validate TD? RDF validation? Structure validation?
 
     </section>
 
-      <p>JSON-LD representation for an <code>Event</code> interaction definition is a JSON object of which the fields are defined below.</p>
+      <p>The JSON-LD representation for an <code>Event</code> interaction definition is a JSON object of which the fields are defined below.</p>
 
       <table class="def">
         <thead>
@@ -656,7 +656,7 @@ How to validate TD? RDF validation? Structure validation?
   }
 </pre>
 
-<p>In the above example, JSON Web Token (JWT) type is assigned (cat), along with a corresponding hashing algorithm "HS256" (alg) and issuing authority of the security token (as).</p>
+<p>In the above example, a JSON Web Token (JWT) type is assigned ("cat"), along with a corresponding hashing algorithm "HS256" ("alg") and the issuing authority of the security token ("as").</p>
 
       <p class="ednote">Consider the need for a context definition for the above example.
       </p>
@@ -665,7 +665,7 @@ How to validate TD? RDF validation? Structure validation?
   <section>
     <h1>Thing as a Whole</h1>
 
-      <p>JSON-LD representation for a Thing Description is a JSON object of which fields are defined below.</p>
+      <p>The JSON-LD representation for a Thing Description is a JSON object of which fields are defined below.</p>
 
       <table class="def">
         <thead>
@@ -729,7 +729,7 @@ The  <code>@context</code> key is used to define Thing Description's context. Al
   </pre>
 
 <p>
-  In case a single Thing Description instance involves several contexts, additional namespaces with prefixs can be extended to the <code>@context</code> array structure. This option proves relevant if one wants to extend the existing Thing Description context without modifying it. For instance:
+  In case a single Thing Description instance involves several contexts, additional namespaces with prefixes can be extended to the <code>@context</code> array structure. This option proves relevant if one wants to extend the existing Thing Description context without modifying it. For instance:
 </p>
   <pre class="example">
     {
@@ -901,7 +901,7 @@ using <code>inputData</code> and <code>outputData</code> field, respectively. Th
       <p>The snippet in the above example is a valid JSON document according to the syntax defined in [[!RFC7159]], which allows sending simple types in the root of the document. There is no need for wrapping a single value into an object.
       </p>
 
-      <p>The same data (i.e. a number of 184) will look like the following when the data is exchanged in XML.
+      <p>The same data (i.e. a number equal to 184) will look like the following when the data is exchanged in XML.
       </p>
 
       <pre class="example">
@@ -916,9 +916,9 @@ using <code>inputData</code> and <code>outputData</code> field, respectively. Th
       <p>In the previous section, we used an example <code>inputData</code> definition consisting of a single <code>integer</code>.
       </p>
 	
-      <p>With type system, it is also possible to define value types that have more than one literal value.
-      Type system provides two distinct constructs to define a structure that can have multiple literal values. 
-      One is <code>object</code>, and the other is <code>array</code>.
+      <p>With the type system, it is also possible to define value types that have more than one literal value.
+      The type system provides two distinct constructs to define a structure that can have multiple literal values. 
+      One is the <code>object</code>, and the other is the <code>array</code>.
       </p>
 
       <section>
@@ -995,7 +995,7 @@ using <code>inputData</code> and <code>outputData</code> field, respectively. Th
           }
         </pre>
     
-        <p>When the numbers being exchanged are 208, 32 and 144, data serialization in JSON format will look like the following.
+        <p>When the numbers being exchanged are 520, 184 and 1314, data serialization in JSON format will look like the following.
         </p>
     
         <pre class="example">
@@ -1025,12 +1025,12 @@ using <code>inputData</code> and <code>outputData</code> field, respectively. Th
     <section>
     <h4>Mapping to XML Schema</h4>
 
-      <p>In the previous section, examples showed what those data whose value type is described using type system
+      <p>In the previous section, examples showed what data whose value type is described using the type system
       look like when serialized to XML in parallel to corresponding JSON serializations.
       </p>
 
-      <p>This section describes how type definitions described using type system can be mapped to XML schema definitions by using the same examples.
-      Given type definitions, providing the mapping to XML schema allows XML tools to directly validate serialized XML data, for example.
+      <p>This section describes how type definitions described using the type system can be mapped to XML schema definitions by using the same examples.
+      Given these type definitions, providing the mapping to XML schema allows XML tools to directly validate serialized XML data, for example.
       The XML structure for which this mapping is designed is based on EXI4JSON [[exi-for-json]].
       </p>
 
@@ -1203,7 +1203,7 @@ using <code>inputData</code> and <code>outputData</code> field, respectively. Th
   <section>
     <h2>Parsing</h2>
 <p>
-To parse a valid Thing Description a simple JSON-based parser and tools can be used to retrieve the content. To validate and follow the references of external used context vocabulary, JSON-LD or RDF-based parsing tools and libraries are highly recommended.   
+To parse a valid Thing Description a simple JSON-based parser and tools can be used to retrieve the content. To validate and follow references to external context vocabulary, JSON-LD or RDF-based parsing tools and libraries are highly recommended.   
 </p>
    </section>
 
@@ -1293,7 +1293,7 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
         Moreover, one of the Events of the Thing is linked to the measured value
         (with the predicate <code>property</code>). It means
         in that context that an event should be triggered each time <code>myTemp</code>
-        changes. The other Event does not define further semantics, it could be used either
+        changes. The other Event does not define further semantics. It could be used either
         in a closed system (where clients are aware of its meaning) or by a human but
         an external agent would not have sufficient information to interpret it.
       </p>
@@ -1342,7 +1342,7 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
       <p>
         In this last example, we illustrate the use of <code>associations</code>.
         The Thing we modeled here acts as a master switch for eight lamps similar
-        to that of <a href="#led-actuator"></a>. It means switching on and off
+        to that of <a href="#led-actuator"></a>. This means switching on and off
         <code>myMasterOnOff</code> will propagate to all associated Things
         by toggling their Action that is also of type <code>Toggle</code>.
       </p>
@@ -1350,7 +1350,7 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
       <p>
         No precise semantics for <code>associations</code> have been defined yet
         and there might exist many other kinds of dependency between Things than
-        simply parent/child relation. This issue will be addressed soon. Until then,
+        simply parent/child relations. This issue will be addressed soon. Until then,
         Thing associations could be useful for discovery.
       </p>
 
@@ -1361,7 +1361,7 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
   </section>
     
 <section id="security-consideration">
-      <h4>Security Consideration</h4>
+      <h4>Security Considerations</h4>
       <p>Security of a WoT system can refer to the security of the Thing Description itself or the security of
       the Thing the Thing Description describes.
       We focus here on the security of the Thing Description itself.
@@ -1454,13 +1454,15 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
 	    data authenticity and in many cases confidentiality 
         (depending on whenever a TD contains any confidential information)
         to avoid manipulation of a TD. 
-      If end-to-end TD authenticity is required, it is possible to sign TD objects with either digital signatures (using asymmetric cryptographic primitives) or Message Authentication Codes (MACs)(using symmetric cryptographic primitives. Such digital signatures or MACs are created by the producers/issuers of TD objects and validated by consumers of TD objects (which should reject signed TD objects whose signatures/MACs are invalid). For TD objects expressed in JSON, RFC 7515 (IETF JSON Web Signature: https://datatracker.ietf.org/doc/rfc7515/) provides the guidelines for computation and validation of digital signatures or MACs using JSON-based data structures. 
-      Similarly, if end-to-end TD confidentiality is required (though probably much more rare case than authenticity), it is possible to encrypt TD objects using available cryptographic encryption primitives. For TD objects expressed in JSON, RFC 7516 (IETF JSON Web Encryption: https://datatracker.ietf.org/doc/rfc7516/) provides the guidelines for encryption and decryption of JSON-based data structures. 
+</p><p>
+      If end-to-end TD authenticity is required, it is possible to sign TD objects with either digital signatures (using asymmetric cryptographic primitives) or Message Authentication Codes (MACs, using symmetric cryptographic primitives). Such digital signatures or MACs are created by the producers/issuers of TD objects and validated by consumers of TD objects (which should reject signed TD objects whose signatures/MACs are invalid). For TD objects expressed in JSON, RFC 7515 (IETF JSON Web Signature: https://datatracker.ietf.org/doc/rfc7515/) provides the guidelines for computation and validation of digital signatures or MACs using JSON-based data structures. 
+</p><p>
+      Similarly, if end-to-end TD confidentiality is required (though probably a much more rare case than authenticity), it is possible to encrypt TD objects using available cryptographic encryption primitives. For TD objects expressed in JSON, RFC 7516 (IETF JSON Web Encryption: https://datatracker.ietf.org/doc/rfc7516/) provides the guidelines for encryption and decryption of JSON-based data structures. 
 	    When TD is stored at the end device or remote storage,
         its authenticity and in some cases confidentiality should
-	    be protected using the best available local methods.
-        TD also should define an Access Control mechanism that prevents 
-	    illegitimate modification of any of its parts. 
+	    also be protected using the best available local methods.
+        An access control mechanism should also be used that prevents 
+	    illegitimate modification of any of the TD's parts. 
             </p><p>
 	    This recommendation helps prevent the following threats: 
             WoT Communication - TD Authenticity,

--- a/index.html.template
+++ b/index.html.template
@@ -656,7 +656,7 @@ How to validate TD? RDF validation? Structure validation?
   }
 </pre>
 
-<p>In the above example, a JSON Web Token (JWT) type is assigned ("cat"), along with a corresponding hashing algorithm "HS256" ("alg") and the issuing authority of the security token ("as").</p>
+<p>In the above example, a JSON Web Token (JWT) type is assigned (<code>cat</code>), along with a corresponding hashing algorithm "HS256" (<code>alg</code>) and the issuing authority of the security token (<code>as</code>).</p>
 
       <p class="ednote">Consider the need for a context definition for the above example.
       </p>

--- a/index.html.template
+++ b/index.html.template
@@ -118,7 +118,7 @@ The TD must be acquired to use and interact with the Thing, since it describes t
   <section id="introduction">
     <h1>Introduction</h1>
     <p>
-The W3C Thing Desccription (TD) is a central building block in a Web of Things (WoT) enabled system and can be considered as the entry point of a Thing (aka the <i>index.html</i> of the Thing). The TD comprises of semantic metadata for the Thing itself, a narrow-waist interaction model with WoT's Properties, Actions, and Events, a semantic schema to make data models machine-understandable, and features for Web Linking to express relations among Things. 
+The W3C Thing Description (TD) is a central building block in a Web of Things (WoT) enabled system and can be considered as the entry point of a Thing (aka the <i>index.html</i> of the Thing). The TD consists of semantic metadata for the Thing itself, a narrow-waist interaction model with WoT's Properties, Actions, and Events, a semantic schema to make data models machine-understandable, and features for Web Linking to express relations among Things. 
 </p>
 <p>
 Properties can be used for controlling parameters, such as a set point or operation state. Actions model invocation of physical processes, but can also be used to abstract RPC-like calls of existing platforms. Events cover the push model where state change notifications, discrete events, and streams of values are sent asynchronously to the receiver. In general, the TD provides metadata for the different communication bindings (e.g., HTTP, CoAP, (MQTT?), etc.), mediaTypes (e.g., "application/json", "application/xml", "application/cbor", "application/exi" etc.), and security policies (authentication, authorization, etc.). The default serialisation of the TD is JSON-LD.
@@ -169,7 +169,7 @@ Example 1 shows a simple TD instance that describes a lamp Thing with the name <
 
 
 
-<p>Based on this content, we know there exists one Property interaction resource with the name <i>status</i>. In addition, information is provided such as that this Property is accessable over the CoAP protocol with a GET method (see CoAP protocol binding description in the W3C WoT protocol template deliverable [XXX]) at coaps://mylamp.example.com:5683/status (announced within the endoind structure by the <code>href</code> kye), which will return a string status value within a JSON structure (JSON as payload format is announced by the <code>mediaType</code> field).
+<p>Based on this content, we know there exists one Property interaction resource with the name <i>status</i>. In addition, information is provided such as that this Property is accessable over the CoAP protocol with a GET method (see CoAP protocol binding description in the W3C WoT protocol template deliverable [XXX]) at coaps://mylamp.example.com:5683/status (announced within the endoind (SP?) structure by the <code>href</code> key), which will return a string status value within a JSON structure (JSON as payload format is announced by the <code>mediaType</code> field).
 </p>
 
 <p class="ednote">
@@ -241,7 +241,7 @@ How to validate TD? RDF validation? Structure validation?
     <h1>Serialization</h1>
 
 <p>
-  Thing Description instances are modelled on the classes defined in <a href="#vocabularyDefinitionSection" class="sec-ref"></a>, and they are serialized in <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a> by default, using the vocabulary defined there when they are served at run-time.
+  Thing Description instances are modeled on the classes defined in <a href="#vocabularyDefinitionSection" class="sec-ref"></a>, and they are serialized in <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a> by default, using the vocabulary defined there when they are served at run-time.
   JSON-LD is a serialization format that adds a semantic layer on top of the JSON specification: the terms that appear in a JSON document
   should be associated with uniquely identified concepts from shared vocabularies. This principle is part of a set of practices to publish data
   on the Web called Linked Data, where concepts are usually identified with URIs and originate from RDF vocabularies.
@@ -325,7 +325,7 @@ How to validate TD? RDF validation? Structure validation?
 
     <p>
       An interaction in the context of the Web of Things is an exchange of data between a Web client and a Thing.
-      This data can be either given as input by the client, returned as output by the Thing or both.
+      This data can be either given as input by the client, returned as output by the Thing, or both.
       Three interaction patterns are defined: 
       <a href="#property-serialization">Property</a>, 
       <a href="#action-serialization">Action</a>, and 
@@ -360,7 +360,7 @@ How to validate TD? RDF validation? Structure validation?
         }
       </pre>
 
-      <p>JSON-LD representation for a <code>Property</code> interaction definition is a JSON object of which the fields are defined below.</p>
+      <p>The JSON-LD representation for a <code>Property</code> interaction definition is a JSON object of which the fields are defined below.</p>
 
       <table class="def">
         <thead>
@@ -443,7 +443,7 @@ How to validate TD? RDF validation? Structure validation?
       <p>
         The <code>Action</code> interaction pattern (also see <a href="#action">Action vocabulary definition section</a>) targets changes or processes on a Thing that take a certain time to complete (i.e., actions cannot be applied instantaneously like property writes).
         Examples include an LED fade in, moving a robot, brewing a cup of coffee, etc.
-        Usually, ongoing Actions are modelled as Task resources, which are created when an Action invocation is received by the Thing.
+        Usually, ongoing Actions are modeled as Task resources, which are created when an Action invocation is received by the Thing.
       </p>
   
       <pre class="example">
@@ -572,7 +572,7 @@ How to validate TD? RDF validation? Structure validation?
 
     </section>
 
-      <p>JSON-LD representation for an <code>Event</code> interaction definition is a JSON object of which the fields are defined below.</p>
+      <p>The JSON-LD representation for an <code>Event</code> interaction definition is a JSON object of which the fields are defined below.</p>
 
       <table class="def">
         <thead>
@@ -656,7 +656,7 @@ How to validate TD? RDF validation? Structure validation?
   }
 </pre>
 
-<p>In the above example, JSON Web Token (JWT) type is assigned (cat), along with a corresponding hashing algorithm "HS256" (alg) and issuing authority of the security token (as).</p>
+<p>In the above example, a JSON Web Token (JWT) type is assigned ("cat"), along with a corresponding hashing algorithm "HS256" ("alg") and the issuing authority of the security token ("as").</p>
 
       <p class="ednote">Consider the need for a context definition for the above example.
       </p>
@@ -665,7 +665,7 @@ How to validate TD? RDF validation? Structure validation?
   <section>
     <h1>Thing as a Whole</h1>
 
-      <p>JSON-LD representation for a Thing Description is a JSON object of which fields are defined below.</p>
+      <p>The JSON-LD representation for a Thing Description is a JSON object of which fields are defined below.</p>
 
       <table class="def">
         <thead>
@@ -729,7 +729,7 @@ The  <code>@context</code> key is used to define Thing Description's context. Al
   </pre>
 
 <p>
-  In case a single Thing Description instance involves several contexts, additional namespaces with prefixs can be extended to the <code>@context</code> array structure. This option proves relevant if one wants to extend the existing Thing Description context without modifying it. For instance:
+  In case a single Thing Description instance involves several contexts, additional namespaces with prefixes can be extended to the <code>@context</code> array structure. This option proves relevant if one wants to extend the existing Thing Description context without modifying it. For instance:
 </p>
   <pre class="example">
     {
@@ -901,7 +901,7 @@ using <code>inputData</code> and <code>outputData</code> field, respectively. Th
       <p>The snippet in the above example is a valid JSON document according to the syntax defined in [[!RFC7159]], which allows sending simple types in the root of the document. There is no need for wrapping a single value into an object.
       </p>
 
-      <p>The same data (i.e. a number of 184) will look like the following when the data is exchanged in XML.
+      <p>The same data (i.e. a number equal to 184) will look like the following when the data is exchanged in XML.
       </p>
 
       <pre class="example">
@@ -916,9 +916,9 @@ using <code>inputData</code> and <code>outputData</code> field, respectively. Th
       <p>In the previous section, we used an example <code>inputData</code> definition consisting of a single <code>integer</code>.
       </p>
 	
-      <p>With type system, it is also possible to define value types that have more than one literal value.
-      Type system provides two distinct constructs to define a structure that can have multiple literal values. 
-      One is <code>object</code>, and the other is <code>array</code>.
+      <p>With the type system, it is also possible to define value types that have more than one literal value.
+      The type system provides two distinct constructs to define a structure that can have multiple literal values. 
+      One is the <code>object</code>, and the other is the <code>array</code>.
       </p>
 
       <section>
@@ -995,7 +995,7 @@ using <code>inputData</code> and <code>outputData</code> field, respectively. Th
           }
         </pre>
     
-        <p>When the numbers being exchanged are 208, 32 and 144, data serialization in JSON format will look like the following.
+        <p>When the numbers being exchanged are 520, 184 and 1314, data serialization in JSON format will look like the following.
         </p>
     
         <pre class="example">
@@ -1025,12 +1025,12 @@ using <code>inputData</code> and <code>outputData</code> field, respectively. Th
     <section>
     <h4>Mapping to XML Schema</h4>
 
-      <p>In the previous section, examples showed what those data whose value type is described using type system
+      <p>In the previous section, examples showed what data whose value type is described using the type system
       look like when serialized to XML in parallel to corresponding JSON serializations.
       </p>
 
-      <p>This section describes how type definitions described using type system can be mapped to XML schema definitions by using the same examples.
-      Given type definitions, providing the mapping to XML schema allows XML tools to directly validate serialized XML data, for example.
+      <p>This section describes how type definitions described using the type system can be mapped to XML schema definitions by using the same examples.
+      Given these type definitions, providing the mapping to XML schema allows XML tools to directly validate serialized XML data, for example.
       The XML structure for which this mapping is designed is based on EXI4JSON [[exi-for-json]].
       </p>
 
@@ -1203,7 +1203,7 @@ using <code>inputData</code> and <code>outputData</code> field, respectively. Th
   <section>
     <h2>Parsing</h2>
 <p>
-To parse a valid Thing Description a simple JSON-based parser and tools can be used to retrieve the content. To validate and follow the references of external used context vocabulary, JSON-LD or RDF-based parsing tools and libraries are highly recommended.   
+To parse a valid Thing Description a simple JSON-based parser and tools can be used to retrieve the content. To validate and follow references to external context vocabulary, JSON-LD or RDF-based parsing tools and libraries are highly recommended.   
 </p>
    </section>
 
@@ -1293,7 +1293,7 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
         Moreover, one of the Events of the Thing is linked to the measured value
         (with the predicate <code>property</code>). It means
         in that context that an event should be triggered each time <code>myTemp</code>
-        changes. The other Event does not define further semantics, it could be used either
+        changes. The other Event does not define further semantics. It could be used either
         in a closed system (where clients are aware of its meaning) or by a human but
         an external agent would not have sufficient information to interpret it.
       </p>
@@ -1342,7 +1342,7 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
       <p>
         In this last example, we illustrate the use of <code>associations</code>.
         The Thing we modeled here acts as a master switch for eight lamps similar
-        to that of <a href="#led-actuator"></a>. It means switching on and off
+        to that of <a href="#led-actuator"></a>. This means switching on and off
         <code>myMasterOnOff</code> will propagate to all associated Things
         by toggling their Action that is also of type <code>Toggle</code>.
       </p>
@@ -1350,7 +1350,7 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
       <p>
         No precise semantics for <code>associations</code> have been defined yet
         and there might exist many other kinds of dependency between Things than
-        simply parent/child relation. This issue will be addressed soon. Until then,
+        simply parent/child relations. This issue will be addressed soon. Until then,
         Thing associations could be useful for discovery.
       </p>
 
@@ -1361,7 +1361,7 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
   </section>
     
 <section id="security-consideration">
-      <h4>Security Consideration</h4>
+      <h4>Security Considerations</h4>
       <p>Security of a WoT system can refer to the security of the Thing Description itself or the security of
       the Thing the Thing Description describes.
       We focus here on the security of the Thing Description itself.
@@ -1454,13 +1454,15 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
 	    data authenticity and in many cases confidentiality 
         (depending on whenever a TD contains any confidential information)
         to avoid manipulation of a TD. 
-      If end-to-end TD authenticity is required, it is possible to sign TD objects with either digital signatures (using asymmetric cryptographic primitives) or Message Authentication Codes (MACs)(using symmetric cryptographic primitives. Such digital signatures or MACs are created by the producers/issuers of TD objects and validated by consumers of TD objects (which should reject signed TD objects whose signatures/MACs are invalid). For TD objects expressed in JSON, RFC 7515 (IETF JSON Web Signature: https://datatracker.ietf.org/doc/rfc7515/) provides the guidelines for computation and validation of digital signatures or MACs using JSON-based data structures. 
-      Similarly, if end-to-end TD confidentiality is required (though probably much more rare case than authenticity), it is possible to encrypt TD objects using available cryptographic encryption primitives. For TD objects expressed in JSON, RFC 7516 (IETF JSON Web Encryption: https://datatracker.ietf.org/doc/rfc7516/) provides the guidelines for encryption and decryption of JSON-based data structures. 
+</p><p>
+      If end-to-end TD authenticity is required, it is possible to sign TD objects with either digital signatures (using asymmetric cryptographic primitives) or Message Authentication Codes (MACs, using symmetric cryptographic primitives). Such digital signatures or MACs are created by the producers/issuers of TD objects and validated by consumers of TD objects (which should reject signed TD objects whose signatures/MACs are invalid). For TD objects expressed in JSON, RFC 7515 (IETF JSON Web Signature: https://datatracker.ietf.org/doc/rfc7515/) provides the guidelines for computation and validation of digital signatures or MACs using JSON-based data structures. 
+</p><p>
+      Similarly, if end-to-end TD confidentiality is required (though probably a much more rare case than authenticity), it is possible to encrypt TD objects using available cryptographic encryption primitives. For TD objects expressed in JSON, RFC 7516 (IETF JSON Web Encryption: https://datatracker.ietf.org/doc/rfc7516/) provides the guidelines for encryption and decryption of JSON-based data structures. 
 	    When TD is stored at the end device or remote storage,
         its authenticity and in some cases confidentiality should
-	    be protected using the best available local methods.
-        TD also should define an Access Control mechanism that prevents 
-	    illegitimate modification of any of its parts. 
+	    also be protected using the best available local methods.
+        An access control mechanism should also be used that prevents 
+	    illegitimate modification of any of the TD's parts. 
             </p><p>
 	    This recommendation helps prevent the following threats: 
             WoT Communication - TD Authenticity,


### PR DESCRIPTION
Suggest some typo fixes.  Also some minor grammar and content fixes.  summary of main changes:
- modelling -> modeling.  Actually, some places in the document used one, some the other.  According to https://www.merriam-webster.com/dictionary/modeled (look under "model" as a verb) "modelling" is actually semi-OK but is marked as "used less frequently", and all the examples use "modeling" or "modeled" so "modelling" and "modelled" seem to be non-standard.
- kye -> key, Desccription -> Description, other such minor fixes
- changed numbers in array example to match the prose and the code example.  If I missed something (i.e. were these supposed to be scaled or something like that) please revert.
- I put quotes around the "cat", "as", etc. keys in the security section but it would be more consistent with similar examples later in the text to use code tags so I will update my PR to use those instead shortly.
- added an Oxford comma in one place.

This does not include my fixes to the abstract, I have set up the PRs to be non-overlapping, so they can be merged separately.