### PR TITLE
fix hyperlinks (to wot-security); add ed note

### DIFF
--- a/index.html
+++ b/index.html
@@ -1361,7 +1361,14 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
   </section>
     
 <section id="security-consideration">
-      <h4>Security Consideration</h4>
+      <h4>Security and Privacy Considerations</h4>
+<p class="ednote">
+  This section will likely undergo significant revision and reorganization.
+  Please see the
+  <a href="https://github.com/w3c/wot-security/">WoT Security and Privacy</a>
+  repository for work in progress.
+</p>
+
       <p>Security of a WoT system can refer to the security of the Thing Description itself or the security of
       the Thing the Thing Description describes.
       We focus here on the security of the Thing Description itself.
@@ -1410,7 +1417,7 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
           <h6>Threat Model</h6>
           <p>
 	   <!-- TODO: This hyperlink should be turned into a proper reference -->
-           The following main <a href="https://github.com/mmccool/wot/blob/master/security-privacy/AssetsThreatModelSecurityObjectives.md">threats</a> on the 
+           The following main <a href="https://github.com/w3c/wot-security/blob/master/wot-threat-model.md">threats</a> on the 
            above assets should be taken into account while developing a TD:
            <ul>
            <li><strong>WoT TD - Privacy.</strong>

--- a/index.html.template
+++ b/index.html.template
@@ -1361,7 +1361,14 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
   </section>
     
 <section id="security-consideration">
-      <h4>Security Consideration</h4>
+      <h4>Security and Privacy Considerations</h4>
+<p class="ednote">
+  This section will likely undergo significant revision and reorganization.
+  Please see the
+  <a href="https://github.com/w3c/wot-security/">WoT Security and Privacy</a>
+  repository for work in progress.
+</p>
+
       <p>Security of a WoT system can refer to the security of the Thing Description itself or the security of
       the Thing the Thing Description describes.
       We focus here on the security of the Thing Description itself.
@@ -1410,7 +1417,7 @@ To parse a valid Thing Description a simple JSON-based parser and tools can be u
           <h6>Threat Model</h6>
           <p>
 	   <!-- TODO: This hyperlink should be turned into a proper reference -->
-           The following main <a href="https://github.com/mmccool/wot/blob/master/security-privacy/AssetsThreatModelSecurityObjectives.md">threats</a> on the 
+           The following main <a href="https://github.com/w3c/wot-security/blob/master/wot-threat-model.md">threats</a> on the 
            above assets should be taken into account while developing a TD:
            <ul>
            <li><strong>WoT TD - Privacy.</strong>


### PR DESCRIPTION
Fix hyperlink to threat model so it points at the new repo.   Add an editor's note to indicate that this material is likely to be revised.   Change section title to "Security and Privacy Considerations" to better reflect its content (eg adds "and Privacy").