### PR TITLE
Automate Normative Assertion Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ npm run render
 
 ## Normative Assertions
 
-To extract a list of normative assertions, run:
+To extract a list of normative assertions, e.g. for organizing testing, issue the following command:
 ```sh
 npm run assertions
 ```
-The assertions will be in testing/assertions.html which will use relative links back up to
-index.html.  The input to this process is index.html (not index.html.template) so `npm run render` first.
+The assertions will be in [testing/assertions.html](testing/assertions.html) which will use relative links back up to
+index.html.  The input to this process is [index.html](index.html) (not index.html.template) so use `npm run render` first.
 
-For this to work, the assertions need to follow specific conventions.  Here is an example:
+For this to work, the assertions need to follow specific conventions.  Here are some examples:
 ```html
 <span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Describe test cases -->
 <span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span>
@@ -36,4 +36,4 @@ Conventions:
 * The entire assertion and the comment need to be on a single input line (sorry).
 
 Best practices:
-* Make the assertion independent of context.  For example, avoid using pronouns referring to previous statements not in the assertion (eg replace "This format" with "The JSON-TD format", etc).
+* Make the assertion independent of context.  For example, avoid using pronouns referring to previous statements not in the assertion (eg replace "this serialization" with "a JSON-TD serialization", etc).

--- a/README.md
+++ b/README.md
@@ -12,3 +12,28 @@ Part of the document is automatically rendered using the [Dust.js](http://www.du
 npm install
 npm run render
 ```
+
+## Normative Assertions
+
+To extract a list of normative assertions, run:
+```sh
+npm run assertions
+```
+The assertions will be in testing/assertions.html which will use relative links back up to
+index.html.  The input to this process is index.html (not index.html.template) so `npm run render` first.
+
+For this to work, the assertions need to follow specific conventions.  Here is an example:
+```html
+<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Describe test cases -->
+<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span>
+```
+
+Conventions:
+* Put the entire assertion inside a span
+* Mark the span with an id unique to this document.  It is recommended that the section id be followed by a short name for the specific assertion.
+* Mark the span with a class of the form `rfc2119-assertion-` followed by one of `MUST`, `MAY`, `MUST-NOT`, etc.
+* The assertion may optionally be followed by a comment; this will also be extracted.  It can be used to define some suitable test cases, constraints, or other issues.
+* The entire assertion and the comment need to be on a single input line (sorry).
+
+Best practices:
+* Make the assertion independent of context.  For example, avoid using pronouns referring to previous statements not in the assertion (eg replace "This format" with "The JSON-TD format", etc).

--- a/README.md
+++ b/README.md
@@ -24,15 +24,18 @@ index.html.  The input to this process is [index.html](index.html) (not index.ht
 
 For this to work, the assertions need to follow specific conventions.  Here are some examples:
 ```html
-<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Describe test cases -->
-<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span>
+<span class="rfc2119-assertion" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Describe test cases -->
+<span class="rfc2119-assertion" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span>
 ```
 
 Conventions:
 * Put the entire assertion inside a span
 * Mark the span with an id unique to this document.  It is recommended that the section id be followed by a short name for the specific assertion.
-* Mark the span with a class of the form `rfc2119-assertion-` followed by one of `MUST`, `MAY`, `MUST-NOT`, etc.
-* The assertion may optionally be followed by a comment; this will also be extracted.  It can be used to define some suitable test cases, constraints, or other issues.
+* Mark the span with a class equal to `rfc2119-assertion`.
+* Include one of the RFC2119 keywords inside a `<em class="rfc2119">` and `</em>`.
+  Note: make sure these tags are in exactly this form (sorry).
+* The assertion may optionally be followed by a comment; this will also be extracted.
+  The comment can be used to define some suitable test cases, constraints, or other issues.
 * The entire assertion and the comment need to be on a single input line (sorry).
 
 Best practices:

--- a/assertions.sh
+++ b/assertions.sh
@@ -34,7 +34,6 @@ do
   echo "<dt>" >> testing/assertions.html
   id=`echo $i | grep -oP '(?<=id\=\")[^\"]+(?=\")' -`
   class=`echo $i | grep -oP '(?<=class\=\"rfc2119\">)[^<]+(?=<\/em>)' -`
-  # class=`echo $i | grep -oP '(?<=class\=\"rfc2119-assertion-)[^\"]+(?=\")' -`
   comment=`echo $i | grep -oP '(?<=<\!--)[^\"]+(?=-->)' -`
   echo "<a href="../index.html#${id}"><tt>$id</tt></a>" >> testing/assertions.html
   echo ": <strong>$class</strong>" >> testing/assertions.html

--- a/assertions.sh
+++ b/assertions.sh
@@ -1,0 +1,57 @@
+#/bin/bashsh
+# Run this after "rendering" in order to extract normative assertions
+# and build testing summary file
+
+# Start of HTML output
+read -r -d '' FRONT << EOM
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Normative Assertions Summary</title>
+  </head>
+  <body>
+	  <h1>Normative Assertions Summary</h1>
+  <p>This file is auto-generated using <tt>npm run assertions</tt>.
+     Run it from the <tt>wot-thing-description</tt> home directory (eg <tt>..</tt>).
+     It uses <tt>../index.html</tt> as input so run <tt>npm run render</tt> first.
+  </p>
+EOM
+echo "$FRONT" > testing/assertions.html
+
+# Find all assertions and add to table
+# break lines at newlines
+# DOES NOT WORK IN SOME sh SHELLS! Make sure to use "bash"
+# Note: we use lists rather than tables here as they
+# behave better when content is split over multiple lines.
+# This allows for long assertion statements without having
+# to mess about with complex table formatting to handle
+# wrapping, etc.
+echo "<dl>" >> testing/assertions.html
+IFS=$'\n'
+for i in `grep 'class="rfc2119-assertion' index.html`
+do
+  echo "<dt>" >> testing/assertions.html
+  id=`echo $i | grep -oP '(?<=id\=\")[^\"]+(?=\")' -`
+  class=`echo $i | grep -oP '(?<=class\=\"rfc2119-assertion-)[^\"]+(?=\")' -`
+  comment=`echo $i | grep -oP '(?<=<\!--)[^\"]+(?=-->)' -`
+  echo "<a href="../index.html#${id}"><tt>$id</tt></a>" >> testing/assertions.html
+  echo ": <strong>$class</strong>" >> testing/assertions.html
+  echo "</dt>" >> testing/assertions.html
+  echo "<dd>" >> testing/assertions.html
+  echo "$i" >> testing/assertions.html 
+  if [ -n "$comment" ]; then
+    echo "<ul>" >> testing/assertions.html
+    echo "<li>${comment}</li>" >> testing/assertions.html
+    echo "</ul>" >> testing/assertions.html
+  fi
+  echo "</dd>" >> testing/assertions.html
+done
+echo "</dl>" >> testing/assertions.html
+
+# End of HTML output
+read -r -d '' BACK << EOM
+  </body>
+</html>
+EOM
+echo "$BACK" >> testing/assertions.html

--- a/assertions.sh
+++ b/assertions.sh
@@ -1,4 +1,4 @@
-#/bin/bashsh
+#!/bin/bash
 # Run this after "rendering" in order to extract normative assertions
 # and build testing summary file
 

--- a/assertions.sh
+++ b/assertions.sh
@@ -8,10 +8,10 @@ read -r -d '' FRONT << EOM
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Normative Assertions Summary</title>
+    <title>WoT Thing Description - Normative Assertions Summary</title>
   </head>
   <body>
-	  <h1>Normative Assertions Summary</h1>
+	  <h1>WoT Thing Description - Normative Assertions Summary</h1>
   <p>This file is auto-generated using <tt>npm run assertions</tt>.
      Run it from the <tt>wot-thing-description</tt> home directory (eg <tt>..</tt>).
      It uses <tt>../index.html</tt> as input so run <tt>npm run render</tt> first.

--- a/assertions.sh
+++ b/assertions.sh
@@ -33,7 +33,8 @@ for i in `grep 'class="rfc2119-assertion' index.html`
 do
   echo "<dt>" >> testing/assertions.html
   id=`echo $i | grep -oP '(?<=id\=\")[^\"]+(?=\")' -`
-  class=`echo $i | grep -oP '(?<=class\=\"rfc2119-assertion-)[^\"]+(?=\")' -`
+  class=`echo $i | grep -oP '(?<=class\=\"rfc2119\">)[^<]+(?=<\/em>)' -`
+  # class=`echo $i | grep -oP '(?<=class\=\"rfc2119-assertion-)[^\"]+(?=\")' -`
   comment=`echo $i | grep -oP '(?<=<\!--)[^\"]+(?=-->)' -`
   echo "<a href="../index.html#${id}"><tt>$id</tt></a>" >> testing/assertions.html
   echo ": <strong>$class</strong>" >> testing/assertions.html

--- a/index.html
+++ b/index.html
@@ -597,17 +597,23 @@ See also [[!WOT-PROTOCOL-BINDING]].</p>
 
 
       <p class="ednote" title="JSON-LD 1.1 ">
-	This is the first draft that uses JSON-LD 1.1 as a serialization format of the Thing Description. The working assumption is based on the <a href="https://json-ld.org/spec/latest/json-ld/#">Community Draft of JSON-LD 1.1</a>. There is the plan to setup a JSON-LD Working Group with the following <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">JSON-LD Working Group Charter</a>. It is planned that this section always conforms to the latest working assumptions of JSON-LD 1.1.
+	This is the first draft that uses JSON-LD 1.1 as a serialization format of the Thing Description. The working assumption is based on the <a href="https://json-ld.org/spec/latest/json-ld/#">Community Draft of JSON-LD 1.1</a>. There is the plan to set up a JSON-LD Working Group with the following <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">JSON-LD Working Group Charter</a>. It is planned that this section always conforms to the latest working assumptions of JSON-LD 1.1.
       </p>
 
 <p> This section specifies the serializiation of Thing Description instances based on <a href="https://json-ld.org/spec/latest/json-ld/#">JSON-LD 1.1</a>. JSON-LD 1.1 is a JSON-based format to serialize Linked Data by using a number of syntax tokens and keywords (typically starting with the <code>@</code> character). JSON-LD 1.1 provides an oppertunity  to be alligned with the <a href="#json-serializiation-section">JSON TD serlializiation</a> and RDF-based modeling to increase the semantic interoperability.  
 </p>
 
-<p>Mainly, an instance is a valid Thing Description serializiations in JSON-LD 1.1 when it meets the following 3 requirememts:</p>
+<p>Mainly, an instance is a valid Thing Description serializations in JSON-LD 1.1 when it meets the following three requirements:</p>
   <ul>
-    <li>it MUST fulfill all requirements that are defined in <a href="#json-serializiation-section">JSON TD</a></li>
-     <li>all vocabularies that have a default value as defined  <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> MUST be present at least with their default value.</li>
-     <li>the <code>@context</code> key from JSON-LD 1.1 MUST have the value of the Thing description context file <code>https://w3c.github.io/wot/w3c-wot-td-context.jsonld</code>.</li>
+    <li>
+        <span class="rfc2119-assertion" id="json-1.1-serialization-baseline">A valid JSON-LD-1.1 Thing Description serialization <em class="rfc2119">MUST</em> fulfill all requirements that are defined in <a href="#json-serializiation-section">JSON TD</a></span><!-- Testing comments go here -->
+    </li>
+     <li>
+        <span class="rfc2119-assertion" id="json-1.1-serialization-defaults">In a valid JSON-LD 1.1 Thing Description serialization, all vocabularies that have a default value as defined  <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> <em class="rfc2119">MUST</em> be present at least with their default value.</span><!-- Testing comments go here -->
+     </li>
+     <li>
+        <span class="rfc2119-assertion" id="json-1.1-serialization-context">In a valid JSON-LD 1.1 Thing Description serialization, the <code>@context</code> key from JSON-LD 1.1 <em class="rfc2119">MUST</em> have the value of the Thing description context file <code>https://w3c.github.io/wot/w3c-wot-td-context.jsonld</code>.</span><!-- Testing comments go here -->
+     </li>
   </ul>
 
 

--- a/index.html
+++ b/index.html
@@ -302,22 +302,22 @@ For example, the Property interaction allows get and set operations. The protoco
 <p>Mainly, all defined core vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will have a JSON key representation.</p>
 
 <p>
-<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Testing comments go here. -->
-<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Testing comments go here. -->
+<span class="rfc2119-assertion" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span><!-- Testing comments go here -->
 </p>
 
 <p>The defined types of the vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will be transtormed to JSON-based types. The following rules are used for vocabularies based on simple type definitions:</p>
 <ul>
 <li><p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-string-type">Vocabularies that are based on simple types string and anyURI <em class="rfc2119">MUST</em> be serialized as JSON string.</span><!-- Testing comments go here. -->
+<span class="rfc2119-assertion" id="json-serialization-string-type">Vocabularies that are based on simple types string and anyURI <em class="rfc2119">MUST</em> be serialized as JSON string.</span><!-- Testing comments go here. -->
 </p></li>
 
 <li><p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-unsigned-int-type">Vocabularies that are based on the simple type unsignedInt <em class="rfc2119">MUST</em> be serialized as JSON integer.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-unsigned-int-type">Vocabularies that are based on the simple type unsignedInt <em class="rfc2119">MUST</em> be serialized as JSON integer.</span><!-- Testing comments go here -->
 </p></li>
 
 <li><p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-number-type">Vocabularies that are based on the simple type double <em class="rfc2119">MUST</em> be serialized as JSON number.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-number-type">Vocabularies that are based on the simple type double <em class="rfc2119">MUST</em> be serialized as JSON number.</span><!-- Testing comments go here -->
 </p></li>
 </ul>
 
@@ -327,16 +327,16 @@ For example, the Property interaction allows get and set operations. The protoco
   <section id="sec-thing-as-a-whole-json">
     <h2>Thing as a whole</h2>
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-mandatory-vocabularies">Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key at the top level of the JSON TD document.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-mandatory-vocabularies">Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key at the top level of the JSON TD document.</span><!-- Testing comments go here -->
 </p>
 
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-standard-objects">The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-standard-objects">The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-link-array">The type of the field <code>links</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-link-array">The type of the field <code>links</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 </p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -364,16 +364,16 @@ For example, the Property interaction allows get and set operations. The protoco
       <h2>properties</h2>
   
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-properties">Properties (and sub-properties) offered by a Thing <em class="rfc2119">MUST</em> be collected in the <code>properties</code> field of (unique) Property names as JSON keys.</span><!-- Testing comments go here -->
-<span class="rfc2119-assertion-MUST" id="json-serialization-property-vocabulary"> Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Property field.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-properties">Properties (and sub-properties) offered by a Thing <em class="rfc2119">MUST</em> be collected in the <code>properties</code> field of (unique) Property names as JSON keys.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-property-vocabulary"> Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Property field.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-property-objects"> The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-property-objects"> The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-property-arrays"> The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-property-arrays"> The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 </p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -426,19 +426,19 @@ For example, the Property interaction allows get and set operations. The protoco
 
 <p>
 Actions offered by a Thing are collected in the <code>actions</code> field of (unique) Action names as JSON keys.
-<span class="rfc2119-assertion-MUST" id="json-serialization-action-vocabulary">Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Action field.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-vocabulary">Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Action field.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-action-object">The type of the fields <code>input</code> and <code>output</code> in an Action <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-object">The type of the fields <code>input</code> and <code>output</code> in an Action <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST-NOT" id="json-serialization-action-forms-not-object">The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field <em class="rfc2119">MUST NOT</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-forms-not-object">The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field <em class="rfc2119">MUST NOT</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-action-forms-array">The type of the field <code>forms</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-forms-array">The type of the field <code>forms</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 </p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -482,15 +482,15 @@ Actions offered by a Thing are collected in the <code>actions</code> field of (u
       <h2>events</h2>
 <p>
 Events (and sub-events) offered by a Thing are collected in the <code>events</code> field of (unique) Event names as JSON keys.
-<span class="rfc2119-assertion-MUST" id="json-serialization-event-vocabulary">Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, <em class="rfc2119">MUST</em> be transformed as a JSON key within a Event field.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-event-vocabulary">Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, <em class="rfc2119">MUST</em> be transformed as a JSON key within a Event field.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-event-objects">The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-event-objects">The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-event-arrays">The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-event-arrays">The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 </p>
 
 
@@ -517,11 +517,11 @@ Events (and sub-events) offered by a Thing are collected in the <code>events</co
       <h2>forms</h2>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-form-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-form-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MAY" id="json-serialization-form-protocol-vocabulary">If required, <code>forms</code> <em class="rfc2119">MAY</em> be supplemented with protocol-specific vocabularies identified with a prefix.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-form-protocol-vocabulary">If required, <code>forms</code> <em class="rfc2119">MAY</em> be supplemented with protocol-specific vocabularies identified with a prefix.</span><!-- Testing comments go here -->
 See also [[!WOT-PROTOCOL-BINDING]].</p>
 
       <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -547,7 +547,7 @@ See also [[!WOT-PROTOCOL-BINDING]].</p>
       <h2>links</h2>
 
 	<p>
-        <span class="rfc2119-assertion-MAY" id="json-serialization-form-link-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+        <span class="rfc2119-assertion" id="json-serialization-form-link-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
 	</p>
 
       <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -572,7 +572,7 @@ See also [[!WOT-PROTOCOL-BINDING]].</p>
       </p>
 
 	<p>
-        <span class="rfc2119-assertion-MAY" id="json-serialization-security-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+        <span class="rfc2119-assertion" id="json-serialization-security-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
 	</p>
 
       <pre class="example">

--- a/index.html
+++ b/index.html
@@ -245,14 +245,14 @@ The namespace for TD is http://www.w3.org/ns/td#. TD itself defines a minimal se
 </p>
 </section>
 
-<section>
+<section id="conformance">
     <h1>Conformance</h1>
 
 <p>
   As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,   and notes in this specification are non-normative. Everything else in this specification is
   normative.
 </p>
-<p>
+<p id="respecRFP2119">
   The key words <em title="MUST" class="rfc2119">MUST</em>, <em title="MUST NOT" class="rfc2119">MUST NOT</em>, <em title="REQUIRED" class="rfc2119">REQUIRED</em>, <em title="SHOULD" class="rfc2119">SHOULD</em>, <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em>, <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em>, <em title="MAY" class="rfc2119">MAY</em>,
   and <em title="OPTIONAL" class="rfc2119">OPTIONAL</em> in this specification are to be interpreted as described in [[!RFC2119]].
 </p>
@@ -301,7 +301,10 @@ For example, the Property interaction allows get and set operations. The protoco
 
 <p>Mainly, all defined core vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will have a JSON key representation.</p>
 
-<p>JSON TD MAY contain vocabularies that are not in the Thing Description core model. These vocabularies MUST carry a prefix for identification within the key name (e.g., "http:header").</p>
+<p>
+<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Describe test cases -->
+<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span>
+</p>
 
 <p>The defined types of the vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will be transtormed to JSON-based types. The following rules are used for vocabularies based on simple type definitions:</p>
 	      <ul>

--- a/index.html
+++ b/index.html
@@ -302,30 +302,42 @@ For example, the Property interaction allows get and set operations. The protoco
 <p>Mainly, all defined core vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will have a JSON key representation.</p>
 
 <p>
-<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Describe test cases -->
-<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span>
+<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Testing comments go here. -->
+<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span><!-- Testing comments go here -->
 </p>
 
 <p>The defined types of the vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will be transtormed to JSON-based types. The following rules are used for vocabularies based on simple type definitions:</p>
-	      <ul>
-<li><p>Vocabularies that are based on simple types string and anyURI MUST be serialized as JSON string.</p></li>
+<ul>
+<li><p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-string-type">Vocabularies that are based on simple types string and anyURI <em class="rfc2119">MUST</em> be serialized as JSON string.</span><!-- Testing comments go here. -->
+</p></li>
 
-<li><p>Vocabularies that are based on the simple type unsignedInt MUST be serialized as JSON integer.</p></li>
+<li><p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-unsigned-int-type">Vocabularies that are based on the simple type unsignedInt <em class="rfc2119">MUST</em> be serialized as JSON integer.</span><!-- Testing comments go here -->
+</p></li>
 
-<li><p>Vocabularies that are based on the simple type double MUST be serialized as JSON number.</p></li>
-	      </ul>
+<li><p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-number-type">Vocabularies that are based on the simple type double <em class="rfc2119">MUST</em> be serialized as JSON number.</span><!-- Testing comments go here -->
+</p></li>
+</ul>
 
 <p>All vocabularies in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> Section associated with class-based types are defined separately for structured JSON type transformation in the following subsections.</p>
 
 
   <section id="sec-thing-as-a-whole-json">
     <h2>Thing as a whole</h2>
-<p>Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, MUST be serialized as a JSON key at the top level of the JSON TD document.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-mandatory-vocabularies">Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key at the top level of the JSON TD document.</span><!-- Testing comments go here -->
+</p>
 
 
-<p>The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> MUST be serialized as a JSON object.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-standard-objects">The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the field <code>links</code> MUST be serialized as a JSON array.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-link-array">The type of the field <code>links</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+</p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
 
@@ -351,11 +363,18 @@ For example, the Property interaction allows get and set operations. The protoco
     <section id="property-serialization-json">
       <h2>properties</h2>
   
-<p>Properties (and sub-properties) offered by a Thing MUST be collected in the <code>properties</code> field of (unique) Property names as JSON keys. Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, MUST be serialized as a JSON key within a Property field.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-properties">Properties (and sub-properties) offered by a Thing <em class="rfc2119">MUST</em> be collected in the <code>properties</code> field of (unique) Property names as JSON keys.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion-MUST" id="json-serialization-property-vocabulary"> Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Property field.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the fields <code>properties</code> and <code>items</code> MUST be serialized as a JSON object.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-property-objects"> The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> MUST be serialized as a JSON array.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-property-arrays"> The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+</p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
 
@@ -405,13 +424,22 @@ For example, the Property interaction allows get and set operations. The protoco
     <section id="action-serialization-json">
       <h2>actions</h2>
 
-<p>Actions offered by a Thing are collected in the <code>actions</code> field of (unique) Action names as JSON keys. Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, MUST serialized as a JSON key within a Action field.</p>
+<p>
+Actions offered by a Thing are collected in the <code>actions</code> field of (unique) Action names as JSON keys.
+<span class="rfc2119-assertion-MUST" id="json-serialization-action-vocabulary">Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Action field.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the fields <code>input</code> and <code>output</code> MUST be serialized as a JSON object.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-action-object">The type of the fields <code>input</code> and <code>output</code> in an Action <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+</p>
 
-<p>The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field MUST NOT be serialized as a JSON object.</p>
+<p>
+<span class="rfc2119-assertion-MUST-NOT" id="json-serialization-action-forms-not-object">The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field <em class="rfc2119">MUST NOT</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the field <code>forms</code>  MUST be serialized as a JSON array.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-action-forms-array">The type of the field <code>forms</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+</p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
 
@@ -452,11 +480,18 @@ For example, the Property interaction allows get and set operations. The protoco
 
     <section id="event-serialization-json">
       <h2>events</h2>
-<p>Events (and sub-events) offered by a Thing are collected in the <code>events</code> field of (unique) Event names as JSON keys. Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, MUST transformed as a JSON key within a Event field.</p>
+<p>
+Events (and sub-events) offered by a Thing are collected in the <code>events</code> field of (unique) Event names as JSON keys.
+<span class="rfc2119-assertion-MUST" id="json-serialization-event-vocabulary">Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, <em class="rfc2119">MUST</em> be transformed as a JSON key within a Event field.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the fields <code>properties</code> and <code>items</code> MUST be serialized as a JSON object.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-event-objects">The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> MUST be serialized as a JSON array.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-event-arrays">The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+</p>
 
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -481,9 +516,13 @@ For example, the Property interaction allows get and set operations. The protoco
     <section id="form-serialization-json">
       <h2>forms</h2>
 
-<p>Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, MUST be serialized as a JSON key.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-form-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+</p>
 
-<p>If required, <code>forms</code> MAY be supplemented with protocol-specific vocabularies identified with a prefix. See also [[!WOT-PROTOCOL-BINDING]].</p>
+<p>
+<span class="rfc2119-assertion-MAY" id="json-serialization-form-protocol-vocabulary">If required, <code>forms</code> <em class="rfc2119">MAY</em> be supplemented with protocol-specific vocabularies identified with a prefix.</span><!-- Testing comments go here -->
+See also [[!WOT-PROTOCOL-BINDING]].</p>
 
       <p>An example of a TD snippet based on the defined fields is given below:</p>
 
@@ -507,7 +546,9 @@ For example, the Property interaction allows get and set operations. The protoco
     <section id="links-serialization-json">
       <h2>links</h2>
 
-	<p>Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, MUST be serialized as a JSON key.</p>
+	<p>
+        <span class="rfc2119-assertion-MAY" id="json-serialization-form-link-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+	</p>
 
       <p>An example of a TD snippet based on the defined fields is given below:</p>
 
@@ -530,7 +571,9 @@ For example, the Property interaction allows get and set operations. The protoco
       <p class="ednote">This is the first draft containing the new security vocabularies. The definition is not yet completed and is still in progress.
       </p>
 
-	<p>Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, MUST be serialized as a JSON key.</p>
+	<p>
+        <span class="rfc2119-assertion-MAY" id="json-serialization-security-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+	</p>
 
       <pre class="example">
         ...

--- a/index.html.template
+++ b/index.html.template
@@ -245,14 +245,14 @@ The namespace for TD is http://www.w3.org/ns/td#. TD itself defines a minimal se
 </p>
 </section>
 
-<section>
+<section id="conformance">
     <h1>Conformance</h1>
 
 <p>
   As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,   and notes in this specification are non-normative. Everything else in this specification is
   normative.
 </p>
-<p>
+<p id="respecRFP2119">
   The key words <em title="MUST" class="rfc2119">MUST</em>, <em title="MUST NOT" class="rfc2119">MUST NOT</em>, <em title="REQUIRED" class="rfc2119">REQUIRED</em>, <em title="SHOULD" class="rfc2119">SHOULD</em>, <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em>, <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em>, <em title="MAY" class="rfc2119">MAY</em>,
   and <em title="OPTIONAL" class="rfc2119">OPTIONAL</em> in this specification are to be interpreted as described in [[!RFC2119]].
 </p>
@@ -297,7 +297,10 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
 
 <p>Mainly, all defined core vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will have a JSON key representation.</p>
 
-<p>JSON TD MAY contain vocabularies that are not in the Thing Description core model. These vocabularies MUST carry a prefix for identification within the key name (e.g., "http:header").</p>
+<p>
+<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Describe test cases -->
+<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span>
+</p>
 
 <p>The defined types of the vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will be transtormed to JSON-based types. The following rules are used for vocabularies based on simple type definitions:</p>
 	      <ul>

--- a/index.html.template
+++ b/index.html.template
@@ -593,17 +593,23 @@ See also [[!WOT-PROTOCOL-BINDING]].</p>
 
 
       <p class="ednote" title="JSON-LD 1.1 ">
-	This is the first draft that uses JSON-LD 1.1 as a serialization format of the Thing Description. The working assumption is based on the <a href="https://json-ld.org/spec/latest/json-ld/#">Community Draft of JSON-LD 1.1</a>. There is the plan to setup a JSON-LD Working Group with the following <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">JSON-LD Working Group Charter</a>. It is planned that this section always conforms to the latest working assumptions of JSON-LD 1.1.
+	This is the first draft that uses JSON-LD 1.1 as a serialization format of the Thing Description. The working assumption is based on the <a href="https://json-ld.org/spec/latest/json-ld/#">Community Draft of JSON-LD 1.1</a>. There is the plan to set up a JSON-LD Working Group with the following <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">JSON-LD Working Group Charter</a>. It is planned that this section always conforms to the latest working assumptions of JSON-LD 1.1.
       </p>
 
 <p> This section specifies the serializiation of Thing Description instances based on <a href="https://json-ld.org/spec/latest/json-ld/#">JSON-LD 1.1</a>. JSON-LD 1.1 is a JSON-based format to serialize Linked Data by using a number of syntax tokens and keywords (typically starting with the <code>@</code> character). JSON-LD 1.1 provides an oppertunity  to be alligned with the <a href="#json-serializiation-section">JSON TD serlializiation</a> and RDF-based modeling to increase the semantic interoperability.  
 </p>
 
-<p>Mainly, an instance is a valid Thing Description serializiations in JSON-LD 1.1 when it meets the following 3 requirememts:</p>
+<p>Mainly, an instance is a valid Thing Description serializations in JSON-LD 1.1 when it meets the following three requirements:</p>
   <ul>
-    <li>it MUST fulfill all requirements that are defined in <a href="#json-serializiation-section">JSON TD</a></li>
-     <li>all vocabularies that have a default value as defined  <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> MUST be present at least with their default value.</li>
-     <li>the <code>@context</code> key from JSON-LD 1.1 MUST have the value of the Thing description context file <code>https://w3c.github.io/wot/w3c-wot-td-context.jsonld</code>.</li>
+    <li>
+        <span class="rfc2119-assertion" id="json-1.1-serialization-baseline">A valid JSON-LD-1.1 Thing Description serialization <em class="rfc2119">MUST</em> fulfill all requirements that are defined in <a href="#json-serializiation-section">JSON TD</a></span><!-- Testing comments go here -->
+    </li>
+     <li>
+        <span class="rfc2119-assertion" id="json-1.1-serialization-defaults">In a valid JSON-LD 1.1 Thing Description serialization, all vocabularies that have a default value as defined  <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> <em class="rfc2119">MUST</em> be present at least with their default value.</span><!-- Testing comments go here -->
+     </li>
+     <li>
+        <span class="rfc2119-assertion" id="json-1.1-serialization-context">In a valid JSON-LD 1.1 Thing Description serialization, the <code>@context</code> key from JSON-LD 1.1 <em class="rfc2119">MUST</em> have the value of the Thing description context file <code>https://w3c.github.io/wot/w3c-wot-td-context.jsonld</code>.</span><!-- Testing comments go here -->
+     </li>
   </ul>
 
 

--- a/index.html.template
+++ b/index.html.template
@@ -298,22 +298,22 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
 <p>Mainly, all defined core vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will have a JSON key representation.</p>
 
 <p>
-<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Testing comments go here. -->
-<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Testing comments go here. -->
+<span class="rfc2119-assertion" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span><!-- Testing comments go here -->
 </p>
 
 <p>The defined types of the vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will be transtormed to JSON-based types. The following rules are used for vocabularies based on simple type definitions:</p>
 <ul>
 <li><p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-string-type">Vocabularies that are based on simple types string and anyURI <em class="rfc2119">MUST</em> be serialized as JSON string.</span><!-- Testing comments go here. -->
+<span class="rfc2119-assertion" id="json-serialization-string-type">Vocabularies that are based on simple types string and anyURI <em class="rfc2119">MUST</em> be serialized as JSON string.</span><!-- Testing comments go here. -->
 </p></li>
 
 <li><p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-unsigned-int-type">Vocabularies that are based on the simple type unsignedInt <em class="rfc2119">MUST</em> be serialized as JSON integer.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-unsigned-int-type">Vocabularies that are based on the simple type unsignedInt <em class="rfc2119">MUST</em> be serialized as JSON integer.</span><!-- Testing comments go here -->
 </p></li>
 
 <li><p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-number-type">Vocabularies that are based on the simple type double <em class="rfc2119">MUST</em> be serialized as JSON number.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-number-type">Vocabularies that are based on the simple type double <em class="rfc2119">MUST</em> be serialized as JSON number.</span><!-- Testing comments go here -->
 </p></li>
 </ul>
 
@@ -323,16 +323,16 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
   <section id="sec-thing-as-a-whole-json">
     <h2>Thing as a whole</h2>
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-mandatory-vocabularies">Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key at the top level of the JSON TD document.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-mandatory-vocabularies">Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key at the top level of the JSON TD document.</span><!-- Testing comments go here -->
 </p>
 
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-standard-objects">The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-standard-objects">The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-link-array">The type of the field <code>links</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-link-array">The type of the field <code>links</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 </p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -360,16 +360,16 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
       <h2>properties</h2>
   
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-properties">Properties (and sub-properties) offered by a Thing <em class="rfc2119">MUST</em> be collected in the <code>properties</code> field of (unique) Property names as JSON keys.</span><!-- Testing comments go here -->
-<span class="rfc2119-assertion-MUST" id="json-serialization-property-vocabulary"> Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Property field.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-properties">Properties (and sub-properties) offered by a Thing <em class="rfc2119">MUST</em> be collected in the <code>properties</code> field of (unique) Property names as JSON keys.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-property-vocabulary"> Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Property field.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-property-objects"> The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-property-objects"> The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-property-arrays"> The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-property-arrays"> The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 </p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -422,19 +422,19 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
 
 <p>
 Actions offered by a Thing are collected in the <code>actions</code> field of (unique) Action names as JSON keys.
-<span class="rfc2119-assertion-MUST" id="json-serialization-action-vocabulary">Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Action field.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-vocabulary">Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Action field.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-action-object">The type of the fields <code>input</code> and <code>output</code> in an Action <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-object">The type of the fields <code>input</code> and <code>output</code> in an Action <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST-NOT" id="json-serialization-action-forms-not-object">The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field <em class="rfc2119">MUST NOT</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-forms-not-object">The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field <em class="rfc2119">MUST NOT</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-action-forms-array">The type of the field <code>forms</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-forms-array">The type of the field <code>forms</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 </p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -478,15 +478,15 @@ Actions offered by a Thing are collected in the <code>actions</code> field of (u
       <h2>events</h2>
 <p>
 Events (and sub-events) offered by a Thing are collected in the <code>events</code> field of (unique) Event names as JSON keys.
-<span class="rfc2119-assertion-MUST" id="json-serialization-event-vocabulary">Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, <em class="rfc2119">MUST</em> be transformed as a JSON key within a Event field.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-event-vocabulary">Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, <em class="rfc2119">MUST</em> be transformed as a JSON key within a Event field.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-event-objects">The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-event-objects">The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-event-arrays">The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-event-arrays">The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 </p>
 
 
@@ -513,11 +513,11 @@ Events (and sub-events) offered by a Thing are collected in the <code>events</co
       <h2>forms</h2>
 
 <p>
-<span class="rfc2119-assertion-MUST" id="json-serialization-form-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-form-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
 </p>
 
 <p>
-<span class="rfc2119-assertion-MAY" id="json-serialization-form-protocol-vocabulary">If required, <code>forms</code> <em class="rfc2119">MAY</em> be supplemented with protocol-specific vocabularies identified with a prefix.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-form-protocol-vocabulary">If required, <code>forms</code> <em class="rfc2119">MAY</em> be supplemented with protocol-specific vocabularies identified with a prefix.</span><!-- Testing comments go here -->
 See also [[!WOT-PROTOCOL-BINDING]].</p>
 
       <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -543,7 +543,7 @@ See also [[!WOT-PROTOCOL-BINDING]].</p>
       <h2>links</h2>
 
 	<p>
-        <span class="rfc2119-assertion-MAY" id="json-serialization-form-link-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+        <span class="rfc2119-assertion" id="json-serialization-form-link-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
 	</p>
 
       <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -568,7 +568,7 @@ See also [[!WOT-PROTOCOL-BINDING]].</p>
       </p>
 
 	<p>
-        <span class="rfc2119-assertion-MAY" id="json-serialization-security-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+        <span class="rfc2119-assertion" id="json-serialization-security-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
 	</p>
 
       <pre class="example">

--- a/index.html.template
+++ b/index.html.template
@@ -298,30 +298,42 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
 <p>Mainly, all defined core vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will have a JSON key representation.</p>
 
 <p>
-<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Describe test cases -->
-<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span>
+<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Testing comments go here. -->
+<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span><!-- Testing comments go here -->
 </p>
 
 <p>The defined types of the vocabulary as defined in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> will be transtormed to JSON-based types. The following rules are used for vocabularies based on simple type definitions:</p>
-	      <ul>
-<li><p>Vocabularies that are based on simple types string and anyURI MUST be serialized as JSON string.</p></li>
+<ul>
+<li><p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-string-type">Vocabularies that are based on simple types string and anyURI <em class="rfc2119">MUST</em> be serialized as JSON string.</span><!-- Testing comments go here. -->
+</p></li>
 
-<li><p>Vocabularies that are based on the simple type unsignedInt MUST be serialized as JSON integer.</p></li>
+<li><p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-unsigned-int-type">Vocabularies that are based on the simple type unsignedInt <em class="rfc2119">MUST</em> be serialized as JSON integer.</span><!-- Testing comments go here -->
+</p></li>
 
-<li><p>Vocabularies that are based on the simple type double MUST be serialized as JSON number.</p></li>
-	      </ul>
+<li><p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-number-type">Vocabularies that are based on the simple type double <em class="rfc2119">MUST</em> be serialized as JSON number.</span><!-- Testing comments go here -->
+</p></li>
+</ul>
 
 <p>All vocabularies in <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> Section associated with class-based types are defined separately for structured JSON type transformation in the following subsections.</p>
 
 
   <section id="sec-thing-as-a-whole-json">
     <h2>Thing as a whole</h2>
-<p>Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, MUST be serialized as a JSON key at the top level of the JSON TD document.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-mandatory-vocabularies">Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key at the top level of the JSON TD document.</span><!-- Testing comments go here -->
+</p>
 
 
-<p>The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> MUST be serialized as a JSON object.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-standard-objects">The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the field <code>links</code> MUST be serialized as a JSON array.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-link-array">The type of the field <code>links</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+</p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
 
@@ -347,11 +359,18 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
     <section id="property-serialization-json">
       <h2>properties</h2>
   
-<p>Properties (and sub-properties) offered by a Thing MUST be collected in the <code>properties</code> field of (unique) Property names as JSON keys. Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, MUST be serialized as a JSON key within a Property field.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-properties">Properties (and sub-properties) offered by a Thing <em class="rfc2119">MUST</em> be collected in the <code>properties</code> field of (unique) Property names as JSON keys.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion-MUST" id="json-serialization-property-vocabulary"> Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Property field.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the fields <code>properties</code> and <code>items</code> MUST be serialized as a JSON object.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-property-objects"> The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> MUST be serialized as a JSON array.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-property-arrays"> The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+</p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
 
@@ -401,13 +420,22 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
     <section id="action-serialization-json">
       <h2>actions</h2>
 
-<p>Actions offered by a Thing are collected in the <code>actions</code> field of (unique) Action names as JSON keys. Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, MUST serialized as a JSON key within a Action field.</p>
+<p>
+Actions offered by a Thing are collected in the <code>actions</code> field of (unique) Action names as JSON keys.
+<span class="rfc2119-assertion-MUST" id="json-serialization-action-vocabulary">Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Action field.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the fields <code>input</code> and <code>output</code> MUST be serialized as a JSON object.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-action-object">The type of the fields <code>input</code> and <code>output</code> in an Action <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+</p>
 
-<p>The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field MUST NOT be serialized as a JSON object.</p>
+<p>
+<span class="rfc2119-assertion-MUST-NOT" id="json-serialization-action-forms-not-object">The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field <em class="rfc2119">MUST NOT</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the field <code>forms</code>  MUST be serialized as a JSON array.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-action-forms-array">The type of the field <code>forms</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+</p>
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
 
@@ -448,11 +476,18 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
 
     <section id="event-serialization-json">
       <h2>events</h2>
-<p>Events (and sub-events) offered by a Thing are collected in the <code>events</code> field of (unique) Event names as JSON keys. Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, MUST transformed as a JSON key within a Event field.</p>
+<p>
+Events (and sub-events) offered by a Thing are collected in the <code>events</code> field of (unique) Event names as JSON keys.
+<span class="rfc2119-assertion-MUST" id="json-serialization-event-vocabulary">Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, <em class="rfc2119">MUST</em> be transformed as a JSON key within a Event field.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the fields <code>properties</code> and <code>items</code> MUST be serialized as a JSON object.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-event-objects">The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+</p>
 
-<p>The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> MUST be serialized as a JSON array.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-event-arrays">The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+</p>
 
 
 <p>An example of a TD snippet based on the defined fields is given below:</p>
@@ -477,9 +512,13 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
     <section id="form-serialization-json">
       <h2>forms</h2>
 
-<p>Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, MUST be serialized as a JSON key.</p>
+<p>
+<span class="rfc2119-assertion-MUST" id="json-serialization-form-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+</p>
 
-<p>If required, <code>forms</code> MAY be supplemented with protocol-specific vocabularies identified with a prefix. See also [[!WOT-PROTOCOL-BINDING]].</p>
+<p>
+<span class="rfc2119-assertion-MAY" id="json-serialization-form-protocol-vocabulary">If required, <code>forms</code> <em class="rfc2119">MAY</em> be supplemented with protocol-specific vocabularies identified with a prefix.</span><!-- Testing comments go here -->
+See also [[!WOT-PROTOCOL-BINDING]].</p>
 
       <p>An example of a TD snippet based on the defined fields is given below:</p>
 
@@ -503,7 +542,9 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
     <section id="links-serialization-json">
       <h2>links</h2>
 
-	<p>Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, MUST be serialized as a JSON key.</p>
+	<p>
+        <span class="rfc2119-assertion-MAY" id="json-serialization-form-link-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+	</p>
 
       <p>An example of a TD snippet based on the defined fields is given below:</p>
 
@@ -526,7 +567,9 @@ We need to be more precise here: How to validate a TD? E.g., structure validatio
       <p class="ednote">This is the first draft containing the new security vocabularies. The definition is not yet completed and is still in progress.
       </p>
 
-	<p>Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, MUST be serialized as a JSON key.</p>
+	<p>
+        <span class="rfc2119-assertion-MAY" id="json-serialization-security-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+	</p>
 
       <pre class="example">
         ...

--- a/ontology/td.ttl
+++ b/ontology/td.ttl
@@ -10,7 +10,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@base <http://www.w3.org/ns/td#> .
+# @base <http://www.w3.org/ns/td#> .
 
 <http://www.w3.org/ns/td#> rdf:type owl:Ontology ;
                             dcterms:creator <http://purl.org/net/mpoveda> ,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "render.js",
   "scripts": {
     "render": "node render.js",
+    "assertions": "bash assertions.sh",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/testing/assertions.html
+++ b/testing/assertions.html
@@ -2,10 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Normative Assertions Summary</title>
+    <title>WoT Thing Description - Normative Assertions Summary</title>
   </head>
   <body>
-	  <h1>Normative Assertions Summary</h1>
+	  <h1>WoT Thing Description - Normative Assertions Summary</h1>
   <p>This file is auto-generated using <tt>npm run assertions</tt>.
      Run it from the <tt>wot-thing-description</tt> home directory (eg <tt>..</tt>).
      It uses <tt>../index.html</tt> as input so run <tt>npm run render</tt> first.

--- a/testing/assertions.html
+++ b/testing/assertions.html
@@ -16,7 +16,7 @@
 : <strong>MAY</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Testing comments go here. -->
+<span class="rfc2119-assertion" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Testing comments go here. -->
 <ul>
 <li> Testing comments go here. </li>
 </ul>
@@ -26,7 +26,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -36,7 +36,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-string-type">Vocabularies that are based on simple types string and anyURI <em class="rfc2119">MUST</em> be serialized as JSON string.</span><!-- Testing comments go here. -->
+<span class="rfc2119-assertion" id="json-serialization-string-type">Vocabularies that are based on simple types string and anyURI <em class="rfc2119">MUST</em> be serialized as JSON string.</span><!-- Testing comments go here. -->
 <ul>
 <li> Testing comments go here. </li>
 </ul>
@@ -46,7 +46,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-unsigned-int-type">Vocabularies that are based on the simple type unsignedInt <em class="rfc2119">MUST</em> be serialized as JSON integer.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-unsigned-int-type">Vocabularies that are based on the simple type unsignedInt <em class="rfc2119">MUST</em> be serialized as JSON integer.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -56,7 +56,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-number-type">Vocabularies that are based on the simple type double <em class="rfc2119">MUST</em> be serialized as JSON number.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-number-type">Vocabularies that are based on the simple type double <em class="rfc2119">MUST</em> be serialized as JSON number.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -66,7 +66,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-mandatory-vocabularies">Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key at the top level of the JSON TD document.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-mandatory-vocabularies">Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key at the top level of the JSON TD document.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -76,7 +76,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-standard-objects">The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-standard-objects">The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -86,7 +86,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-link-array">The type of the field <code>links</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-link-array">The type of the field <code>links</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -96,7 +96,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-properties">Properties (and sub-properties) offered by a Thing <em class="rfc2119">MUST</em> be collected in the <code>properties</code> field of (unique) Property names as JSON keys.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-properties">Properties (and sub-properties) offered by a Thing <em class="rfc2119">MUST</em> be collected in the <code>properties</code> field of (unique) Property names as JSON keys.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -106,7 +106,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-property-vocabulary"> Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Property field.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-property-vocabulary"> Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Property field.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -116,7 +116,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-property-objects"> The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-property-objects"> The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -126,7 +126,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-property-arrays"> The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-property-arrays"> The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -136,7 +136,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-action-vocabulary">Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Action field.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-vocabulary">Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Action field.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -146,17 +146,17 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-action-object">The type of the fields <code>input</code> and <code>output</code> in an Action <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-object">The type of the fields <code>input</code> and <code>output</code> in an Action <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
 </dd>
 <dt>
 <a href=../index.html#json-serialization-action-forms-not-object><tt>json-serialization-action-forms-not-object</tt></a>
-: <strong>MUST-NOT</strong>
+: <strong>MUST NOT</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST-NOT" id="json-serialization-action-forms-not-object">The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field <em class="rfc2119">MUST NOT</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-forms-not-object">The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field <em class="rfc2119">MUST NOT</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -166,7 +166,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-action-forms-array">The type of the field <code>forms</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-action-forms-array">The type of the field <code>forms</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -176,7 +176,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-event-vocabulary">Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, <em class="rfc2119">MUST</em> be transformed as a JSON key within a Event field.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-event-vocabulary">Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, <em class="rfc2119">MUST</em> be transformed as a JSON key within a Event field.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -186,7 +186,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-event-objects">The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-event-objects">The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -196,7 +196,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-event-arrays">The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-event-arrays">The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -206,7 +206,7 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-form-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-form-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
@@ -216,27 +216,27 @@
 : <strong>MAY</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MAY" id="json-serialization-form-protocol-vocabulary">If required, <code>forms</code> <em class="rfc2119">MAY</em> be supplemented with protocol-specific vocabularies identified with a prefix.</span><!-- Testing comments go here -->
+<span class="rfc2119-assertion" id="json-serialization-form-protocol-vocabulary">If required, <code>forms</code> <em class="rfc2119">MAY</em> be supplemented with protocol-specific vocabularies identified with a prefix.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
 </dd>
 <dt>
 <a href=../index.html#json-serialization-form-link-vocabulary><tt>json-serialization-form-link-vocabulary</tt></a>
-: <strong>MAY</strong>
+: <strong>MUST</strong>
 </dt>
 <dd>
-        <span class="rfc2119-assertion-MAY" id="json-serialization-form-link-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+        <span class="rfc2119-assertion" id="json-serialization-form-link-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>
 </dd>
 <dt>
 <a href=../index.html#json-serialization-security-vocabulary><tt>json-serialization-security-vocabulary</tt></a>
-: <strong>MAY</strong>
+: <strong>MUST</strong>
 </dt>
 <dd>
-        <span class="rfc2119-assertion-MAY" id="json-serialization-security-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+        <span class="rfc2119-assertion" id="json-serialization-security-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
 <ul>
 <li> Testing comments go here </li>
 </ul>

--- a/testing/assertions.html
+++ b/testing/assertions.html
@@ -16,9 +16,9 @@
 : <strong>MAY</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Describe test cases -->
+<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Testing comments go here. -->
 <ul>
-<li> Describe test cases </li>
+<li> Testing comments go here. </li>
 </ul>
 </dd>
 <dt>
@@ -26,7 +26,220 @@
 : <strong>MUST</strong>
 </dt>
 <dd>
-<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span>
+<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-string-type><tt>json-serialization-string-type</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-string-type">Vocabularies that are based on simple types string and anyURI <em class="rfc2119">MUST</em> be serialized as JSON string.</span><!-- Testing comments go here. -->
+<ul>
+<li> Testing comments go here. </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-unsigned-int-type><tt>json-serialization-unsigned-int-type</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-unsigned-int-type">Vocabularies that are based on the simple type unsignedInt <em class="rfc2119">MUST</em> be serialized as JSON integer.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-number-type><tt>json-serialization-number-type</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-number-type">Vocabularies that are based on the simple type double <em class="rfc2119">MUST</em> be serialized as JSON number.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-mandatory-vocabularies><tt>json-serialization-mandatory-vocabularies</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-mandatory-vocabularies">Each mandatory and required vocabulary, as defined in the class <a href="#thing" class="sec-ref">Thing</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key at the top level of the JSON TD document.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-standard-objects><tt>json-serialization-standard-objects</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-standard-objects">The type of the fields <code>properties</code>, <code>actions</code>, <code>events</code>, and <code>securityDefinitions</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-link-array><tt>json-serialization-link-array</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-link-array">The type of the field <code>links</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-properties><tt>json-serialization-properties</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-properties">Properties (and sub-properties) offered by a Thing <em class="rfc2119">MUST</em> be collected in the <code>properties</code> field of (unique) Property names as JSON keys.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-property-vocabulary><tt>json-serialization-property-vocabulary</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-property-vocabulary"> Each mandatory and required vocabulary, as defined in the class <a href="#property" class="sec-ref">Property</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Property field.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-property-objects><tt>json-serialization-property-objects</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-property-objects"> The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-property-arrays><tt>json-serialization-property-arrays</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-property-arrays"> The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-action-vocabulary><tt>json-serialization-action-vocabulary</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-action-vocabulary">Each required vocabulary, as defined in the class <a href="#action" class="sec-ref">Action</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key within a Action field.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-action-object><tt>json-serialization-action-object</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-action-object">The type of the fields <code>input</code> and <code>output</code> in an Action <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-action-forms-not-object><tt>json-serialization-action-forms-not-object</tt></a>
+: <strong>MUST-NOT</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST-NOT" id="json-serialization-action-forms-not-object">The members keys of <code>input</code> and <code>output</code> rely on the the class <a href="#property" class="sec-ref">Property</a>. The <code>forms</code> field <em class="rfc2119">MUST NOT</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-action-forms-array><tt>json-serialization-action-forms-array</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-action-forms-array">The type of the field <code>forms</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-event-vocabulary><tt>json-serialization-event-vocabulary</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-event-vocabulary">Each required vocabulary, as defined in the class <a href="#event" class="sec-ref">Event</a>, <em class="rfc2119">MUST</em> be transformed as a JSON key within a Event field.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-event-objects><tt>json-serialization-event-objects</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-event-objects">The type of the fields <code>properties</code> and <code>items</code> <em class="rfc2119">MUST</em> be serialized as a JSON object.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-event-arrays><tt>json-serialization-event-arrays</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-event-arrays">The type of the fields <code>forms</code>, <code>required</code>, and <code>enum</code> <em class="rfc2119">MUST</em> be serialized as a JSON array.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-form-vocabulary><tt>json-serialization-form-vocabulary</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-form-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#form" class="sec-ref">Form</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-form-protocol-vocabulary><tt>json-serialization-form-protocol-vocabulary</tt></a>
+: <strong>MAY</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MAY" id="json-serialization-form-protocol-vocabulary">If required, <code>forms</code> <em class="rfc2119">MAY</em> be supplemented with protocol-specific vocabularies identified with a prefix.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-form-link-vocabulary><tt>json-serialization-form-link-vocabulary</tt></a>
+: <strong>MAY</strong>
+</dt>
+<dd>
+        <span class="rfc2119-assertion-MAY" id="json-serialization-form-link-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#link" class="sec-ref">Link</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-security-vocabulary><tt>json-serialization-security-vocabulary</tt></a>
+: <strong>MAY</strong>
+</dt>
+<dd>
+        <span class="rfc2119-assertion-MAY" id="json-serialization-security-vocabulary">Each mandatory and required vocabulary, as defined in the class <a href="#security" class="sec-ref">Security</a>, <em class="rfc2119">MUST</em> be serialized as a JSON key.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
 </dd>
 </dl>
   </body>

--- a/testing/assertions.html
+++ b/testing/assertions.html
@@ -241,6 +241,36 @@
 <li> Testing comments go here </li>
 </ul>
 </dd>
+<dt>
+<a href=../index.html#json-1.1-serialization-baseline><tt>json-1.1-serialization-baseline</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+        <span class="rfc2119-assertion" id="json-1.1-serialization-baseline">A valid JSON-LD-1.1 Thing Description serialization <em class="rfc2119">MUST</em> fulfill all requirements that are defined in <a href="#json-serializiation-section">JSON TD</a></span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-1.1-serialization-defaults><tt>json-1.1-serialization-defaults</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+        <span class="rfc2119-assertion" id="json-1.1-serialization-defaults">In a valid JSON-LD 1.1 Thing Description serialization, all vocabularies that have a default value as defined  <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> <em class="rfc2119">MUST</em> be present at least with their default value.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-1.1-serialization-context><tt>json-1.1-serialization-context</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+        <span class="rfc2119-assertion" id="json-1.1-serialization-context">In a valid JSON-LD 1.1 Thing Description serialization, the <code>@context</code> key from JSON-LD 1.1 <em class="rfc2119">MUST</em> have the value of the Thing description context file <code>https://w3c.github.io/wot/w3c-wot-td-context.jsonld</code>.</span><!-- Testing comments go here -->
+<ul>
+<li> Testing comments go here </li>
+</ul>
+</dd>
 </dl>
   </body>
 </html>

--- a/testing/assertions.html
+++ b/testing/assertions.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Normative Assertions Summary</title>
+  </head>
+  <body>
+	  <h1>Normative Assertions Summary</h1>
+  <p>This file is auto-generated using <tt>npm run assertions</tt>.
+     Run it from the <tt>wot-thing-description</tt> home directory (eg <tt>..</tt>).
+     It uses <tt>../index.html</tt> as input so run <tt>npm run render</tt> first.
+  </p>
+<dl>
+<dt>
+<a href=../index.html#json-serialization-additional-vocabularies><tt>json-serialization-additional-vocabularies</tt></a>
+: <strong>MAY</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MAY" id="json-serialization-additional-vocabularies">JSON TD <em class="rfc2119">MAY</em> contain additional optional vocabularies that are not in the Thing Description core model.</span><!-- Describe test cases -->
+<ul>
+<li> Describe test cases </li>
+</ul>
+</dd>
+<dt>
+<a href=../index.html#json-serialization-additional-vocabularies-prefix><tt>json-serialization-additional-vocabularies-prefix</tt></a>
+: <strong>MUST</strong>
+</dt>
+<dd>
+<span class="rfc2119-assertion-MUST" id="json-serialization-additional-vocabularies-prefix">Terms from additional optional vocabularies used in a JSON-TD <em class="rfc2119">MUST</em> carry a prefix for identification within the key name (e.g., <tt>"http:header"</tt>).</span>
+</dd>
+</dl>
+  </body>
+</html>

--- a/testing/assertions.md
+++ b/testing/assertions.md
@@ -1,5 +1,0 @@
-# List of Normative Assertions to be Tested
-
-Reference             | Class          | Normative Statement        | Test Case  
-----------------------|----------------|----------------------------|---------------------------------------
-(hyperlink into spec) | (MAY,MUST,etc) | (summary of the statement) | (description of how it will be tested)


### PR DESCRIPTION
Some conventions and scripts to make extracting normative assertions easier.
Note: This also comments out the @base in the ontology as it was breaking the render, at least on my system.  This may have to be reverted after the merge.