### PR TITLE
Editorial changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,10 +134,9 @@
   Thing Descriptions provide a set of interactions based on a small vocabulary 
   that makes it possible both to integrate diverse devices and 
   to allow diverse applications to interoperate. 
-  Thing Descriptions, by default, are encoded in JSON-LD. 
-  JSON-LD provides both a powerful foundation to represent knowledge 
-  about Things and simplicity, 
-  since it allows processing as a JSON document. 
+  Thing Descriptions, by default, are encoded in a JSON format that also allows
+  JSON-LD processing. The latter provides a powerful foundation to represent
+  knowledge about Things in a machine-understandable way.
   A Thing Description instance can be hosted by the Thing itself or hosted 
   externally when a Thing has resource restrictions (e.g., limited memory space) 
   or when a Web of Things-compatible legacy device is retrofitted 
@@ -170,9 +169,9 @@
   <section id="introduction">
   <h1>Introduction</h1>
   <p>
-  The W3C Thing Description (TD) is a central building block in a Web of Things 
-  (WoT) enabled system and can be considered as the entry point of a Thing 
-  (much like the <i>index.html</i> of a web site). 
+  The Thing Description (TD) is a central building block in the W3C Web of
+  Things (WoT) and can be considered as the entry point of a Thing
+  (much like the <i>index.html</i> of a Web site).
   The TD consists of semantic metadata for the Thing itself,
   an interaction model based on WoT's <code>Properties</code>,
   <code>Actions</code>, and <code>Events</code> paradigm, 
@@ -180,26 +179,23 @@
   and features for Web Linking to express relations among Things. 
   </p>
   <p>
-  Properties can be used for controlling (or retrieving) parameters, 
-  such as a setting an operation state (or getting the current value). 
-  Actions model invocation of physical processes, 
+  Properties can be used for sensing and controlling parameters,
+  such as getting the current value or setting an operation state.
+  Actions model invocation of physical (and hence time-consuming) processes,
   but can also be used to abstract RPC-like calls of existing platforms. 
-  Events are used for interactions that use the push model of
-  communication where state change notifications, 
-  discrete events, 
-  and streams of values are sent asynchronously to the receiver. 
+  Events are used for the push model of communication where notifications,
+  discrete events, or streams of values are sent asynchronously to the receiver.
   In general, the TD provides metadata for different communication bindings 
-  (e.g., HTTP, CoAP, MQTT, etc.), 
-  mediaTypes (e.g., "application/json", "application/xml", "application/cbor", 
-  "application/exi" etc.), 
-  and security mechanisms (for authentication, authorization, 
-  confidentiality, etc.). 
+  identified by URI schemes (e.g., "http", "coap", "mqtt", etc.),
+  media types (e.g., "application/json", "application/xml", "application/cbor",
+  "application/exi" etc.), and security mechanisms (for authentication,
+  authorization, confidentiality, etc.).
   Serialization of TD instances is based on JSON and includes at least 
   the TD core vocabulary as JSON keys as defined in this specification document.
   </p>
   <p>
-  Example 1 shows a simple TD instance in such a JSON serializiation that 
-  reflects WoT's <code>Properties</code>, <code>Actions</code>, 
+  Example 1 shows a simple TD instance in such a JSON serializiation and
+  depicts WoT's <code>Properties</code>, <code>Actions</code>,
   and <code>Events</code> paradigm 
   by describing a lamp Thing with the name <i>MyLampThing</i>.
   </p>
@@ -223,7 +219,10 @@
     "events":{
         "overheating":{
             "type": "string",
-            "forms": [{"href": "https://mylamp.example.com/oh"}]
+            "forms": [{
+                "href": "https://mylamp.example.com/oh",
+                "subProtocol": "LongPoll"
+            }]
         }
     }
 }
@@ -238,26 +237,21 @@
   at the URI <code>https://mylamp.example.com/status</code> 
   (announced within the <code>forms</code> structure by the 
   <code>href</code> key), and will return a string status value.
-  The use of the GET method is not stated explicitly but is 
-  the default assumption made by the W3C WoT 
-  protocol template deliverable [[!WOT-PROTOCOL-BINDING]].
+  The use of the GET method is not stated explicitly, 
+  but is one of the default assumptions defined by this document.
   </p>
   <p>
-  In a similar manner an <code>Action</code> is specified to toggle the 
+  In a similar manner, an <code>Action</code> is specified to toggle the
   switch status using the POST method applied to the 
-  <code>https://mylamp.example.com/toggle</code> resource 
-  (see again the HTTP protocol binding description in the W3C WoT protocol 
-  template deliverable [[!WOT-PROTOCOL-BINDING]]).
+  <code>https://mylamp.example.com/toggle</code> resource,
+  where POST is again a default assumption for invoking Actions.
   </p>
   <p>
-  The WoT's <code>Event</code> model enables a mechanism for events to be 
-  notified by a Thing. 
+  The <code>Event</code> pattern enables a mechanism for asynchronous messages
+  to be sent by a Thing.
   Here, a subscription to be notified upon a possible overheating event 
-  of the lamp can be obtained by using the default event-handling mechanism 
-  defined in the protocol binding for HTTP at 
-  <code>https://mylamp.example.com/oh</code> 
-  (see again the HTTP protocol binding description in the W3C WoT protocol 
-  template deliverable [[!WOT-PROTOCOL-BINDING]]).
+  of the lamp can be obtained by using the HTTP with its long polling
+  sub-protocol at <code>https://mylamp.example.com/oh</code>.
   </p>
   <p>
   This example also specifies the <code>basic</code> security scheme, 
@@ -287,12 +281,17 @@
   the Thing Description processor follows default assumptions for 
   interpretation as defined in this specification.
   </p>
+  <p class="ednote">
+  As default values are primarily reducing the size of TDs and IoT systems using
+  JSON usually have less resource constraints, a more sensible
+  default for <code>mediaType</code> might be "application/cbor".
+  </p>
   <p>
   The TD can be also processed as an RDF-based model. 
-  In that case, the Thing Description instance can be transformed 
+  In that case, the Thing Description instance needs to be transformed
   into valid JSON-LD first.  
   In terms of JSON-LD 1.1 serialization, 
-  RDF semantic processing's open-world assumption requires vocabulary terms 
+  the open-world assumption of RDF semantic processing requires vocabulary terms
   with default values to be always present explicitly in the instances. 
   Example 2 shows the same TD in a JSON-LD 1.1 serializiation representing
   exactly the same information as in Example 1; however, default values
@@ -312,6 +311,7 @@
             "type": "string",
             "forms": [{
                 "href": "https://mylamp.example.com/status",
+                "http:methodName": "GET",
                 "mediaType": "application/json"
             }]
         }
@@ -320,6 +320,7 @@
         "toggle": {
             "forms": [{
                 "href": "https://mylamp.example.com/toggle",
+                "http:methodName": "POST",
                 "mediaType": "application/json"
             }]
         }
@@ -329,6 +330,7 @@
             "type": "string",
             "forms": [{
                 "href": "https://mylamp.example.com/oh",
+                "subProtocol": "LongPoll",
                 "mediaType": "application/json"
             }]
         }
@@ -337,7 +339,7 @@
  </pre>
   <p>
   For more examples, including the use of other protocols besides HTTP,
-  see <a href="#example-serialization" class="sec-ref">Section 7.</a>
+  see Section <a href="#example-serialization"></a>.
   </p>
   </section>
 
@@ -398,17 +400,14 @@
   <p>
   A Thing Description instance complies with this specification if it follows 
   the normative statements in Section 
-  <a href="#vocabularyDefinitionSection" class="sec-ref"><span class="secno">5.</span> 
-  <span class="sec-title">Vocabulary Definition</span></a> 
+  <a href="#sec-vocabulary-definition"></a>
   and Section 
-  <a href="#TD-serialization-section" class="sec-ref"><span class="secno">6.</span> 
-  <span class="sec-title">Thing Description Serializations</span></a> 
+  <a href="#sec-td-serialization"></a> 
   regarding Thing Description serialization.
   </p>
   <p>
   A JSON Schema is provided in Annex 
-  <a href="#json-schema-4-validation" class="sec-ref"><span class="secno">A</span> 
-  <span class="sec-title">JSON Schema for TD Instance Validation</span></a> 
+  <a href="#json-schema-4-validation"></a> 
   to validate Thing Description instances based on JSON-LD 1.1.
   </p>
 
@@ -420,7 +419,7 @@
 
 
 
-<section id="vocabularyDefinitionSection"><h1>Information Model</h1><!-- h1>Vocabulary</h1 --><section><h2>Overview</h2><p>The W3C Thing Description provides a set of vocabulary for describing physical and virtual Things. To increase interoperability  the vocabulary terms are defined using the Resource Description Framework (RDF).  <span class="rfc2119-assertion" id="td-vocabulary">All vocabulary restrictions noted in these tables MUST be followed,including mandatory items and default values.</span></p><p>In general, the Thing Description vocabulary set is grouped in three modules: the core Thing Description vocabulary reflecting WoT's paradigm of <code>Properties</code>, <code>Actions</code>, and <code>Events</code> (also see [[!WOT-ARCHITECTURE]]);the data schema vocabulary reflecting a subset of JSON Schema terms in a linked data representation; and the security vocabulary used to define security mechanismconfiguration requirements.</p><p>An overview of this vocabulary with its class context and class relation is given by the following three figures: the TD core model, the TD data schema model, and the TD security model. Please note that the figures reflect the vocabulary terms and structure as they would be used in a Thing Description instance (see see <a href="#TD-serialization-section" class="sec-ref"><span class="secno">6.</span> <span class="sec-title">Thing Description Serialization</span></a>). The full ontology definitions of the different modules can be viewed by following the namespaces as provided in Section <a href="#namespaces" class="sec-ref"><span class="secno">3.</span> <span class="sec-title">Namespaces</span></a>.</p><!--<p><a href="http://visualdataweb.de/webvowl/#iri=https://rawgit.com/w3c/wot-thing-description/TD-JSON-LD-1.1/ontology/td.ttl">Click here for the visualization</a></p>--><figure id="td-core-model"><img src="td-core-model/td-core-model.svg" alt="TD core model figure"/><figcaption>TD core model</figcaption></figure><figure id="td-data-schema-model"><img src="td-core-model/td-data-schema-model.svg" alt="TD data schema model figure"/><figcaption>TD data schema model</figcaption></figure><figure id="td-security-model"><img src="td-core-model/td-security-model.svg" alt="TD security model figure"/><figcaption>TD security model</figcaption></figure><p class="ednote" title="Default Values and Mandatory Attributes">In the figures above, and in the tables to follow, items which have default values are indicated as being optional. However, technically, these are optional <em>only in the JSON serialization</em>. They are actually mandatory parts of the information model and are also mandatory in the JSON-LD serialization. In addition, the security scheme configuration is not actually optional even in the JSON serialization.  Security configuration is mandatory at least one of the three levels at which it may be specified... so it can be omitted only if it is specified at a different level for each form. A future version of this document should better express the status of these attributes. </p><p>A detailed description of the vocabulary of the TD core model and TD data schema model is given in the next sub-section.</p></section><section id="sec-core-vocabulary-definition"><h2>Core Vocabulary Definition</h2>      <section><h3><code>Thing</code></h3><p>Describes a physical and/or virtual Thing (may represent one or more physical and/or virtual Things) in the Web of Things context.</p><table class="def"><thead><tr><th>Field Name</th><th>Description</th><th>Mandatory</th><th>Default value</th><th>Type</th></tr></thead><tbody><tr><td><code>id</code></td><td>unique identifier of the Thing (URI, e.g. custom URN)</td><td>yes</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#anyURI"><code>anyURI</code></a></td></tr><tr><td><code>security</code></td><td>Set of security configurations that must all be satisfied for access to resources at or below the current level, if not overridden at a lower level.</td><td>no</td><td>.</td><td>array of <a href="#securityscheme"><code>SecurityScheme</code></a></td></tr><tr><td><code>name</code></td><td>Name of the Thing.</td><td>yes</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>description</code></td><td>Provides additional (human) readable information.</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>support</code></td><td>Provides information about the TD maintainer (e.g., author, link or telephone number to get support, etc).</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>base</code></td><td>Define the base URI that is valid for all defined local interaction resources. All other URIs in the TD must then be resolved using the algorithm defined in [[!RFC3986]].</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#anyURI"><code>anyURI</code></a></td></tr><tr><td><code>properties</code></td><td>All Property-based interaction patterns of the Thing.</td><td>no</td><td>.</td><td><a href="#property"><code>Property</code></a></td></tr><tr><td><code>actions</code></td><td>All Action-based interaction patterns of the Thing.</td><td>no</td><td>.</td><td><a href="#action"><code>Action</code></a></td></tr><tr><td><code>events</code></td><td>All Event-based interaction patterns of the Thing.</td><td>no</td><td>.</td><td><a href="#event"><code>Event</code></a></td></tr><tr><td><code>links</code></td><td>Provides Web links to arbitrary resources that relate to the specified Thing Description.</td><td>no</td><td>.</td><td>array of <a href="#link"><code>Link</code></a></td></tr></tbody></table></section>      <section><h3><code>InteractionPattern</code></h3><p>Three interaction patterns are defined as subclasses: Property, Action and Event. When a concrete Property, Action or Event is defined in a Thing Description, it is called an &quot;interaction resource&quot;. Interactions between Things can be as simple as one Thing accessing another Thing&#39;s data to get or (in the case the data is also writable) change the representation of data such as metadata, status or mode. A Thing may also be interested in getting asynchronously notified of future changes in another Thing, or may want to initiate a process served in another Thing that may take some time to complete and monitor the progress. Interactions between Things may involve exchanges of data between them. This data can be either given as input by the client Thing, returned as output by the server Thing or both.</p><p class="note">Each instance of a <code>Property</code>, <code>Action</code>, and <code>Event</code>  class has a (unique) name. See Section <a href="#json-serializiation-section" class="sec-ref">Representation Format</a> for more details about JSON-LD 1.1 identifiers.</p><table class="def"><thead><tr><th>Field Name</th><th>Description</th><th>Mandatory</th><th>Default value</th><th>Type</th></tr></thead><tbody><tr><td><code>forms</code></td><td>Indicates one or more endpoints from which an interaction pattern is accessible.</td><td>yes</td><td>.</td><td>array of <a href="#form"><code>Form</code></a></td></tr><tr><td><code>label</code></td><td>Provides a label (e.g., display a text for UI representation) of the interaction pattern.</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>description</code></td><td>Provides additional (human) readable information.</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>security</code></td><td>Set of security configurations that must all be satisfied for access to resources at or below the current level, if not overridden at a lower level.</td><td>no</td><td>.</td><td>array of <a href="#securityscheme"><code>SecurityScheme</code></a></td></tr><tr><td><code>scopes</code></td><td>Array of authorization scope identifiers.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr></tbody></table><p>The class <code>InteractionPattern</code> has the following subclasses:</p><ul><li><td><a href="#event"><code>Event</code></a></td></li><li><td><a href="#property"><code>Property</code></a></td></li><li><td><a href="#action"><code>Action</code></a></td></li></ul></section>      <section><h3><code>Property</code></h3><p>Properties expose internal state of a Thing that can be directly retrieved (get) and optionally modified (set). In addition, Things can also choose to make Properties observable by pushing the new state (not an event) after a change; this must follow eventual consistency (also see CAP Theorem).</p><table class="def"><thead><tr><th>Field Name</th><th>Description</th><th>Mandatory</th><th>Default value</th><th>Type</th></tr></thead><tbody><tr><td><code>observable</code></td><td>Indicates whether a remote servient can subscribe to (&quot;observe&quot;) the Property, to receive change notifications or periodic updates (true/false).</td><td>no</td><td>false</td><td><a href="http://www.w3.org/2001/XMLSchema#boolean"><code>boolean</code></a></td></tr><tr><td><code>writable</code></td><td>Boolean value that indicates whether a property is writable (=true) or not (=false).</td><td>no</td><td>false</td><td><a href="http://www.w3.org/2001/XMLSchema#boolean"><code>boolean</code></a></td></tr></tbody></table><p class="note">Property instances may also be instances of the class <a href="#dataschema" class="sec-ref">DataSchema</a> and therefore can contain, among others, the <code>type</code> term.</p></section>      <section><h3><code>Action</code></h3><p>Actions offer functions of the Thing. These functions may manipulate the interal state of a Thing in a way that is not possible through setting Properties. Examples are changing internal state that is not exposed as a Property, changing multiple Properties, changing Properties over time or with a process that should not be disclosed. Actions may also be pure functions, that is, they may not use any internal state at all, and may simply process input data and return a result that directly depends only on the input given.</p><table class="def"><thead><tr><th>Field Name</th><th>Description</th><th>Mandatory</th><th>Default value</th><th>Type</th></tr></thead><tbody><tr><td><code>input</code></td><td>Link to the n-ary class that allows the declaration of the accepted data type of an action.</td><td>no</td><td>.</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr><tr><td><code>output</code></td><td>Link to the n-ary class that allows the declaration of the data type returned by an action.</td><td>no</td><td>.</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table></section>      <section><h3><code>Event</code></h3><p>The Event Interaction Pattern describes event sources that asynchronously push messages. Here not state, but state transitions (events) are communicated (e.g., &quot;clicked&quot;). Events may be triggered by internal state changes that are not exposed as Properties. Events usually follow strong consistency, where messages need to be queued to ensure eventual delivery of all events that have occurred.</p><p>Instances of the <code>Event</code> class contains the term definitions of the class <a href="#interactionpattern" class="sec-ref">InteractionPattern</a> and <a href="#dataschema" class="sec-ref">DataSchema</a>.</p></section>      <section><h3><code>Form</code></h3><p>Communication metadata indicating where a service can be accessed by a client application. An interaction might have more than one form.</p><table class="def"><thead><tr><th>Field Name</th><th>Description</th><th>Mandatory</th><th>Default value</th><th>Type</th></tr></thead><tbody><tr><td><code>href</code></td><td>URI of the endpoint where an interaction pattern is provided.</td><td>yes</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#anyURI"><code>anyURI</code></a></td></tr><tr><td><code>mediaType</code></td><td>Assign the underlying media type of an interaction pattern based on IANA (https://www.iana.org/assignments/media-types/media-types.xhtml).</td><td>no</td><td>application/json</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>rel</code></td><td>Indicates the expected result of performing the operation described by the form.
+<section id="sec-vocabulary-definition"><h1>Information Model</h1><!-- h1>Vocabulary</h1 --><section><h2>Overview</h2><p>The W3C Thing Description provides a set of vocabulary for describing physical and virtual Things. To increase interoperability  the vocabulary terms are defined using the Resource Description Framework (RDF).  <span class="rfc2119-assertion" id="td-vocabulary">All vocabulary restrictions noted in these tables MUST be followed,including mandatory items and default values.</span></p><p>In general, the Thing Description vocabulary set is grouped in three modules: the core Thing Description vocabulary reflecting WoT's paradigm of <code>Properties</code>, <code>Actions</code>, and <code>Events</code> (also see [[!WOT-ARCHITECTURE]]);the data schema vocabulary reflecting a subset of JSON Schema terms in a linked data representation; and the security vocabulary used to define security mechanismconfiguration requirements.</p><p>An overview of this vocabulary with its class context and class relation is given by the following three figures: the TD core model, the TD data schema model, and the TD security model. Please note that the figures reflect the vocabulary terms and structure as they would be used in a Thing Description instance (see Section <a href="#sec-td-serialization"></a>).The full ontology definitions of the different modules can be viewed by following the namespaces as provided in Section <a href="#namespaces"></a>.</p><!--<p><a href="http://visualdataweb.de/webvowl/#iri=https://rawgit.com/w3c/wot-thing-description/TD-JSON-LD-1.1/ontology/td.ttl">Click here for the visualization</a></p>--><figure id="td-core-model"><img src="td-core-model/td-core-model.svg" alt="TD core model figure"/><figcaption>TD core model</figcaption></figure><figure id="td-data-schema-model"><img src="td-core-model/td-data-schema-model.svg" alt="TD data schema model figure"/><figcaption>TD data schema model</figcaption></figure><figure id="td-security-model"><img src="td-core-model/td-security-model.svg" alt="TD security model figure"/><figcaption>TD security model</figcaption></figure><p class="ednote" title="Default Values and Mandatory Attributes">In the figures above, and in the tables to follow, items which have default values are indicated as being optional. However, technically, these are optional <em>only in the JSON serialization</em>. They are actually mandatory parts of the information model and are also mandatory in the JSON-LD serialization. In addition, the security scheme configuration is not actually optional even in the JSON serialization.  Security configuration is mandatory at least one of the three levels at which it may be specified... so it can be omitted only if it is specified at a different level for each form. A future version of this document should better express the status of these attributes. </p><p>A detailed description of the vocabulary of the TD core model and TD data schema model is given in the next sub-section.</p></section><section id="sec-core-vocabulary-definition"><h2>Core Vocabulary Definition</h2>      <section><h3><code>Thing</code></h3><p>Describes a physical and/or virtual Thing (may represent one or more physical and/or virtual Things) in the Web of Things context.</p><table class="def"><thead><tr><th>Field Name</th><th>Description</th><th>Mandatory</th><th>Default value</th><th>Type</th></tr></thead><tbody><tr><td><code>id</code></td><td>unique identifier of the Thing (URI, e.g. custom URN)</td><td>yes</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#anyURI"><code>anyURI</code></a></td></tr><tr><td><code>security</code></td><td>Set of security configurations that must all be satisfied for access to resources at or below the current level, if not overridden at a lower level.</td><td>no</td><td>.</td><td>array of <a href="#securityscheme"><code>SecurityScheme</code></a></td></tr><tr><td><code>name</code></td><td>Name of the Thing.</td><td>yes</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>description</code></td><td>Provides additional (human) readable information.</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>support</code></td><td>Provides information about the TD maintainer (e.g., author, link or telephone number to get support, etc).</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>base</code></td><td>Define the base URI that is valid for all defined local interaction resources. All other URIs in the TD must then be resolved using the algorithm defined in [[!RFC3986]].</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#anyURI"><code>anyURI</code></a></td></tr><tr><td><code>properties</code></td><td>All Property-based interaction patterns of the Thing.</td><td>no</td><td>.</td><td><a href="#property"><code>Property</code></a></td></tr><tr><td><code>actions</code></td><td>All Action-based interaction patterns of the Thing.</td><td>no</td><td>.</td><td><a href="#action"><code>Action</code></a></td></tr><tr><td><code>events</code></td><td>All Event-based interaction patterns of the Thing.</td><td>no</td><td>.</td><td><a href="#event"><code>Event</code></a></td></tr><tr><td><code>links</code></td><td>Provides Web links to arbitrary resources that relate to the specified Thing Description.</td><td>no</td><td>.</td><td>array of <a href="#link"><code>Link</code></a></td></tr></tbody></table></section>      <section><h3><code>InteractionPattern</code></h3><p>Three interaction patterns are defined as subclasses: Property, Action and Event. When a concrete Property, Action or Event is defined in a Thing Description, it is called an &quot;interaction resource&quot;. Interactions between Things can be as simple as one Thing accessing another Thing&#39;s data to get or (in the case the data is also writable) change the representation of data such as metadata, status or mode. A Thing may also be interested in getting asynchronously notified of future changes in another Thing, or may want to initiate a process served in another Thing that may take some time to complete and monitor the progress. Interactions between Things may involve exchanges of data between them. This data can be either given as input by the client Thing, returned as output by the server Thing or both.</p><p class="note">Each instance of a <code>Property</code>, <code>Action</code>, and <code>Event</code>  class has a (unique) name. See Section <a href="#json-serializiation-section" class="sec-ref">Representation Format</a> for more details about JSON-LD 1.1 identifiers.</p><table class="def"><thead><tr><th>Field Name</th><th>Description</th><th>Mandatory</th><th>Default value</th><th>Type</th></tr></thead><tbody><tr><td><code>forms</code></td><td>Indicates one or more endpoints from which an interaction pattern is accessible.</td><td>yes</td><td>.</td><td>array of <a href="#form"><code>Form</code></a></td></tr><tr><td><code>label</code></td><td>Provides a label (e.g., display a text for UI representation) of the interaction pattern.</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>description</code></td><td>Provides additional (human) readable information.</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>security</code></td><td>Set of security configurations that must all be satisfied for access to resources at or below the current level, if not overridden at a lower level.</td><td>no</td><td>.</td><td>array of <a href="#securityscheme"><code>SecurityScheme</code></a></td></tr><tr><td><code>scopes</code></td><td>Array of authorization scope identifiers.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.</td><td>no</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr></tbody></table><p>The class <code>InteractionPattern</code> has the following subclasses:</p><ul><li><td><a href="#event"><code>Event</code></a></td></li><li><td><a href="#property"><code>Property</code></a></td></li><li><td><a href="#action"><code>Action</code></a></td></li></ul></section>      <section><h3><code>Property</code></h3><p>Properties expose internal state of a Thing that can be directly retrieved (get) and optionally modified (set). In addition, Things can also choose to make Properties observable by pushing the new state (not an event) after a change; this must follow eventual consistency (also see CAP Theorem).</p><table class="def"><thead><tr><th>Field Name</th><th>Description</th><th>Mandatory</th><th>Default value</th><th>Type</th></tr></thead><tbody><tr><td><code>observable</code></td><td>Indicates whether a remote servient can subscribe to (&quot;observe&quot;) the Property, to receive change notifications or periodic updates (true/false).</td><td>no</td><td>false</td><td><a href="http://www.w3.org/2001/XMLSchema#boolean"><code>boolean</code></a></td></tr><tr><td><code>writable</code></td><td>Boolean value that indicates whether a property is writable (=true) or not (=false).</td><td>no</td><td>false</td><td><a href="http://www.w3.org/2001/XMLSchema#boolean"><code>boolean</code></a></td></tr></tbody></table><p class="note">Property instances may also be instances of the class <a href="#dataschema" class="sec-ref">DataSchema</a> and therefore can contain, among others, the <code>type</code> term.</p></section>      <section><h3><code>Action</code></h3><p>Actions offer functions of the Thing. These functions may manipulate the interal state of a Thing in a way that is not possible through setting Properties. Examples are changing internal state that is not exposed as a Property, changing multiple Properties, changing Properties over time or with a process that should not be disclosed. Actions may also be pure functions, that is, they may not use any internal state at all, and may simply process input data and return a result that directly depends only on the input given.</p><table class="def"><thead><tr><th>Field Name</th><th>Description</th><th>Mandatory</th><th>Default value</th><th>Type</th></tr></thead><tbody><tr><td><code>input</code></td><td>Link to the n-ary class that allows the declaration of the accepted data type of an action.</td><td>no</td><td>.</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr><tr><td><code>output</code></td><td>Link to the n-ary class that allows the declaration of the data type returned by an action.</td><td>no</td><td>.</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table></section>      <section><h3><code>Event</code></h3><p>The Event Interaction Pattern describes event sources that asynchronously push messages. Here not state, but state transitions (events) are communicated (e.g., &quot;clicked&quot;). Events may be triggered by internal state changes that are not exposed as Properties. Events usually follow strong consistency, where messages need to be queued to ensure eventual delivery of all events that have occurred.</p><p>Instances of the <code>Event</code> class contains the term definitions of the class <a href="#interactionpattern" class="sec-ref">InteractionPattern</a> and <a href="#dataschema" class="sec-ref">DataSchema</a>.</p></section>      <section><h3><code>Form</code></h3><p>Communication metadata indicating where a service can be accessed by a client application. An interaction might have more than one form.</p><table class="def"><thead><tr><th>Field Name</th><th>Description</th><th>Mandatory</th><th>Default value</th><th>Type</th></tr></thead><tbody><tr><td><code>href</code></td><td>URI of the endpoint where an interaction pattern is provided.</td><td>yes</td><td>.</td><td><a href="http://www.w3.org/2001/XMLSchema#anyURI"><code>anyURI</code></a></td></tr><tr><td><code>mediaType</code></td><td>Assign the underlying media type of an interaction pattern based on IANA (https://www.iana.org/assignments/media-types/media-types.xhtml).</td><td>no</td><td>application/json</td><td><a href="http://www.w3.org/2001/XMLSchema#string"><code>string</code></a></td></tr><tr><td><code>rel</code></td><td>Indicates the expected result of performing the operation described by the form.
 
 For example, the Property interaction allows get and set operations.  
 The protocol binding may contain a form for the get operation and a different form for the set operation.  
@@ -436,45 +435,46 @@ The rel attribute indicates which form is which and allows the client to select 
 
 
 
-  <section id="TD-serialization-section">
-  <h1 >Thing Description Serialization</h1>
+  <section id="sec-td-serialization">
+  <h1>Thing Description Serialization</h1>
 
-  <p class="ednote" title="JSON-LD 1.1 ">
+  <p class="ednote" title="JSON-LD 1.1">
   This is the first draft that uses JSON-LD 1.1 as a serialization format 
   of the Thing Description. 
-  As this is a work in progress, working assumptions are based on the latest
+  As that is work in progress, working assumptions are based on the latest
   <a href="https://json-ld.org/spec/latest/json-ld/#">Community Draft of JSON-LD 1.1</a>. 
-  There is a plan to set up a JSON-LD Working Group with the following 
-  <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">JSON-LD Working Group Charter</a>. 
+  A new JSON-LD Working Group has already been
+  <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">chartered</a>.
   It is planned that this section will conform to the latest working draft 
-  of JSON-LD 1.1.
+  of their JSON-LD 1.1 deliverable and only use stable elements.
   </p>
 
   <p>
-  Thing Description instances are modeled and structured based on the 
-  <a href="#vocabularyDefinitionSection" class="sec-ref">Thing Description Information Model</a>. 
-  This section proposes a TD serialization based on JSON-LD 1.1. 
+  Thing Description instances are modeled and structured based on Section
+  <a href="#sec-vocabulary-definition"></a>.
+  This section defines a TD serialization based on JSON [[!RFC8259]].
   </p>
 
   <section id="json-serializiation-section">
   <h1>Representation Format</h1>
 
   <p>
-  This section introduces the JSON-based serialization of the Thing Description. 
-  This serialization also follows the syntax of JSON-LD 1.1 
-  in order to streamline the semantic evaluation of TDs.
+  The JSON serialization of TDs follows the syntax of JSON-LD 1.1
+  in order to streamline semantic evaluation.
+  Hence, serializations can be parsed either as raw JSON or with a JSON-LD 1.1
+  processor.
   </p>
 
   <p>
   In order to enable this convergence,
-  all vocabulary terms defined in 
-  <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> 
+  all vocabulary terms defined in Section
+  <a href="#sec-vocabulary-definition"></a>
   will have a JSON key representation.
   </p>
   <p>
   In addition,
   <span class="rfc2119-assertion" id="td-string-type">
-  Thing Description instances MAY contain JSON-LD 1.1 keys such as 
+  Thing Description instances MAY contain JSON-LD 1.1 keywords such as
   <code>@context</code> and <code>@type</code>.</span>
   </p>
 
@@ -484,8 +484,8 @@ The rel attribute indicates which form is which and allows the client to select 
   within the key name (e.g., "http:header").</p>-->
 
   <p>
-  The defined types of the vocabulary as defined in 
-  <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> 
+  The data types of the vocabulary as defined in Section
+  <a href="#sec-data-schema-vocabulary-definition"></a>
   will be transformed to JSON-based types. 
   The following rules are used for vocabulary terms based on some simple type 
   definitions:
@@ -506,8 +506,8 @@ The rel attribute indicates which form is which and allows the client to select 
   </ul>
 
   <p>
-  All vocabulary terms in the
-  <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> Section 
+  All vocabulary terms in Section
+  <a href="#sec-vocabulary-definition"></a>
   associated with more complex class-based types are defined separately for 
   structured JSON type transformation in the following subsections.
   </p>
@@ -516,7 +516,7 @@ The rel attribute indicates which form is which and allows the client to select 
   <h2>Thing as a whole</h2>
 
   <p><span class="rfc2119-assertion" id="td-context">
-  The first line of a Thing Description instance MAY include the 
+  The root object of a Thing Description instance MAY include the
   <code>@context</code> key from JSON-LD 1.1 with the value URI of 
   the Thing description context file <code>http://www.w3.org/ns/td</code>.
   </span></p>
@@ -528,9 +528,15 @@ The rel attribute indicates which form is which and allows the client to select 
 }
 </pre>
 
+  <p class="ednote">
+  <code>http://www.w3.org/ns/td</code> uses content negotiation to return the
+  context file. Thus, it must be fetched with an <code>Accept</code> header set
+  to <code>application/ld+json</code>.
+  </p>
+
   <p><span class="rfc2119-assertion" id="td-context-jsonld">
-  When a Thing Description instance is processed and interpreted by a 
-  JSON-LD 1.1 processor the <code>@context</code> with its value 
+  When a Thing Description instance is processed and interpreted by a
+  JSON-LD 1.1 processor the <code>@context</code> field
   MUST be present</span> 
   (see also Section <a href="#note-jsonld-processing" class="sec-ref">JSON-LD 1.1 Processing</a>). 
   </p>
@@ -545,32 +551,32 @@ The rel attribute indicates which form is which and allows the client to select 
 <pre class="example">
 {
     "@context": ["http://www.w3.org/ns/td",
-                {"sensor": "http://iotschema.org/"}],
+                {"iot": "http://iotschema.org/"}],
     ...
 }
 </pre>
 
   <p><span class="rfc2119-assertion" id="td-context-toplevel">
-  Each mandatory and optional vocabulary, 
-  as defined in the class <a href="#thing" class="sec-ref">Thing</a>, 
+  Each mandatory and optional field name
+  as defined in the class <a href="#thing" class="sec-ref"><code>Thing</code></a>
   MUST be serialized as a JSON key 
-  at the top level of the Thing Description instance.
+  in the root object of the Thing Description instance.
   </span></p>
 
   <!-- should this be "the type" or "the elements of"? -->
   <p><span class="rfc2119-assertion" id="td-objects">
   The type of the fields <code>properties</code>, <code>actions</code>, 
-  and <code>events</code> MUST be serialized as a JSON object.
+  and <code>events</code> MUST be a JSON object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-arrays">
-  The type of the field <code>links</code> and <code>security</code> 
-  MUST be serialized as a JSON array.
+  The type of the fields <code>links</code> and <code>security</code>
+  MUST be a JSON array.
   </span></p>
 
   <p>
-  An example of a TD snippet based on the defined fields of the 
-  <a href="#thing" class="sec-ref">Thing</a> information model 
+  A TD snippet based on the defined fields of the class
+  <a href="#thing" class="sec-ref"><code>Thing</code></a>
   without the optional field <code>@context</code> is given below:
   </p>
 <pre class="example">
@@ -612,21 +618,21 @@ The rel attribute indicates which form is which and allows the client to select 
  </section> <!-- end of id="sec-thing-as-a-whole-json"-->
 
  <section id="property-serialization-json">
- <h2>properties</h2>
+ <h2><code>properties</code></h2>
   
   <p><span class="rfc2119-assertion" id="td-properties">
-  Properties (and sub-properties) offered by a Thing MUST be collected 
-  in the JSON object-based <code>properties</code> field 
-  of (unique) Property names as JSON keys.
+  Properties (and sub-properties) offered by a Thing MUST be collected
+  in the JSON-object based <code>properties</code> field
+  with (unique) Property names as JSON keys.
   </span></p>
 
   <span class="rfc2119-assertion" id="td-property-keys">
-  Each mandatory and optional vocabulary, 
-  as defined in the class <a href="#property" class="sec-ref">Property</a>, 
-  its two superclasses 
-  <a href="#interactionPattern" class="sec-ref">InteractionPattern</a> 
-  and <a href="#dataschema" class="sec-ref">DataSchema</a>, 
-  MUST be serialized as a JSON key within a Property field.
+  Each mandatory and optional vocabulary term
+  as defined in the class <a href="#property" class="sec-ref"><code>Property</code></a>,
+  as well as its two superclasses
+  <a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
+  and <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
+  MUST be serialized as a JSON key within a Property object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-property-objects">
@@ -636,11 +642,12 @@ The rel attribute indicates which form is which and allows the client to select 
 
   <p><span class="rfc2119-assertion" id="td-property-arrays">
   The type of the fields <code>forms</code>, <code>required</code>, 
-  and <code>enum</code> MUST be serialized as a JSON array.
+  and <code>enum</code>, and potentially <code>security</code>,
+  MUST be serialized as a JSON array.
   </span></p>
 
   <p>
-  An example of a TD snippet based on the defined fields is given below:
+  A TD snippet based on the defined fields is given below:
   </p>
 <pre class="example">
 {
@@ -669,7 +676,7 @@ The rel attribute indicates which form is which and allows the client to select 
                     "maxItems": 3
                 }
             },
-            "required": ["brightness","rgb"],
+            "required": ["brightness", "rgb"],
             "forms": [...]
         }
     }
@@ -678,29 +685,30 @@ The rel attribute indicates which form is which and allows the client to select 
 </pre>
 
   <p><span class="rfc2119-assertion" id="td-property-semantic">
-  Similar to case at the <code>Thing</code> level,
+  Similar to the case at the <code>Thing</code> level,
   properties MAY have additional semantic annotations based on 
-  JSON-LD 1.1 keys.
+  JSON-LD 1.1 keywords.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-property-defaults">
   When a Thing Description instance is processed and interpreted by 
   a JSON-LD 1.1 processor, 
   each <code>property</code> MUST contain the vocabulary terms 
-  <code>observable</code> and <code>writable</code> due to the linked data's 
-  <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>.
+  <code>observable</code> and <code>writable</code> due to the 
+  <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>
+  of Linked Data.
   </span>
-  This assumption means that if a Thing Description instance 
-  were to omit these vocabulary terms, 
+  This assumption means that if a Linked Data model of a Thing Description
+  instance were to omit these vocabulary terms,
   then the interpreter would not be able to make any assumptions
   about their actual value. 
   </p>
 
   <p>
-  An example of a JSON-LD 1.1 serialization of a TD snippet 
-  including semantic annotations and the 
+  A snippet of a JSON-LD 1.1 processable TD serialization including
+  semantic annotations and the
   default values of <code>observable</code> and <code>writable</code> 
-  based on class <a href="#property" class="sec-ref">Property</a> definition
+  based on the class <a href="#property" class="sec-ref"><code>Property</code></a>
   is given as follows:
   </p>
 <pre class="example">
@@ -744,39 +752,43 @@ The rel attribute indicates which form is which and allows the client to select 
     ...
 </pre>
 
-    </section> <!-- end of id="property-serialization-json"-->
+  </section> <!-- end of id="property-serialization-json"-->
 
-    <section id="action-serialization-json">
-    <h2>actions</h2>
+  <section id="action-serialization-json">
+  <h2><code>actions</code></h2>
 
-    <p>
-    Actions offered by a Thing are collected in the JSON object-based 
-    <code>actions</code> field of (unique) Action names as JSON keys. 
-    <span class="rfc2119-assertion" id="td-actions">
-    Each optional vocabulary term,
-    as defined in the class <a href="#action" class="sec-ref">Action</a> 
-    and its superclass 
-    <a href="#interactionPattern" class="sec-ref">InteractionPattern</a>,
-    MUST be serialized as a JSON key within a Action field.
-    </span></p>
+  <p><span class="rfc2119-assertion" id="td-actions">
+  Actions offered by a Thing MUST be collected
+  in the JSON-object based <code>actions</code> field
+  with (unique) Action names as JSON keys.
+  </span></p>
 
-    <p><span class="rfc2119-assertion" id="td-action-objects">
-    The type of the fields <code>input</code> and <code>output</code> 
-    MUST be serialized as a JSON object.
-    </span></p>
+  <span class="rfc2119-assertion" id="td-action-keys">
+  Each optional vocabulary term
+  as defined in the class <a href="#action" class="sec-ref"><code>Action</code></a>
+  and its superclass
+  <a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
+  MUST be serialized as a JSON key within an Action object.
+  </span></p>
 
-    <p>The member keys of <code>input</code> and <code>output</code> 
-    rely on the the class <a href="#property" class="sec-ref">Property</a>.
-    </p>
+  <p><span class="rfc2119-assertion" id="td-action-objects">
+  The type of the fields <code>input</code> and <code>output</code>
+  MUST be serialized as a JSON object.
+  </span></p>
 
-    <p><span class="rfc2119-assertion" id="td-action-arrays">
-    The type of the field <code>forms</code> 
-    MUST be serialized as a JSON array.
-    </span></p>
+  <p>The keys of <code>input</code> and <code>output</code>
+  rely on the the class <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>.
+  </p>
 
-    <p>An example of a TD snippet based on the defined fields is 
-    given below:
-    </p>
+  <p><span class="rfc2119-assertion" id="td-action-arrays">
+  The type of the field <code>forms</code>,
+  and potentially <code>security</code>,
+  MUST be serialized as a JSON array.
+  </span></p>
+
+  <p>
+  A TD snippet based on the defined fields is given below:
+  </p>
 
 <pre class="example">
     ...
@@ -810,26 +822,28 @@ The rel attribute indicates which form is which and allows the client to select 
 </pre>
 
   <p><span class="rfc2119-assertion" id="td-action-semantic">
-  Definitions within the  <code>actions</code> level 
-  MAY have also additional semantic annotations based on JSON-LD 1.1 keys.
+  Definitions within the <code>actions</code> field
+  MAY have additional semantic annotations based on JSON-LD 1.1 keywords.
   </span></p>
 
   </section> <!-- end of id="action-serialization-json"-->
 
   <section id="event-serialization-json">
-  <h2>events</h2>
+  <h2><code>events</code></h2>
 
-  <p>
-  Events (and sub-events) offered by a Thing are collected in the JSON 
-  object-based <code>events</code> field with (unique) Event names as 
-  JSON keys.
-  <span class="rfc2119-assertion" id="td-events">
-  Each optional vocabulary term, 
-  as defined in the class <a href="#event" class="sec-ref">Event</a>, 
-  as well as its two superclasses 
-  <a href="#interactionPattern" class="sec-ref">InteractionPattern</a> 
-  and <a href="#dataschema" class="sec-ref">DataSchema</a>, 
-  MUST be serialized as a JSON key within a Event field.
+  <p><span class="rfc2119-assertion" id="td-events">
+  Events offered by a Thing MUST be collected
+  in the JSON-object based <code>events</code> field
+  with (unique) Event names as JSON keys.
+  </span></p>
+
+  <span class="rfc2119-assertion" id="td-event-keys">
+  Each optional vocabulary term
+  as defined in the class <a href="#event" class="sec-ref"><code>Event</code></a>,
+  as well as its two superclasses
+  <a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
+  and <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
+  MUST be serialized as a JSON key within an Event object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-event-objects">
@@ -839,11 +853,12 @@ The rel attribute indicates which form is which and allows the client to select 
 
   <p><span class="rfc2119-assertion" id="td-event-arrays">
   The type of the fields <code>forms</code>, <code>required</code>, 
-  and <code>enum</code> MUST be serialized as a JSON array.
+  and <code>enum</code>, and potentially <code>security</code>,
+  MUST be serialized as a JSON array.
   </span></p>
 
   <p>
-  An example of a TD snippet based on the defined fields is given below:
+  A TD snippet based on the defined fields is given below:
   </p>
 <pre class="example">
     ...
@@ -860,20 +875,19 @@ The rel attribute indicates which form is which and allows the client to select 
     ...
 </pre>
 
-  <p><span class="rfc2119-assertion" id="td-action-semantic">
-  Definitions within the  <code>events</code> level 
-  MAY have also additional semantic anotations 
-  based on JSON-LD 1.1 keys.
+  <p><span class="rfc2119-assertion" id="td-event-semantic">
+  Definitions within the <code>events</code> field
+  MAY have additional semantic anotations based on JSON-LD 1.1 keywords.
   </span></p>
 
   </section> <!-- end of id="event-serialization-json"-->
 
   <section id="form-serialization-json">
-  <h2>forms</h2>
+  <h2><code>forms</code></h2>
 
   <p><span class="rfc2119-assertion" id="td-forms">
-  Each mandatory and optional vocabulary term,
-  as defined in the class <a href="#form" class="sec-ref">Form</a>, 
+  Each mandatory and optional vocabulary term
+  as defined in the class <a href="#form" class="sec-ref"><code>Form</code></a>,
   MUST be serialized as a JSON key.
   </span></p>
 
@@ -890,16 +904,17 @@ The rel attribute indicates which form is which and allows the client to select 
   by a JSON-LD 1.1 processor, 
   each <code>forms</code> (array) entry 
   MUST contain a <code>mediaType</code> 
-  due to linked data's 
-  <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>.
+  due to the
+  <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>
+  of Linked Data.
   </span>
-  This assumption means that if a Thing Description instance 
-  were to omit these vocabulary terms, 
+  This assumption means that if a Linked Data model of a Thing Description
+  instance were to omit these vocabulary terms,
   then the interpreter would not be able to make any assumptions
-  about their actual value. 
+  about their actual value.
   </p>
 
-  <p>An example of a TD snippet based on the defined fields is given below:</p>
+  <p>A TD snippet based on the defined fields is given below:</p>
 <pre class="example">
     ...
     "forms": [{
@@ -907,7 +922,7 @@ The rel attribute indicates which form is which and allows the client to select 
         "mediaType": "application/json",
         "http:methodName": "POST",
         "rel": "writeProperty",
-        "security": [{"scheme":"basic","in":"header"}]
+        "security": [{"scheme":"basic", "in":"header"}]
     }]
     ...
 </pre>
@@ -915,22 +930,22 @@ The rel attribute indicates which form is which and allows the client to select 
     </section> <!-- end of id="form-serialization-json"-->
 
     <section id="links-serialization-json">
-    <h2>links</h2>
+    <h2><code>links</code></h2>
 
     <p><span class="rfc2119-assertion" id="td-links">
-    Each mandatory and optional vocabulary term, 
-    as defined in the class <a href="#link" class="sec-ref">Link</a>, 
+    Each mandatory and optional vocabulary term
+    as defined in the class <a href="#link" class="sec-ref"><code>Link</code></a>,
     MUST be serialized as a JSON key.
     </span></p>
 
-    <p>An example of a TD snippet based on the defined fields is given below:</p>
+    <p>A TD snippet based on the defined fields is given below:</p>
 
 <pre class="example">
     ...
     "links": [{
         "href": "https://servient.example.com/things/lampController",
         "rel": "controlledBy",
-        "mediaType": "application/td"
+        "mediaType": "application/td+json"
     }]
     ...
 </pre>
@@ -938,17 +953,17 @@ The rel attribute indicates which form is which and allows the client to select 
     </section> <!-- end of id="links-serialization-json"-->
 
     <section id="security-serialization-json">
-    <h2>security</h2>
+    <h2><code>security</code></h2>
 
     <p><span class="rfc2119-assertion" id="td-security">
-    Each mandatory and optional vocabulary term, 
+    Each mandatory and optional vocabulary term
     as defined in the class 
-    <a href="#security" class="sec-ref">SecurityScheme</a>, 
+    <a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>,
     MUST be serialized as a JSON key.
     </span></p>
 
     <p>
-    The following TD snippet example shows a simple security configuration specifying
+    The following TD snippet shows a simple security configuration specifying
     basic username/password authentication in the header.
     The value of <code>in</code> given is actually the default value of
     <code>header</code>.
@@ -990,7 +1005,7 @@ The rel attribute indicates which form is which and allows the client to select 
     <p>
     Security definitions can be given at more than one level.
     In this case, definitions at the lower levels override (completely replace)
-    the definitions at the higher level.  
+    the definitions at the higher level.
     </p>
 
     <p>
@@ -1034,9 +1049,8 @@ The rel attribute indicates which form is which and allows the client to select 
     </p>
 <pre class="example">
 {
-    "name": "MyThing",
     "id": "urn:dev:wot:com:example:servient:myThing",
-    "base": "https://servient.example.com/",
+    "name": "MyThing",
     "description": "Additional (human) readable information of the Thing.",
     "support": "https://servient.example.com/contact",
     "security": [{"scheme": "nosec"}],
@@ -1056,7 +1070,7 @@ The rel attribute indicates which form is which and allows the client to select 
     the security configuration in the <code>overheating</code> event 
     to indicate no authentication is required.  
     For the <code>status</code> property and the <code>toggle</code>
-    action, however, <code>basic</code> authentication is required, as defined
+    action, however, <code>basic</code> authentication is required as defined
     at the top level of the Thing.
     </p>
 <pre class="example">
@@ -1149,6 +1163,11 @@ The rel attribute indicates which form is which and allows the client to select 
   the media type <code>application/td+json</code>.
   </p>
 
+  <p class="ednote" title="CoAP Content Format">
+  CoAP-based WoT implementations can use the experimental Content-Format
+  <code>65100</code> until a proper identifier has been registered.
+  </p>
+
   <p><span class="rfc2119-assertion" id="td-media-type">
   The media type <code>application/td+json</code>
   MUST be also associated with the JSON-LD context 
@@ -1159,9 +1178,9 @@ The rel attribute indicates which form is which and allows the client to select 
   that may omit the <code>@context</code> key term.
   </p>
 
-  <p class="ednote" title="Media Type">
-  The <code>application/td+json</code> media type has not registered  
-  with IANA yet.
+  <p class="ednote" title="IANA Considerations">
+  Neither the <code>application/td+json</code> media type nor
+  a CoAP Content-Format identifier have been registered with IANA yet.
   </p>
 
   </section>
@@ -1179,15 +1198,14 @@ The rel attribute indicates which form is which and allows the client to select 
   <p><span class="rfc2119-assertion" id="td-writable-observable-default">
   If the key terms <code>writable</code> and/or <code>observable</code> 
   are not present within a <code>properties</code> definition,
-  the default value defined in 
-  the <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> 
+  the default value defined in <a href="#sec-vocabulary-definition"></a>
   MUST be assumed.
   </span></p>
   
   <p><span class="rfc2119-assertion" id="td-media-type-default">
   If the <code>mediaType</code> key term is not present within a 
-  <code>forms</code> definition, the default value as defined in the
-  <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> 
+  <code>forms</code> definition, the default value as defined in
+  <a href="#sec-vocabulary-definition"></a>
   MUST be assumed.   
   </span></p>
 
@@ -1207,7 +1225,7 @@ The rel attribute indicates which form is which and allows the client to select 
   in terms of RDF triples, 
   a Thing Description instance first requires a valid JSON-LD 1.1 
   representation based on this Thing Description specification. 
-  Then this representation can be passed to a JSON-LD 1.1 interpreter.
+  Then this representation can be passed to a JSON-LD 1.1 processor.
   </p>
 
   <p><!-- The following is not marked as a testable assertion because it 
@@ -1216,24 +1234,25 @@ The rel attribute indicates which form is which and allows the client to select 
           independently as referring to preprocessing.
           This is why "must" is in lower case.  -->
   The following pre-processing steps of a Thing Description instance 
-  must be executed before starting JSON-LD 1.1 based processing:
+  must be executed before starting JSON-LD 1.1 processing:
   <ul>
   <li><span class="rfc2119-assertion" id="td-jsonld-preprocessing-context">
      Before starting JSON-LD 1.1 processing of a Thing Description instance,
      there MUST be a <code>@context</code> key from JSON-LD 1.1 as defined 
      in Section 
-     <a href="#sec-thing-as-a-whole-json" class="sec-ref">Thing as a whole</a>.
+     <a href="#sec-thing-as-a-whole-json"></a>.
   </span></li>
   <li><span class="rfc2119-assertion" id="td-jsonld-preprocessing-prefix">
      Before starting JSON-LD 1.1 processing of a Thing Description instance,
      all external vocabulary terms used in the Thing Description MUST 
-     provide their context URIs as prefix or within the <code>@context</code>.
+     provide their context URIs as prefix or within the <code>@context</code>
+     field.
   </span></li>
   <li><span class="rfc2119-assertion" id="td-jsonld-preprocessing-defaults">
      Before starting JSON-LD 1.1 processing of a Thing Description instance,
-     all vocabulary terms that have a default value as defined in the 
-     <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> Section
-     MUST be present at least with their default value.
+     all mandatory vocabulary terms as defined in Section
+     <a href="#sec-vocabulary-definition"></a> that are missing from the instance
+     MUST be inserted explicitly with their default value.
   </span></li>
   </ul>
   </p>
@@ -1244,16 +1263,15 @@ The rel attribute indicates which form is which and allows the client to select 
        So I have redirected this to examples 1 and 2.
   -->
   <p>
-  The 
-  <a href="#introduction">Introduction</a>  
-  Section shows an example of how the input and output of such
+  Section <a href="#introduction"></a>
+  shows an example of how the input and output of such
   preprocessing would appear.
   </p>
 
   </section>
   </section>
 
-  </section> <!-- end of id="TD-serialization-section"-->
+  </section> <!-- end of id="sec-td-serialization"-->
 
   <section id="example-serialization">
   <h2>Example Thing Description Instances</h2>
@@ -1362,7 +1380,7 @@ The rel attribute indicates which form is which and allows the client to select 
   </p>
   </section>
 
-  <section   id="json-schema-4-validation" class="appendix normative">
+  <section id="json-schema-4-validation" class="appendix normative">
   <h1>JSON Schema for TD Instance Validation</h1>
 
 <pre class="advisement">
@@ -1782,7 +1800,7 @@ The rel attribute indicates which form is which and allows the client to select 
 
   </section>
 
-  <section   id="acknowledgements" class="appendix normative">
+  <section id="acknowledgements" class="appendix normative">
   <h1>Acknowledgements</h1>
   <p>tbd</p>
   </section>

--- a/index.html.template.html
+++ b/index.html.template.html
@@ -134,10 +134,9 @@
   Thing Descriptions provide a set of interactions based on a small vocabulary 
   that makes it possible both to integrate diverse devices and 
   to allow diverse applications to interoperate. 
-  Thing Descriptions, by default, are encoded in JSON-LD. 
-  JSON-LD provides both a powerful foundation to represent knowledge 
-  about Things and simplicity, 
-  since it allows processing as a JSON document. 
+  Thing Descriptions, by default, are encoded in a JSON format that also allows
+  JSON-LD processing. The latter provides a powerful foundation to represent
+  knowledge about Things in a machine-understandable way.
   A Thing Description instance can be hosted by the Thing itself or hosted 
   externally when a Thing has resource restrictions (e.g., limited memory space) 
   or when a Web of Things-compatible legacy device is retrofitted 
@@ -170,9 +169,9 @@
   <section id="introduction">
   <h1>Introduction</h1>
   <p>
-  The W3C Thing Description (TD) is a central building block in a Web of Things 
-  (WoT) enabled system and can be considered as the entry point of a Thing 
-  (much like the <i>index.html</i> of a web site). 
+  The Thing Description (TD) is a central building block in the W3C Web of
+  Things (WoT) and can be considered as the entry point of a Thing
+  (much like the <i>index.html</i> of a Web site).
   The TD consists of semantic metadata for the Thing itself,
   an interaction model based on WoT's <code>Properties</code>,
   <code>Actions</code>, and <code>Events</code> paradigm, 
@@ -180,26 +179,23 @@
   and features for Web Linking to express relations among Things. 
   </p>
   <p>
-  Properties can be used for controlling (or retrieving) parameters, 
-  such as a setting an operation state (or getting the current value). 
-  Actions model invocation of physical processes, 
+  Properties can be used for sensing and controlling parameters,
+  such as getting the current value or setting an operation state.
+  Actions model invocation of physical (and hence time-consuming) processes,
   but can also be used to abstract RPC-like calls of existing platforms. 
-  Events are used for interactions that use the push model of
-  communication where state change notifications, 
-  discrete events, 
-  and streams of values are sent asynchronously to the receiver. 
+  Events are used for the push model of communication where notifications,
+  discrete events, or streams of values are sent asynchronously to the receiver.
   In general, the TD provides metadata for different communication bindings 
-  (e.g., HTTP, CoAP, MQTT, etc.), 
-  mediaTypes (e.g., "application/json", "application/xml", "application/cbor", 
-  "application/exi" etc.), 
-  and security mechanisms (for authentication, authorization, 
-  confidentiality, etc.). 
+  identified by URI schemes (e.g., "http", "coap", "mqtt", etc.),
+  media types (e.g., "application/json", "application/xml", "application/cbor",
+  "application/exi" etc.), and security mechanisms (for authentication,
+  authorization, confidentiality, etc.).
   Serialization of TD instances is based on JSON and includes at least 
   the TD core vocabulary as JSON keys as defined in this specification document.
   </p>
   <p>
-  Example 1 shows a simple TD instance in such a JSON serializiation that 
-  reflects WoT's <code>Properties</code>, <code>Actions</code>, 
+  Example 1 shows a simple TD instance in such a JSON serializiation and
+  depicts WoT's <code>Properties</code>, <code>Actions</code>,
   and <code>Events</code> paradigm 
   by describing a lamp Thing with the name <i>MyLampThing</i>.
   </p>
@@ -223,7 +219,10 @@
     "events":{
         "overheating":{
             "type": "string",
-            "forms": [{"href": "https://mylamp.example.com/oh"}]
+            "forms": [{
+                "href": "https://mylamp.example.com/oh",
+                "subProtocol": "LongPoll"
+            }]
         }
     }
 }
@@ -238,26 +237,21 @@
   at the URI <code>https://mylamp.example.com/status</code> 
   (announced within the <code>forms</code> structure by the 
   <code>href</code> key), and will return a string status value.
-  The use of the GET method is not stated explicitly but is 
-  the default assumption made by the W3C WoT 
-  protocol template deliverable [[!WOT-PROTOCOL-BINDING]].
+  The use of the GET method is not stated explicitly, 
+  but is one of the default assumptions defined by this document.
   </p>
   <p>
-  In a similar manner an <code>Action</code> is specified to toggle the 
+  In a similar manner, an <code>Action</code> is specified to toggle the
   switch status using the POST method applied to the 
-  <code>https://mylamp.example.com/toggle</code> resource 
-  (see again the HTTP protocol binding description in the W3C WoT protocol 
-  template deliverable [[!WOT-PROTOCOL-BINDING]]).
+  <code>https://mylamp.example.com/toggle</code> resource,
+  where POST is again a default assumption for invoking Actions.
   </p>
   <p>
-  The WoT's <code>Event</code> model enables a mechanism for events to be 
-  notified by a Thing. 
+  The <code>Event</code> pattern enables a mechanism for asynchronous messages
+  to be sent by a Thing.
   Here, a subscription to be notified upon a possible overheating event 
-  of the lamp can be obtained by using the default event-handling mechanism 
-  defined in the protocol binding for HTTP at 
-  <code>https://mylamp.example.com/oh</code> 
-  (see again the HTTP protocol binding description in the W3C WoT protocol 
-  template deliverable [[!WOT-PROTOCOL-BINDING]]).
+  of the lamp can be obtained by using the HTTP with its long polling
+  sub-protocol at <code>https://mylamp.example.com/oh</code>.
   </p>
   <p>
   This example also specifies the <code>basic</code> security scheme, 
@@ -287,12 +281,17 @@
   the Thing Description processor follows default assumptions for 
   interpretation as defined in this specification.
   </p>
+  <p class="ednote">
+  As default values are primarily reducing the size of TDs and IoT systems using
+  JSON usually have less resource constraints, a more sensible
+  default for <code>mediaType</code> might be "application/cbor".
+  </p>
   <p>
   The TD can be also processed as an RDF-based model. 
-  In that case, the Thing Description instance can be transformed 
+  In that case, the Thing Description instance needs to be transformed
   into valid JSON-LD first.  
   In terms of JSON-LD 1.1 serialization, 
-  RDF semantic processing's open-world assumption requires vocabulary terms 
+  the open-world assumption of RDF semantic processing requires vocabulary terms
   with default values to be always present explicitly in the instances. 
   Example 2 shows the same TD in a JSON-LD 1.1 serializiation representing
   exactly the same information as in Example 1; however, default values
@@ -312,6 +311,7 @@
             "type": "string",
             "forms": [{
                 "href": "https://mylamp.example.com/status",
+                "http:methodName": "GET",
                 "mediaType": "application/json"
             }]
         }
@@ -320,6 +320,7 @@
         "toggle": {
             "forms": [{
                 "href": "https://mylamp.example.com/toggle",
+                "http:methodName": "POST",
                 "mediaType": "application/json"
             }]
         }
@@ -329,6 +330,7 @@
             "type": "string",
             "forms": [{
                 "href": "https://mylamp.example.com/oh",
+                "subProtocol": "LongPoll",
                 "mediaType": "application/json"
             }]
         }
@@ -337,7 +339,7 @@
  </pre>
   <p>
   For more examples, including the use of other protocols besides HTTP,
-  see <a href="#example-serialization" class="sec-ref">Section 7.</a>
+  see Section <a href="#example-serialization"></a>.
   </p>
   </section>
 
@@ -398,17 +400,14 @@
   <p>
   A Thing Description instance complies with this specification if it follows 
   the normative statements in Section 
-  <a href="#vocabularyDefinitionSection" class="sec-ref"><span class="secno">5.</span> 
-  <span class="sec-title">Vocabulary Definition</span></a> 
+  <a href="#sec-vocabulary-definition"></a>
   and Section 
-  <a href="#TD-serialization-section" class="sec-ref"><span class="secno">6.</span> 
-  <span class="sec-title">Thing Description Serializations</span></a> 
+  <a href="#sec-td-serialization"></a> 
   regarding Thing Description serialization.
   </p>
   <p>
   A JSON Schema is provided in Annex 
-  <a href="#json-schema-4-validation" class="sec-ref"><span class="secno">A</span> 
-  <span class="sec-title">JSON Schema for TD Instance Validation</span></a> 
+  <a href="#json-schema-4-validation"></a> 
   to validate Thing Description instances based on JSON-LD 1.1.
   </p>
 
@@ -424,45 +423,46 @@
 
 
 
-  <section id="TD-serialization-section">
-  <h1 >Thing Description Serialization</h1>
+  <section id="sec-td-serialization">
+  <h1>Thing Description Serialization</h1>
 
-  <p class="ednote" title="JSON-LD 1.1 ">
+  <p class="ednote" title="JSON-LD 1.1">
   This is the first draft that uses JSON-LD 1.1 as a serialization format 
   of the Thing Description. 
-  As this is a work in progress, working assumptions are based on the latest
+  As that is work in progress, working assumptions are based on the latest
   <a href="https://json-ld.org/spec/latest/json-ld/#">Community Draft of JSON-LD 1.1</a>. 
-  There is a plan to set up a JSON-LD Working Group with the following 
-  <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">JSON-LD Working Group Charter</a>. 
+  A new JSON-LD Working Group has already been
+  <a href="https://www.w3.org/2018/03/jsonld-wg-charter.html">chartered</a>.
   It is planned that this section will conform to the latest working draft 
-  of JSON-LD 1.1.
+  of their JSON-LD 1.1 deliverable and only use stable elements.
   </p>
 
   <p>
-  Thing Description instances are modeled and structured based on the 
-  <a href="#vocabularyDefinitionSection" class="sec-ref">Thing Description Information Model</a>. 
-  This section proposes a TD serialization based on JSON-LD 1.1. 
+  Thing Description instances are modeled and structured based on Section
+  <a href="#sec-vocabulary-definition"></a>.
+  This section defines a TD serialization based on JSON [[!RFC8259]].
   </p>
 
   <section id="json-serializiation-section">
   <h1>Representation Format</h1>
 
   <p>
-  This section introduces the JSON-based serialization of the Thing Description. 
-  This serialization also follows the syntax of JSON-LD 1.1 
-  in order to streamline the semantic evaluation of TDs.
+  The JSON serialization of TDs follows the syntax of JSON-LD 1.1
+  in order to streamline semantic evaluation.
+  Hence, serializations can be parsed either as raw JSON or with a JSON-LD 1.1
+  processor.
   </p>
 
   <p>
   In order to enable this convergence,
-  all vocabulary terms defined in 
-  <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> 
+  all vocabulary terms defined in Section
+  <a href="#sec-vocabulary-definition"></a>
   will have a JSON key representation.
   </p>
   <p>
   In addition,
   <span class="rfc2119-assertion" id="td-string-type">
-  Thing Description instances MAY contain JSON-LD 1.1 keys such as 
+  Thing Description instances MAY contain JSON-LD 1.1 keywords such as
   <code>@context</code> and <code>@type</code>.</span>
   </p>
 
@@ -472,8 +472,8 @@
   within the key name (e.g., "http:header").</p>-->
 
   <p>
-  The defined types of the vocabulary as defined in 
-  <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> 
+  The data types of the vocabulary as defined in Section
+  <a href="#sec-data-schema-vocabulary-definition"></a>
   will be transformed to JSON-based types. 
   The following rules are used for vocabulary terms based on some simple type 
   definitions:
@@ -494,8 +494,8 @@
   </ul>
 
   <p>
-  All vocabulary terms in the
-  <a href="#sec-vocabulary-definitions" class="sec-ref">Vocabulary Definitions</a> Section 
+  All vocabulary terms in Section
+  <a href="#sec-vocabulary-definition"></a>
   associated with more complex class-based types are defined separately for 
   structured JSON type transformation in the following subsections.
   </p>
@@ -504,7 +504,7 @@
   <h2>Thing as a whole</h2>
 
   <p><span class="rfc2119-assertion" id="td-context">
-  The first line of a Thing Description instance MAY include the 
+  The root object of a Thing Description instance MAY include the
   <code>@context</code> key from JSON-LD 1.1 with the value URI of 
   the Thing description context file <code>http://www.w3.org/ns/td</code>.
   </span></p>
@@ -516,9 +516,15 @@
 }
 </pre>
 
+  <p class="ednote">
+  <code>http://www.w3.org/ns/td</code> uses content negotiation to return the
+  context file. Thus, it must be fetched with an <code>Accept</code> header set
+  to <code>application/ld+json</code>.
+  </p>
+
   <p><span class="rfc2119-assertion" id="td-context-jsonld">
-  When a Thing Description instance is processed and interpreted by a 
-  JSON-LD 1.1 processor the <code>@context</code> with its value 
+  When a Thing Description instance is processed and interpreted by a
+  JSON-LD 1.1 processor the <code>@context</code> field
   MUST be present</span> 
   (see also Section <a href="#note-jsonld-processing" class="sec-ref">JSON-LD 1.1 Processing</a>). 
   </p>
@@ -533,32 +539,32 @@
 <pre class="example">
 {
     "@context": ["http://www.w3.org/ns/td",
-                {"sensor": "http://iotschema.org/"}],
+                {"iot": "http://iotschema.org/"}],
     ...
 }
 </pre>
 
   <p><span class="rfc2119-assertion" id="td-context-toplevel">
-  Each mandatory and optional vocabulary, 
-  as defined in the class <a href="#thing" class="sec-ref">Thing</a>, 
+  Each mandatory and optional field name
+  as defined in the class <a href="#thing" class="sec-ref"><code>Thing</code></a>
   MUST be serialized as a JSON key 
-  at the top level of the Thing Description instance.
+  in the root object of the Thing Description instance.
   </span></p>
 
   <!-- should this be "the type" or "the elements of"? -->
   <p><span class="rfc2119-assertion" id="td-objects">
   The type of the fields <code>properties</code>, <code>actions</code>, 
-  and <code>events</code> MUST be serialized as a JSON object.
+  and <code>events</code> MUST be a JSON object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-arrays">
-  The type of the field <code>links</code> and <code>security</code> 
-  MUST be serialized as a JSON array.
+  The type of the fields <code>links</code> and <code>security</code>
+  MUST be a JSON array.
   </span></p>
 
   <p>
-  An example of a TD snippet based on the defined fields of the 
-  <a href="#thing" class="sec-ref">Thing</a> information model 
+  A TD snippet based on the defined fields of the class
+  <a href="#thing" class="sec-ref"><code>Thing</code></a>
   without the optional field <code>@context</code> is given below:
   </p>
 <pre class="example">
@@ -600,21 +606,21 @@
  </section> <!-- end of id="sec-thing-as-a-whole-json"-->
 
  <section id="property-serialization-json">
- <h2>properties</h2>
+ <h2><code>properties</code></h2>
   
   <p><span class="rfc2119-assertion" id="td-properties">
-  Properties (and sub-properties) offered by a Thing MUST be collected 
-  in the JSON object-based <code>properties</code> field 
-  of (unique) Property names as JSON keys.
+  Properties (and sub-properties) offered by a Thing MUST be collected
+  in the JSON-object based <code>properties</code> field
+  with (unique) Property names as JSON keys.
   </span></p>
 
   <span class="rfc2119-assertion" id="td-property-keys">
-  Each mandatory and optional vocabulary, 
-  as defined in the class <a href="#property" class="sec-ref">Property</a>, 
-  its two superclasses 
-  <a href="#interactionPattern" class="sec-ref">InteractionPattern</a> 
-  and <a href="#dataschema" class="sec-ref">DataSchema</a>, 
-  MUST be serialized as a JSON key within a Property field.
+  Each mandatory and optional vocabulary term
+  as defined in the class <a href="#property" class="sec-ref"><code>Property</code></a>,
+  as well as its two superclasses
+  <a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
+  and <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
+  MUST be serialized as a JSON key within a Property object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-property-objects">
@@ -624,11 +630,12 @@
 
   <p><span class="rfc2119-assertion" id="td-property-arrays">
   The type of the fields <code>forms</code>, <code>required</code>, 
-  and <code>enum</code> MUST be serialized as a JSON array.
+  and <code>enum</code>, and potentially <code>security</code>,
+  MUST be serialized as a JSON array.
   </span></p>
 
   <p>
-  An example of a TD snippet based on the defined fields is given below:
+  A TD snippet based on the defined fields is given below:
   </p>
 <pre class="example">
 {
@@ -657,7 +664,7 @@
                     "maxItems": 3
                 }
             },
-            "required": ["brightness","rgb"],
+            "required": ["brightness", "rgb"],
             "forms": [...]
         }
     }
@@ -666,29 +673,30 @@
 </pre>
 
   <p><span class="rfc2119-assertion" id="td-property-semantic">
-  Similar to case at the <code>Thing</code> level,
+  Similar to the case at the <code>Thing</code> level,
   properties MAY have additional semantic annotations based on 
-  JSON-LD 1.1 keys.
+  JSON-LD 1.1 keywords.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-property-defaults">
   When a Thing Description instance is processed and interpreted by 
   a JSON-LD 1.1 processor, 
   each <code>property</code> MUST contain the vocabulary terms 
-  <code>observable</code> and <code>writable</code> due to the linked data's 
-  <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>.
+  <code>observable</code> and <code>writable</code> due to the 
+  <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>
+  of Linked Data.
   </span>
-  This assumption means that if a Thing Description instance 
-  were to omit these vocabulary terms, 
+  This assumption means that if a Linked Data model of a Thing Description
+  instance were to omit these vocabulary terms,
   then the interpreter would not be able to make any assumptions
   about their actual value. 
   </p>
 
   <p>
-  An example of a JSON-LD 1.1 serialization of a TD snippet 
-  including semantic annotations and the 
+  A snippet of a JSON-LD 1.1 processable TD serialization including
+  semantic annotations and the
   default values of <code>observable</code> and <code>writable</code> 
-  based on class <a href="#property" class="sec-ref">Property</a> definition
+  based on the class <a href="#property" class="sec-ref"><code>Property</code></a>
   is given as follows:
   </p>
 <pre class="example">
@@ -732,39 +740,43 @@
     ...
 </pre>
 
-    </section> <!-- end of id="property-serialization-json"-->
+  </section> <!-- end of id="property-serialization-json"-->
 
-    <section id="action-serialization-json">
-    <h2>actions</h2>
+  <section id="action-serialization-json">
+  <h2><code>actions</code></h2>
 
-    <p>
-    Actions offered by a Thing are collected in the JSON object-based 
-    <code>actions</code> field of (unique) Action names as JSON keys. 
-    <span class="rfc2119-assertion" id="td-actions">
-    Each optional vocabulary term,
-    as defined in the class <a href="#action" class="sec-ref">Action</a> 
-    and its superclass 
-    <a href="#interactionPattern" class="sec-ref">InteractionPattern</a>,
-    MUST be serialized as a JSON key within a Action field.
-    </span></p>
+  <p><span class="rfc2119-assertion" id="td-actions">
+  Actions offered by a Thing MUST be collected
+  in the JSON-object based <code>actions</code> field
+  with (unique) Action names as JSON keys.
+  </span></p>
 
-    <p><span class="rfc2119-assertion" id="td-action-objects">
-    The type of the fields <code>input</code> and <code>output</code> 
-    MUST be serialized as a JSON object.
-    </span></p>
+  <span class="rfc2119-assertion" id="td-action-keys">
+  Each optional vocabulary term
+  as defined in the class <a href="#action" class="sec-ref"><code>Action</code></a>
+  and its superclass
+  <a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
+  MUST be serialized as a JSON key within an Action object.
+  </span></p>
 
-    <p>The member keys of <code>input</code> and <code>output</code> 
-    rely on the the class <a href="#property" class="sec-ref">Property</a>.
-    </p>
+  <p><span class="rfc2119-assertion" id="td-action-objects">
+  The type of the fields <code>input</code> and <code>output</code>
+  MUST be serialized as a JSON object.
+  </span></p>
 
-    <p><span class="rfc2119-assertion" id="td-action-arrays">
-    The type of the field <code>forms</code> 
-    MUST be serialized as a JSON array.
-    </span></p>
+  <p>The keys of <code>input</code> and <code>output</code>
+  rely on the the class <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>.
+  </p>
 
-    <p>An example of a TD snippet based on the defined fields is 
-    given below:
-    </p>
+  <p><span class="rfc2119-assertion" id="td-action-arrays">
+  The type of the field <code>forms</code>,
+  and potentially <code>security</code>,
+  MUST be serialized as a JSON array.
+  </span></p>
+
+  <p>
+  A TD snippet based on the defined fields is given below:
+  </p>
 
 <pre class="example">
     ...
@@ -798,26 +810,28 @@
 </pre>
 
   <p><span class="rfc2119-assertion" id="td-action-semantic">
-  Definitions within the  <code>actions</code> level 
-  MAY have also additional semantic annotations based on JSON-LD 1.1 keys.
+  Definitions within the <code>actions</code> field
+  MAY have additional semantic annotations based on JSON-LD 1.1 keywords.
   </span></p>
 
   </section> <!-- end of id="action-serialization-json"-->
 
   <section id="event-serialization-json">
-  <h2>events</h2>
+  <h2><code>events</code></h2>
 
-  <p>
-  Events (and sub-events) offered by a Thing are collected in the JSON 
-  object-based <code>events</code> field with (unique) Event names as 
-  JSON keys.
-  <span class="rfc2119-assertion" id="td-events">
-  Each optional vocabulary term, 
-  as defined in the class <a href="#event" class="sec-ref">Event</a>, 
-  as well as its two superclasses 
-  <a href="#interactionPattern" class="sec-ref">InteractionPattern</a> 
-  and <a href="#dataschema" class="sec-ref">DataSchema</a>, 
-  MUST be serialized as a JSON key within a Event field.
+  <p><span class="rfc2119-assertion" id="td-events">
+  Events offered by a Thing MUST be collected
+  in the JSON-object based <code>events</code> field
+  with (unique) Event names as JSON keys.
+  </span></p>
+
+  <span class="rfc2119-assertion" id="td-event-keys">
+  Each optional vocabulary term
+  as defined in the class <a href="#event" class="sec-ref"><code>Event</code></a>,
+  as well as its two superclasses
+  <a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
+  and <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
+  MUST be serialized as a JSON key within an Event object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-event-objects">
@@ -827,11 +841,12 @@
 
   <p><span class="rfc2119-assertion" id="td-event-arrays">
   The type of the fields <code>forms</code>, <code>required</code>, 
-  and <code>enum</code> MUST be serialized as a JSON array.
+  and <code>enum</code>, and potentially <code>security</code>,
+  MUST be serialized as a JSON array.
   </span></p>
 
   <p>
-  An example of a TD snippet based on the defined fields is given below:
+  A TD snippet based on the defined fields is given below:
   </p>
 <pre class="example">
     ...
@@ -848,20 +863,19 @@
     ...
 </pre>
 
-  <p><span class="rfc2119-assertion" id="td-action-semantic">
-  Definitions within the  <code>events</code> level 
-  MAY have also additional semantic anotations 
-  based on JSON-LD 1.1 keys.
+  <p><span class="rfc2119-assertion" id="td-event-semantic">
+  Definitions within the <code>events</code> field
+  MAY have additional semantic anotations based on JSON-LD 1.1 keywords.
   </span></p>
 
   </section> <!-- end of id="event-serialization-json"-->
 
   <section id="form-serialization-json">
-  <h2>forms</h2>
+  <h2><code>forms</code></h2>
 
   <p><span class="rfc2119-assertion" id="td-forms">
-  Each mandatory and optional vocabulary term,
-  as defined in the class <a href="#form" class="sec-ref">Form</a>, 
+  Each mandatory and optional vocabulary term
+  as defined in the class <a href="#form" class="sec-ref"><code>Form</code></a>,
   MUST be serialized as a JSON key.
   </span></p>
 
@@ -878,16 +892,17 @@
   by a JSON-LD 1.1 processor, 
   each <code>forms</code> (array) entry 
   MUST contain a <code>mediaType</code> 
-  due to linked data's 
-  <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>.
+  due to the
+  <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>
+  of Linked Data.
   </span>
-  This assumption means that if a Thing Description instance 
-  were to omit these vocabulary terms, 
+  This assumption means that if a Linked Data model of a Thing Description
+  instance were to omit these vocabulary terms,
   then the interpreter would not be able to make any assumptions
-  about their actual value. 
+  about their actual value.
   </p>
 
-  <p>An example of a TD snippet based on the defined fields is given below:</p>
+  <p>A TD snippet based on the defined fields is given below:</p>
 <pre class="example">
     ...
     "forms": [{
@@ -895,7 +910,7 @@
         "mediaType": "application/json",
         "http:methodName": "POST",
         "rel": "writeProperty",
-        "security": [{"scheme":"basic","in":"header"}]
+        "security": [{"scheme":"basic", "in":"header"}]
     }]
     ...
 </pre>
@@ -903,22 +918,22 @@
     </section> <!-- end of id="form-serialization-json"-->
 
     <section id="links-serialization-json">
-    <h2>links</h2>
+    <h2><code>links</code></h2>
 
     <p><span class="rfc2119-assertion" id="td-links">
-    Each mandatory and optional vocabulary term, 
-    as defined in the class <a href="#link" class="sec-ref">Link</a>, 
+    Each mandatory and optional vocabulary term
+    as defined in the class <a href="#link" class="sec-ref"><code>Link</code></a>,
     MUST be serialized as a JSON key.
     </span></p>
 
-    <p>An example of a TD snippet based on the defined fields is given below:</p>
+    <p>A TD snippet based on the defined fields is given below:</p>
 
 <pre class="example">
     ...
     "links": [{
         "href": "https://servient.example.com/things/lampController",
         "rel": "controlledBy",
-        "mediaType": "application/td"
+        "mediaType": "application/td+json"
     }]
     ...
 </pre>
@@ -926,17 +941,17 @@
     </section> <!-- end of id="links-serialization-json"-->
 
     <section id="security-serialization-json">
-    <h2>security</h2>
+    <h2><code>security</code></h2>
 
     <p><span class="rfc2119-assertion" id="td-security">
-    Each mandatory and optional vocabulary term, 
+    Each mandatory and optional vocabulary term
     as defined in the class 
-    <a href="#security" class="sec-ref">SecurityScheme</a>, 
+    <a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>,
     MUST be serialized as a JSON key.
     </span></p>
 
     <p>
-    The following TD snippet example shows a simple security configuration specifying
+    The following TD snippet shows a simple security configuration specifying
     basic username/password authentication in the header.
     The value of <code>in</code> given is actually the default value of
     <code>header</code>.
@@ -978,7 +993,7 @@
     <p>
     Security definitions can be given at more than one level.
     In this case, definitions at the lower levels override (completely replace)
-    the definitions at the higher level.  
+    the definitions at the higher level.
     </p>
 
     <p>
@@ -1022,9 +1037,8 @@
     </p>
 <pre class="example">
 {
-    "name": "MyThing",
     "id": "urn:dev:wot:com:example:servient:myThing",
-    "base": "https://servient.example.com/",
+    "name": "MyThing",
     "description": "Additional (human) readable information of the Thing.",
     "support": "https://servient.example.com/contact",
     "security": [{"scheme": "nosec"}],
@@ -1044,7 +1058,7 @@
     the security configuration in the <code>overheating</code> event 
     to indicate no authentication is required.  
     For the <code>status</code> property and the <code>toggle</code>
-    action, however, <code>basic</code> authentication is required, as defined
+    action, however, <code>basic</code> authentication is required as defined
     at the top level of the Thing.
     </p>
 <pre class="example">
@@ -1137,6 +1151,11 @@
   the media type <code>application/td+json</code>.
   </p>
 
+  <p class="ednote" title="CoAP Content Format">
+  CoAP-based WoT implementations can use the experimental Content-Format
+  <code>65100</code> until a proper identifier has been registered.
+  </p>
+
   <p><span class="rfc2119-assertion" id="td-media-type">
   The media type <code>application/td+json</code>
   MUST be also associated with the JSON-LD context 
@@ -1147,9 +1166,9 @@
   that may omit the <code>@context</code> key term.
   </p>
 
-  <p class="ednote" title="Media Type">
-  The <code>application/td+json</code> media type has not registered  
-  with IANA yet.
+  <p class="ednote" title="IANA Considerations">
+  Neither the <code>application/td+json</code> media type nor
+  a CoAP Content-Format identifier have been registered with IANA yet.
   </p>
 
   </section>
@@ -1167,15 +1186,14 @@
   <p><span class="rfc2119-assertion" id="td-writable-observable-default">
   If the key terms <code>writable</code> and/or <code>observable</code> 
   are not present within a <code>properties</code> definition,
-  the default value defined in 
-  the <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> 
+  the default value defined in <a href="#sec-vocabulary-definition"></a>
   MUST be assumed.
   </span></p>
   
   <p><span class="rfc2119-assertion" id="td-media-type-default">
   If the <code>mediaType</code> key term is not present within a 
-  <code>forms</code> definition, the default value as defined in the
-  <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> 
+  <code>forms</code> definition, the default value as defined in
+  <a href="#sec-vocabulary-definition"></a>
   MUST be assumed.   
   </span></p>
 
@@ -1195,7 +1213,7 @@
   in terms of RDF triples, 
   a Thing Description instance first requires a valid JSON-LD 1.1 
   representation based on this Thing Description specification. 
-  Then this representation can be passed to a JSON-LD 1.1 interpreter.
+  Then this representation can be passed to a JSON-LD 1.1 processor.
   </p>
 
   <p><!-- The following is not marked as a testable assertion because it 
@@ -1204,24 +1222,25 @@
           independently as referring to preprocessing.
           This is why "must" is in lower case.  -->
   The following pre-processing steps of a Thing Description instance 
-  must be executed before starting JSON-LD 1.1 based processing:
+  must be executed before starting JSON-LD 1.1 processing:
   <ul>
   <li><span class="rfc2119-assertion" id="td-jsonld-preprocessing-context">
      Before starting JSON-LD 1.1 processing of a Thing Description instance,
      there MUST be a <code>@context</code> key from JSON-LD 1.1 as defined 
      in Section 
-     <a href="#sec-thing-as-a-whole-json" class="sec-ref">Thing as a whole</a>.
+     <a href="#sec-thing-as-a-whole-json"></a>.
   </span></li>
   <li><span class="rfc2119-assertion" id="td-jsonld-preprocessing-prefix">
      Before starting JSON-LD 1.1 processing of a Thing Description instance,
      all external vocabulary terms used in the Thing Description MUST 
-     provide their context URIs as prefix or within the <code>@context</code>.
+     provide their context URIs as prefix or within the <code>@context</code>
+     field.
   </span></li>
   <li><span class="rfc2119-assertion" id="td-jsonld-preprocessing-defaults">
      Before starting JSON-LD 1.1 processing of a Thing Description instance,
-     all vocabulary terms that have a default value as defined in the 
-     <a href="#vocabularyDefinitionSection">Vocabulary Definition</a> Section
-     MUST be present at least with their default value.
+     all mandatory vocabulary terms as defined in Section
+     <a href="#sec-vocabulary-definition"></a> that are missing from the instance
+     MUST be inserted explicitly with their default value.
   </span></li>
   </ul>
   </p>
@@ -1232,16 +1251,15 @@
        So I have redirected this to examples 1 and 2.
   -->
   <p>
-  The 
-  <a href="#introduction">Introduction</a>  
-  Section shows an example of how the input and output of such
+  Section <a href="#introduction"></a>
+  shows an example of how the input and output of such
   preprocessing would appear.
   </p>
 
   </section>
   </section>
 
-  </section> <!-- end of id="TD-serialization-section"-->
+  </section> <!-- end of id="sec-td-serialization"-->
 
   <section id="example-serialization">
   <h2>Example Thing Description Instances</h2>
@@ -1350,7 +1368,7 @@
   </p>
   </section>
 
-  <section   id="json-schema-4-validation" class="appendix normative">
+  <section id="json-schema-4-validation" class="appendix normative">
   <h1>JSON Schema for TD Instance Validation</h1>
 
 <pre class="advisement">
@@ -1405,7 +1423,7 @@
 
   </section>
 
-  <section   id="acknowledgements" class="appendix normative">
+  <section id="acknowledgements" class="appendix normative">
   <h1>Acknowledgements</h1>
   <p>tbd</p>
   </section>

--- a/vocabulary.template
+++ b/vocabulary.template
@@ -1,4 +1,4 @@
-<section id="vocabularyDefinitionSection">
+<section id="sec-vocabulary-definition">
 <h1>Information Model</h1>
 <!-- h1>Vocabulary</h1 -->
 
@@ -34,10 +34,10 @@
   Please note that the figures reflect the vocabulary terms and structure 
   as they would be used in a Thing Description 
   instance 
-  (see see <a href="#TD-serialization-section" class="sec-ref"><span class="secno">6.</span> <span class="sec-title">Thing Description Serialization</span></a>). 
+  (see Section <a href="#sec-td-serialization"></a>).
   The full ontology definitions of the different modules 
   can be viewed by following the namespaces as provided in Section 
-  <a href="#namespaces" class="sec-ref"><span class="secno">3.</span> <span class="sec-title">Namespaces</span></a>.
+  <a href="#namespaces"></a>.
   </p>
   <!--<p><a href="http://visualdataweb.de/webvowl/#iri=https://rawgit.com/w3c/wot-thing-description/TD-JSON-LD-1.1/ontology/td.ttl">Click here for the visualization</a></p>-->
  


### PR DESCRIPTION
* Clarified default values (not from informational WoT Binding Templates)
* Fixed Eample 1 (Event over HTTP needs `subProtocol`)
* Fixed Action and Event assertions on "collecting" in respective fields (`actions`, `events`)
* Added experimental CoAP Content-Format (65100)
* Added reference to JSON (RFC8259)
* Improved wording on JSON terms
* Clarified serialization is JSON that allows JSON-LD processing
* Changed JSON-LD "keys" to "keywords" (correct wording from JSON-LD spec)
* Added Editors' Note on CBOR as potential default media type
* Fixed section linking (don't give text within `<a></a>`, so that ReSpec fills it in)
* Made JSON keys to appear as `code`