### PR TITLE
test plan cleanup

### DIFF
--- a/testing/plan.html
+++ b/testing/plan.html
@@ -7,137 +7,415 @@
 	  <h2>Web of Things (WoT) Thing Description</h2>
   
 
-<dl><dt><a href="../index.html#td-vocabulary">td-vocabulary</a>: <strong>MUST</strong></dt><dd class="td-vocabulary"><span class="rfc2119-assertion" id="td-vocabulary">All vocabulary restrictions noted in these tables MUST be followed,including mandatory items and default values.</span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-unique-identifiers">td-unique-identifiers</a>: <strong>MUST</strong></dt><dd class="td-unique-identifiers"><span class="rfc2119-assertion" id="td-unique-identifiers">Each instance of a <code>Property</code>, <code>Action</code>, and <code>Event</code> class MUST have an identifier that is unique within the context of a Thing Description document.</span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-string-type">td-string-type</a>: <strong>MUST</strong></dt><dd class="td-string-type"><span class="rfc2119-assertion" id="td-string-type">
+<dl><dt><a href="../index.html#td-vocabulary">td-vocabulary</a>: <strong>MUST</strong></dt><dd class="td-vocabulary"><span class="rfc2119-assertion" id="td-vocabulary">All vocabulary restrictions noted in these tables MUST be followed,including mandatory items and default values.</span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-unique-identifiers">td-unique-identifiers</a>: <strong>MUST</strong></dt><dd class="td-unique-identifiers"><span class="rfc2119-assertion" id="td-unique-identifiers">Each instance of a <code>Property</code>, <code>Action</code>, and <code>Event</code> class MUST have an identifier that is unique within the context of a Thing Description document.</span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-jsonld-keywords">td-jsonld-keywords</a>: <strong>MAY</strong></dt><dd class="td-jsonld-keywords"><span class="rfc2119-assertion" id="td-jsonld-keywords">
+  Thing Description instances MAY contain JSON-LD 1.1 keywords such as
+  <code>@context</code> and <code>@type</code>.</span><ul><li><span class="testspec" id="td-jsonld-keywords">
+<ul>
+<li>	
+TESTED
+</li>
+<li>	
+EXAMPLE EXISTS only for @context
+</li>
+<li>	
+COUNTER EXAMPLE CANNOT EXIST
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-string-type">td-string-type</a>: <strong>MUST</strong></dt><dd class="td-string-type"><span class="rfc2119-assertion" id="td-string-type">
         Vocabulary terms that use simple types string and anyURI
         MUST be serialized as JSON string.
   </span><ul><li><span class="testspec" id="td-string-type">
-    TO DO: test spec for td-string-type.
+<ul>
+<li>	
+ASSERTION NOT CLEAR (does this mean that strings we have in TD such as &quot;type&quot;:&quot;number&quot; must be &quot;type&quot; and not (type) or (type is number) etc.? )
+</li>
+<li>	
+IF YES THEN TESTED
+</li>
+<li>	
+EXAMPLE DOES NOT EXIST
+</li>
+<li>	
+COUNTER EXAMPLE DOES NOT EXIST
+</li>
+</ul>
 </span></li></ul></dd><dt><a href="../index.html#td-integer-type">td-integer-type</a>: <strong>MUST</strong></dt><dd class="td-integer-type"><span class="rfc2119-assertion" id="td-integer-type">
         Vocabulary terms that use simple type unsignedInt
         MUST be serialized as JSON integer.
   </span><ul><li><span class="testspec" id="td-integer-type">
-    TO DO: test spec for td-integer-type.
+<ul>
+<li>	
+ASSERTION NOT CLEAR (does this mean that strings we have in TD such as &quot;type&quot;:123 must be 123 and not (1 2 3))
+</li>
+<li>	
+IF YES THEN TESTED
+</li>
+<li>	
+EXAMPLE DOES NOT EXIST
+</li>
+<li>	
+COUNTER EXAMPLE DOES NOT EXIST
+</li>
+</ul>
 </span></li></ul></dd><dt><a href="../index.html#td-number-type">td-number-type</a>: <strong>MUST</strong></dt><dd class="td-number-type"><span class="rfc2119-assertion" id="td-number-type">
         Vocabulary terms that use simple type double
         MUST be serialized as JSON number.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-context">td-context</a>: <strong>MAY</strong></dt><dd class="td-context"><span class="rfc2119-assertion" id="td-context">
+  </span><ul><li><span class="testspec" id="td-number-type">
+<ul>
+<li>	
+ASSERTION NOT CLEAR (does this mean that strings we have in TD such as &quot;type&quot;:123 must be 123 and not (1 2 3))
+</li>
+<li>	
+IF YES THEN TESTED
+</li>
+<li>	
+EXAMPLE DOES NOT EXIST
+</li>
+<li>	
+COUNTEREXAMPLE DOES NOT EXIST
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-context">td-context</a>: <strong>MAY</strong></dt><dd class="td-context"><span class="rfc2119-assertion" id="td-context">
   The root object of a Thing Description instance MAY include the
   <code>@context</code> key from JSON-LD 1.1 with the value URI of 
   the Thing description context file <code>http://www.w3.org/ns/td</code>.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-context-jsonld">td-context-jsonld</a>: <strong>MUST</strong></dt><dd class="td-context-jsonld"><span class="rfc2119-assertion" id="td-context-jsonld">
+  </span><ul><li><span class="testspec" id="td-context">
+<ul>
+<li>	
+ASSERTION NOT CLEAR: Can you have an @context key without this context file
+</li>
+<li>	
+IF YES THEN TESTED WRONGLY
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-context-jsonld">td-context-jsonld</a>: <strong>MUST</strong></dt><dd class="td-context-jsonld"><span class="rfc2119-assertion" id="td-context-jsonld">
   When a Thing Description instance is processed and interpreted by a
   JSON-LD 1.1 processor the <code>@context</code> field
-  MUST be present</span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-additional-contexts">td-additional-contexts</a>: <strong>MUST</strong></dt><dd class="td-additional-contexts"><span class="rfc2119-assertion" id="td-additional-contexts">
+  MUST be present</span><ul><li><span class="testspec" id="td-context-jsonld">
+<ul>
+<li>	
+NOT TESTED
+</li>
+<li>	
+HOW TO TEST
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-additional-contexts">td-additional-contexts</a>: <strong>MUST</strong></dt><dd class="td-additional-contexts"><span class="rfc2119-assertion" id="td-additional-contexts">
   When a single Thing Description instance involves several contexts, 
   additional namespaces with prefixes MUST be appended to the 
-  <code>@context</code> array structure.</span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-context-toplevel">td-context-toplevel</a>: <strong>MUST</strong></dt><dd class="td-context-toplevel"><span class="rfc2119-assertion" id="td-context-toplevel">
+  <code>@context</code> array structure.</span><ul><li><span class="testspec" id="td-additional-contexts">
+<ul>
+<li>	
+TESTED
+</li>
+<li>	
+EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-context-toplevel">td-context-toplevel</a>: <strong>MUST</strong></dt><dd class="td-context-toplevel"><span class="rfc2119-assertion" id="td-context-toplevel">
   Each mandatory and optional field name
   as defined in the class <a href="#thing" class="sec-ref"><code>Thing</code></a>
   MUST be serialized as a JSON key 
   in the root object of the Thing Description instance.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-objects">td-objects</a>: <strong>MUST</strong></dt><dd class="td-objects"><span class="rfc2119-assertion" id="td-objects">
+  </span><ul><li><span class="testspec" id="td-context-toplevel">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
+</li>
+<li>	
+	COUNTER EXAMPLE DOESN&apos;T EXIST 
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-objects">td-objects</a>: <strong>MUST</strong></dt><dd class="td-objects"><span class="rfc2119-assertion" id="td-objects">
   The type of the fields <code>properties</code>, <code>actions</code>, 
-  and <code>events</code> MUST be a JSON object.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-arrays">td-arrays</a>: <strong>MUST</strong></dt><dd class="td-arrays"><span class="rfc2119-assertion" id="td-arrays">
+  <code>events</code>, and <code>version</code> MUST be a JSON object.
+  </span><ul><li><span class="testspec" id="td-objects">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
+</li>
+<li>	
+	COUNTER EXAMPLE DOESN&apos;T EXIST 
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-arrays">td-arrays</a>: <strong>MUST</strong></dt><dd class="td-arrays"><span class="rfc2119-assertion" id="td-arrays">
   The type of the fields <code>links</code>,
   <code>scopes</code>, and <code>security</code>
   MUST be a JSON array.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-properties">td-properties</a>: <strong>MUST</strong></dt><dd class="td-properties"><span class="rfc2119-assertion" id="td-properties">
+  </span><ul><li><span class="testspec" id="td-arrays">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
+</li>
+<li>	
+	COUNTER EXAMPLE DOESN&apos;T EXIST 
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-properties">td-properties</a>: <strong>MUST</strong></dt><dd class="td-properties"><span class="rfc2119-assertion" id="td-properties">
   Properties (and sub-properties) offered by a Thing MUST be collected
   in the JSON-object based <code>properties</code> field
   with (unique) Property names as JSON keys.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-property-keys">td-property-keys</a>: <strong>MUST</strong></dt><dd class="td-property-keys"><span class="rfc2119-assertion" id="td-property-keys">
+  </span><ul><li><span class="testspec" id="td-properties">
+<ul>
+<li>	
+	NOT TESTED
+</li>
+<li>	
+	TDS THAT DON&apos;T RESPECT THIS ASSERTION ARE VALIDATED
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-property-keys">td-property-keys</a>: <strong>MUST</strong></dt><dd class="td-property-keys"><span class="rfc2119-assertion" id="td-property-keys">
   Each mandatory and optional vocabulary term
   as defined in the class <a href="#property" class="sec-ref"><code>Property</code></a>,
   as well as its two superclasses
   <a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
   and <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
   MUST be serialized as a JSON key within a Property object.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-property-objects">td-property-objects</a>: <strong>MUST</strong></dt><dd class="td-property-objects"><span class="rfc2119-assertion" id="td-property-objects">
+  </span><ul><li><span class="testspec" id="td-property-keys">
+<ul>
+<li>	
+	ASSERTION NOT CLEAR
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-property-objects">td-property-objects</a>: <strong>MUST</strong></dt><dd class="td-property-objects"><span class="rfc2119-assertion" id="td-property-objects">
   The type of the fields <code>properties</code> and <code>items</code> 
   MUST be serialized as a JSON object.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-property-arrays">td-property-arrays</a>: <strong>MUST</strong></dt><dd class="td-property-arrays"><span class="rfc2119-assertion" id="td-property-arrays">
+  </span><ul><li><span class="testspec" id="td-property-objects">
+<ul>
+<li>	
+	ASSERTION NOT CLEAR (SOUNDS WRONG SINCE ITEMS CAN BE AN ARRAY 
+	IN JSON SCHEMA)
+</li>
+<li>	
+	NOT TESTED
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-property-arrays">td-property-arrays</a>: <strong>MUST</strong></dt><dd class="td-property-arrays"><span class="rfc2119-assertion" id="td-property-arrays">
   The type of the fields <code>forms</code>, <code>required</code>, 
   and <code>enum</code>, <code>scopes</code>, and <code>security</code>,
   MUST be serialized as a JSON array.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-property-semantic">td-property-semantic</a>: <strong>MAY</strong></dt><dd class="td-property-semantic"><span class="rfc2119-assertion" id="td-property-semantic">
+  </span><ul><li><span class="testspec" id="td-property-arrays">
+<ul>
+<li>	
+	TESTED
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-property-semantic">td-property-semantic</a>: <strong>MAY</strong></dt><dd class="td-property-semantic"><span class="rfc2119-assertion" id="td-property-semantic">
   Similar to the case at the <code>Thing</code> level,
   properties MAY have additional semantic annotations based on 
   JSON-LD 1.1 keywords.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-property-defaults">td-property-defaults</a>: <strong>MUST</strong></dt><dd class="td-property-defaults"><span class="rfc2119-assertion" id="td-property-defaults">
+  </span><ul><li><span class="testspec" id="td-property-semantic">
+<ul>
+<li>	
+	CANNOT BE TESTED
+</li>
+<li>	
+	EXAMPLE EXISTS
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-property-defaults">td-property-defaults</a>: <strong>MUST</strong></dt><dd class="td-property-defaults"><span class="rfc2119-assertion" id="td-property-defaults">
   When a Thing Description instance is processed and interpreted by 
   a JSON-LD 1.1 processor, 
   each <code>property</code> MUST contain the vocabulary terms 
   <code>observable</code> and <code>writable</code> due to the 
   <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>
   of Linked Data.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-actions">td-actions</a>: <strong>MUST</strong></dt><dd class="td-actions"><span class="rfc2119-assertion" id="td-actions">
+  </span><ul><li><span class="testspec" id="td-property-defaults">
+<ul>
+<li>	
+	NOT TESTED
+</li>
+<li>	
+	NOT CLEAR HOW TO TEST
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-actions">td-actions</a>: <strong>MUST</strong></dt><dd class="td-actions"><span class="rfc2119-assertion" id="td-actions">
   Actions offered by a Thing MUST be collected
   in the JSON-object based <code>actions</code> field
   with (unique) Action names as JSON keys.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-action-keys">td-action-keys</a>: <strong>MUST</strong></dt><dd class="td-action-keys"><span class="rfc2119-assertion" id="td-action-keys">
+  </span><ul><li><span class="testspec" id="td-actions">
+<ul>
+<li>	
+	NOT TESTED
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-action-keys">td-action-keys</a>: <strong>MUST</strong></dt><dd class="td-action-keys"><span class="rfc2119-assertion" id="td-action-keys">
   Each optional vocabulary term
   as defined in the class <a href="#action" class="sec-ref"><code>Action</code></a>
   and its superclass
   <a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
   MUST be serialized as a JSON key within an Action object.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-action-objects">td-action-objects</a>: <strong>MUST</strong></dt><dd class="td-action-objects"><span class="rfc2119-assertion" id="td-action-objects">
-  The type of the fields <code>input</code> and <code>output</code>
-  MUST be serialized as a JSON object.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-action-arrays">td-action-arrays</a>: <strong>MUST</strong></dt><dd class="td-action-arrays"><span class="rfc2119-assertion" id="td-action-arrays">
+  </span><ul><li><span class="testspec" id="td-action-keys">
+<ul>
+<li>	
+	ASSERTION NOT CLEAR
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-action-objects">td-action-objects</a>: <strong>MUST</strong></dt><dd class="td-action-objects"><span class="rfc2119-assertion" id="td-action-objects">
+    The type of the fields <code>subscription</code>, <code>data</code>, and <code>cancellation</code>
+    MUST be serialized as a JSON object.
+    </span><ul><li><span class="testspec" id="td-action-objects">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE DOES NOT EXIST
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-action-arrays">td-action-arrays</a>: <strong>MUST</strong></dt><dd class="td-action-arrays"><span class="rfc2119-assertion" id="td-action-arrays">
   The type of the fields <code>forms</code>, <code>scopes</code>,
   and <code>security</code>
   MUST be serialized as a JSON array.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-action-semantic">td-action-semantic</a>: <strong>MAY</strong></dt><dd class="td-action-semantic"><span class="rfc2119-assertion" id="td-action-semantic">
+  </span><ul><li><span class="testspec" id="td-action-arrays">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE EXISTS
+</li>
+<li>	
+	COUNTER EXAMPLE DOES NOT EXIST
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-action-semantic">td-action-semantic</a>: <strong>MAY</strong></dt><dd class="td-action-semantic"><span class="rfc2119-assertion" id="td-action-semantic">
   Definitions within the <code>actions</code> field
   MAY have additional semantic annotations based on JSON-LD 1.1 keywords.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-events">td-events</a>: <strong>MUST</strong></dt><dd class="td-events"><span class="rfc2119-assertion" id="td-events">
-  Events offered by a Thing MUST be collected
-  in the JSON-object based <code>events</code> field
-  with (unique) Event names as JSON keys.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-event-keys">td-event-keys</a>: <strong>MUST</strong></dt><dd class="td-event-keys"><span class="rfc2119-assertion" id="td-event-keys">
+  </span><ul><li><span class="testspec" id="td-action-semantic">
+<ul>
+<li>	
+	CANNOT BE TESTED
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-events">td-events</a>: <strong>MUST</strong></dt><dd class="td-events"><span class="rfc2119-assertion" id="td-events">
+        In such a case these variables in the URI MUST be collected
+        in the JSON-object based <code>uriVariables</code> field
+        with the associated (unique) variables names as JSON keys.
+    </span><ul><li><span class="testspec" id="td-events">
+<ul>
+<li>	
+	HOW TO TEST COUNTER EXAMPLE? 
+</li>
+<li>	
+	WHAT IS A COUNTER EXAMPLE?
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-event-keys">td-event-keys</a>: <strong>MUST</strong></dt><dd class="td-event-keys"><span class="rfc2119-assertion" id="td-event-keys">
   Each optional vocabulary term
   as defined in the class <a href="#event" class="sec-ref"><code>Event</code></a>,
   as well as its two superclasses
   <a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
   and <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
   MUST be serialized as a JSON key within an Event object.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-event-objects">td-event-objects</a>: <strong>MUST</strong></dt><dd class="td-event-objects"><span class="rfc2119-assertion" id="td-event-objects">
-  The type of the fields <code>properties</code> and <code>items</code> 
-  MUST be serialized as a JSON object.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-event-arrays">td-event-arrays</a>: <strong>MUST</strong></dt><dd class="td-event-arrays"><span class="rfc2119-assertion" id="td-event-arrays">
+  </span><ul><li><span class="testspec" id="td-event-keys">
+<ul>
+<li>	
+	ASSERTION NOT CLEAR
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-event-arrays">td-event-arrays</a>: <strong>MUST</strong></dt><dd class="td-event-arrays"><span class="rfc2119-assertion" id="td-event-arrays">
   The type of the fields <code>forms</code>, <code>required</code>, 
   and <code>enum</code>, <code>scopes</code>, and <code>security</code>
   MUST be serialized as a JSON array.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-event-semantic">td-event-semantic</a>: <strong>MAY</strong></dt><dd class="td-event-semantic"><span class="rfc2119-assertion" id="td-event-semantic">
+  </span><ul><li><span class="testspec" id="td-event-arrays">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE DOES NOT EXIST EXPICITLY FOR THIS
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-event-semantic">td-event-semantic</a>: <strong>MAY</strong></dt><dd class="td-event-semantic"><span class="rfc2119-assertion" id="td-event-semantic">
   Definitions within the <code>events</code> field
   MAY have additional semantic anotations based on JSON-LD 1.1 keywords.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-forms">td-forms</a>: <strong>MUST</strong></dt><dd class="td-forms"><span class="rfc2119-assertion" id="td-forms">
+  </span><ul><li><span class="testspec" id="td-event-semantic">
+<ul>
+<li>	
+	CANNOT BE TESTED
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-forms">td-forms</a>: <strong>MUST</strong></dt><dd class="td-forms"><span class="rfc2119-assertion" id="td-forms">
   Each mandatory and optional vocabulary term
   as defined in the class <a href="#form" class="sec-ref"><code>Form</code></a>,
   MUST be serialized as a JSON key.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-form-protocolbindings">td-form-protocolbindings</a>: <strong>MAY</strong></dt><dd class="td-form-protocolbindings"><span class="rfc2119-assertion" id="td-form-protocolbindings">
+  </span><ul><li><span class="testspec" id="td-forms">
+<ul>
+<li>	
+	HOW TO TEST COUNTEREXAMPLE? 
+</li>
+<li>	
+	WHAT IS A COUNTEREXAMPLE?
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-form-protocolbindings">td-form-protocolbindings</a>: <strong>MAY</strong></dt><dd class="td-form-protocolbindings"><span class="rfc2119-assertion" id="td-form-protocolbindings">
   If required, <code>forms</code> 
   MAY be supplemented with protocol-specific vocabulary terms 
   identified with a prefix. 
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-form-mediatype">td-form-mediatype</a>: <strong>MUST</strong></dt><dd class="td-form-mediatype"><span class="rfc2119-assertion" id="td-form-mediatype">
+  </span><ul><li><span class="testspec" id="td-form-protocolbindings">
+<ul>
+<li>	
+	Ege: CANNOT BE TESTED
+</li>
+<li>	
+	McCool: CONSIDER TESTING WITH SHEX
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-form-contenttype">td-form-contenttype</a>: <strong>MUST</strong></dt><dd class="td-form-contenttype"><span class="rfc2119-assertion" id="td-form-contenttype">
   When a Thing Description instance is processed and interpreted 
   by a JSON-LD 1.1 processor, 
   each <code>forms</code> (array) entry 
-  MUST contain a <code>mediaType</code> 
+  MUST contain a <code>contenttype</code> 
   due to the
   <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>
   of Linked Data.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-links">td-links</a>: <strong>MUST</strong></dt><dd class="td-links"><span class="rfc2119-assertion" id="td-links">
+  </span><ul><li><span class="testspec" id="td-form-contenttype">
+<ul>
+<li>	
+	NOT TESTED
+</li>
+<li>	
+	HOW TO TEST
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-links">td-links</a>: <strong>MUST</strong></dt><dd class="td-links"><span class="rfc2119-assertion" id="td-links">
     Each mandatory and optional vocabulary term
     as defined in the class <a href="#link" class="sec-ref"><code>Link</code></a>,
     MUST be serialized as a JSON key.
-    </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-security">td-security</a>: <strong>MUST</strong></dt><dd class="td-security"><span class="rfc2119-assertion" id="td-security">
+    </span><ul><li><span class="testspec" id="td-links">
+<ul>
+<li>	
+	HOW TO TEST COUNTEREXAMPLE? 
+</li>
+<li>	
+	WHAT IS A COUNTEREXAMPLE?
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-security">td-security</a>: <strong>MUST</strong></dt><dd class="td-security"><span class="rfc2119-assertion" id="td-security">
     Each mandatory and optional vocabulary term
     as defined in the class 
     <a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>,
     MUST be serialized as a JSON key.
-    </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-security-mandatory">td-security-mandatory</a>: <strong>MUST</strong></dt><dd class="td-security-mandatory"><span class="rfc2119-assertion" id="td-security-mandatory">
+    </span><ul><li><span class="testspec" id="td-security">
+<ul>
+<li>	
+	HOW TO TEST COUNTEREXAMPLE? 
+</li>
+<li>	
+	WHAT IS A COUNTEREXAMPLE?
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-security-mandatory">td-security-mandatory</a>: <strong>MUST</strong></dt><dd class="td-security-mandatory"><span class="rfc2119-assertion" id="td-security-mandatory">
     Every form in a Thing MUST have a security configuration either provided 
     in the form itself,
     at the interaction level directly above it 
@@ -145,37 +423,108 @@
     or at the Thing level 
     (if security is not configured in either the form or at the
     interaction level).
-    </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-security-binding">td-security-binding</a>: <strong>MUST</strong></dt><dd class="td-security-binding"><span class="rfc2119-assertion" id="td-security-binding">
+    </span><ul><li><span class="testspec" id="td-security-mandatory">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE EXISTS
+</li>
+<li>	
+	COUNTEREXAMPLE DOESN&apos;T EXIST
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-security-binding">td-security-binding</a>: <strong>MUST</strong></dt><dd class="td-security-binding"><span class="rfc2119-assertion" id="td-security-binding">
     The security configuration metadata provided in a Thing Description 
     MUST accurately reflect the
     security requirements of the Thing.
-    </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-media-type">td-media-type</a>: <strong>MUST</strong></dt><dd class="td-media-type"><span class="rfc2119-assertion" id="td-media-type">
+    </span><ul><li><span class="testspec" id="td-security-binding">
+<ul>
+<li>	
+	HOW TO TEST? 
+</li>
+<li>	
+	PENETRATION TEST?
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-version">td-version</a>: <strong>MAY</strong></dt><dd class="td-version"><span class="rfc2119-assertion" id="td-version">
+        The version container MAY be used to provide additional application and/or device specific version information based on terms from non-TD namespaces. 
+    </span><ul><li><span class="testspec" id="td-version">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE EXISTS
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-media-type">td-media-type</a>: <strong>MUST</strong></dt><dd class="td-media-type"><span class="rfc2119-assertion" id="td-media-type">
   The media type <code>application/td+json</code>
   MUST be also associated with the JSON-LD context 
   <code>http://www.w3.org/ns/td</code>.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-writable-observable-default">td-writable-observable-default</a>: <strong>MUST</strong></dt><dd class="td-writable-observable-default"><span class="rfc2119-assertion" id="td-writable-observable-default">
+  </span><ul><li><span class="testspec" id="td-media-type">
+<ul>
+<li>	
+	ASSERTION NOT CLEAR
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-writable-observable-default">td-writable-observable-default</a>: <strong>MUST</strong></dt><dd class="td-writable-observable-default"><span class="rfc2119-assertion" id="td-writable-observable-default">
   If the key terms <code>writable</code> and/or <code>observable</code> 
   are not present within a <code>properties</code> definition,
   the default value defined in <a href="#sec-vocabulary-definition"></a>
   MUST be assumed.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-media-type-default">td-media-type-default</a>: <strong>MUST</strong></dt><dd class="td-media-type-default"><span class="rfc2119-assertion" id="td-media-type-default">
-  If the <code>mediaType</code> key term is not present within a 
+  </span><ul><li><span class="testspec" id="td-writable-observable-default">
+<ul>
+<li>	
+	HOW TO TEST?
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-media-type-default">td-media-type-default</a>: <strong>MUST</strong></dt><dd class="td-media-type-default"><span class="rfc2119-assertion" id="td-media-type-default">
+  If the <code>contenttype</code> key term is not present within a 
   <code>forms</code> definition, the default value as defined in
   <a href="#sec-vocabulary-definition"></a>
   MUST be assumed.   
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-jsonld-preprocessing-context">td-jsonld-preprocessing-context</a>: <strong>MUST</strong></dt><dd class="td-jsonld-preprocessing-context"><span class="rfc2119-assertion" id="td-jsonld-preprocessing-context">
+  </span><ul><li><span class="testspec" id="td-media-type-default">
+<ul>
+<li>	
+	HOW TO TEST?
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-jsonld-preprocessing-context">td-jsonld-preprocessing-context</a>: <strong>MUST</strong></dt><dd class="td-jsonld-preprocessing-context"><span class="rfc2119-assertion" id="td-jsonld-preprocessing-context">
      Before starting JSON-LD 1.1 processing of a Thing Description instance,
      there MUST be a <code>@context</code> key from JSON-LD 1.1 as defined 
      in Section 
      <a href="#sec-thing-as-a-whole-json"></a>.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-jsonld-preprocessing-prefix">td-jsonld-preprocessing-prefix</a>: <strong>MUST</strong></dt><dd class="td-jsonld-preprocessing-prefix"><span class="rfc2119-assertion" id="td-jsonld-preprocessing-prefix">
+  </span><ul><li><span class="testspec" id="td-jsonld-preprocessing-context">
+<ul>
+<li>	
+	HOW TO TEST? 
+</li>
+<li>	
+	HOW TO DISGUISH WHETHER IT SHOULD BE A JSON-LD WHICH LACKS THE @CONTEXT?
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-jsonld-preprocessing-prefix">td-jsonld-preprocessing-prefix</a>: <strong>MUST</strong></dt><dd class="td-jsonld-preprocessing-prefix"><span class="rfc2119-assertion" id="td-jsonld-preprocessing-prefix">
      Before starting JSON-LD 1.1 processing of a Thing Description instance,
      all external vocabulary terms used in the Thing Description MUST 
      provide their context URIs as prefix or within the <code>@context</code>
      field.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-jsonld-preprocessing-defaults">td-jsonld-preprocessing-defaults</a>: <strong>MUST</strong></dt><dd class="td-jsonld-preprocessing-defaults"><span class="rfc2119-assertion" id="td-jsonld-preprocessing-defaults">
+  </span><ul><li><span class="testspec" id="td-jsonld-preprocessing-prefix">
+<ul>
+<li>	
+	HOW TO TEST? 
+</li>
+</ul>
+</span></li></ul></dd><dt><a href="../index.html#td-jsonld-preprocessing-defaults">td-jsonld-preprocessing-defaults</a>: <strong>MUST</strong></dt><dd class="td-jsonld-preprocessing-defaults"><span class="rfc2119-assertion" id="td-jsonld-preprocessing-defaults">
      Before starting JSON-LD 1.1 processing of a Thing Description instance,
      all mandatory vocabulary terms as defined in Section
      <a href="#sec-vocabulary-definition"></a> that are missing from the instance
      MUST be inserted explicitly with their default value.
-  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd></dl></body></html>
+  </span><ul><li><span class="testspec" id="td-jsonld-preprocessing-defaults">
+<ul>
+<li>	
+	HOW TO TEST? 
+</li>
+</ul>
+</span></li></ul></dd></dl></body></html>

--- a/testing/testspec.html
+++ b/testing/testspec.html
@@ -1,287 +1,448 @@
-<span class="testspec" id="td-number-type">
-	NOT TESTED
+<!-- EXAMPLE 
+<span class="testspec" id="unique-id">
+<ul>
+<li>	
+        NOT TESTED
+</li>
+<li>	
 	TESTED WITH JSON SCHEMA etc
+</li>
+<li>	
 	EXAMPLE EXISTS
+</li>
+<li>	
 	ASSERTION NOT CLEAR
+</li>
+</ul>
 </span>
-<span id="td-jsonld-keywords">
-	Thing Description instances MAY contain JSON-LD 1.1 keywords such as
-<code>@context</code> and <code>@type</code>.
+-->
+<span class="testspec" 
+      id="td-jsonld-keywords">
+<ul>
+<li>	
 TESTED
+</li>
+<li>	
 EXAMPLE EXISTS only for @context
+</li>
+<li>	
 COUNTER EXAMPLE CANNOT EXIST
+</li>
+</ul>
 </span>
-<span id="td-string-type">
-	Vocabulary terms that use simple types string and anyURI
-MUST be serialized as JSON string.
+<span class="testspec" 
+      id="td-string-type">
+<ul>
+<li>	
 ASSERTION NOT CLEAR (does this mean that strings we have in TD such as "type":"number" must be "type" and not (type) or (type is number) etc.? )
+</li>
+<li>	
 IF YES THEN TESTED
+</li>
+<li>	
 EXAMPLE DOES NOT EXIST
+</li>
+<li>	
 COUNTER EXAMPLE DOES NOT EXIST
+</li>
+</ul>
 </span>
-<span id="td-integer-type">
-	Vocabulary terms that use simple type unsignedInt
-	MUST be serialized as JSON integer.
+<span class="testspec" 
+      id="td-integer-type">
+<ul>
+<li>	
 ASSERTION NOT CLEAR (does this mean that strings we have in TD such as "type":123 must be 123 and not (1 2 3))
+</li>
+<li>	
 IF YES THEN TESTED
+</li>
+<li>	
 EXAMPLE DOES NOT EXIST
+</li>
+<li>	
 COUNTER EXAMPLE DOES NOT EXIST
+</li>
+</ul>
 </span>
-<span id="td-number-type">
-	Vocabulary terms that use simple type double
-MUST be serialized as JSON number. 
+<span class="testspec" 
+      id="td-number-type">
+<ul>
+<li>	
 ASSERTION NOT CLEAR (does this mean that strings we have in TD such as "type":123 must be 123 and not (1 2 3))
+</li>
+<li>	
 IF YES THEN TESTED
+</li>
+<li>	
 EXAMPLE DOES NOT EXIST
-COUNTER EXAMPLE DOES NOT EXIST
+</li>
+<li>	
+COUNTEREXAMPLE DOES NOT EXIST
+</li>
+</ul>
 </span>
-<span id="td-context">
-	The root object of a Thing Description instance MAY include the
-	<code>@context</code> key from JSON-LD 1.1 with the value URI of
-	the Thing description context file <code>http://www.w3.org/ns/td</code>.
+<span class="testspec" 
+      id="td-context">
+<ul>
+<li>	
 ASSERTION NOT CLEAR: Can you have an @context key without this context file
+</li>
+<li>	
 IF YES THEN TESTED WRONGLY
+</li>
+</ul>
 </span>
-<span id="td-context-jsonld">
-	When a Thing Description instance is processed and interpreted by a
-	JSON-LD 1.1 processor the <code>@context</code> field
-MUST be present
+<span class="testspec" 
+      id="td-context-jsonld">
+<ul>
+<li>	
 NOT TESTED
+</li>
+<li>	
 HOW TO TEST
+</li>
+</ul>
 </span>
-<span id="td-additional-contexts">
-	When a single Thing Description instance involves several contexts,
-	additional namespaces with prefixes MUST be appended to the
-<code>@context</code> array structure.
+<span class="testspec" 
+      id="td-additional-contexts">
+<ul>
+<li>	
 TESTED
+</li>
+<li>	
 EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
+</li>
+</ul>
 </span>
-<span id="td-context-toplevel">
-	Each mandatory and optional field name
-	as defined in the class <a href="#thing" class="sec-ref"><code>Thing</code></a>
-	MUST be serialized as a JSON key
-	in the root object of the Thing Description instance.
+<span class="testspec" 
+      id="td-context-toplevel">
+<ul>
+<li>	
 	TESTED
+</li>
+<li>	
 	EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
+</li>
+<li>	
 	COUNTER EXAMPLE DOESN'T EXIST 
+</li>
+</ul>
 </span>
-<span id="td-objects">
-	The type of the fields <code>properties</code>, <code>actions</code>,
-	<code>events</code>, and <code>version</code> MUST be a JSON object.
+<span class="testspec" 
+      id="td-objects">
+<ul>
+<li>	
 	TESTED
+</li>
+<li>	
 	EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
+</li>
+<li>	
 	COUNTER EXAMPLE DOESN'T EXIST 
+</li>
+</ul>
 </span>
-<span class="rfc2119-assertion" id="td-arrays">
-	The type of the fields <code>links</code>,
-	<code>scopes</code>, and <code>security</code>
-	MUST be a JSON array.
+<span class="testspec" 
+      id="td-arrays">
+<ul>
+<li>	
 	TESTED
+</li>
+<li>	
 	EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
+</li>
+<li>	
 	COUNTER EXAMPLE DOESN'T EXIST 
+</li>
+</ul>
 </span>
-<span class="rfc2119-assertion" id="td-properties">
-	Properties (and sub-properties) offered by a Thing MUST be collected
-	in the JSON-object based <code>properties</code> field
-	with (unique) Property names as JSON keys.
+<span class="testspec" 
+      id="td-properties">
+<ul>
+<li>	
 	NOT TESTED
+</li>
+<li>	
 	TDS THAT DON'T RESPECT THIS ASSERTION ARE VALIDATED
-</span
-<span class="rfc2119-assertion" id="td-property-keys">
-	Each mandatory and optional vocabulary term
-	as defined in the class <a href="#property" class="sec-ref"><code>Property</code></a>,
-	as well as its two superclasses
-	<a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
-	and <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
-	MUST be serialized as a JSON key within a Property object.
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-property-keys">
+<ul>
+<li>	
 	ASSERTION NOT CLEAR
+</li>
+</ul>
 </span>
-<span class="rfc2119-assertion" id="td-property-objects">
-	The type of the fields <code>properties</code> and <code>items</code>
-	MUST be serialized as a JSON object.
-	ASSERTION NOT CLEAR (SOUNDS WRONG SINCE ITEMS CAN BE AN ARRAY IN JSON SCHEMA)
+<span class="testspec" 
+      id="td-property-objects">
+<ul>
+<li>	
+	ASSERTION NOT CLEAR (SOUNDS WRONG SINCE ITEMS CAN BE AN ARRAY 
+	IN JSON SCHEMA)
+</li>
+<li>	
 	NOT TESTED
+</li>
+</ul>
 </span>
-<span class="rfc2119-assertion" id="td-property-arrays">
-	The type of the fields <code>forms</code>, <code>required</code>,
-	and <code>enum</code>, <code>scopes</code>, and <code>security</code>,
-	MUST be serialized as a JSON array.
+<span class="testspec" 
+      id="td-property-arrays">
+<ul>
+<li>	
 	TESTED
+</li>
+</ul>
 </span>
-<span class="rfc2119-assertion" id="td-property-semantic">
-	Similar to the case at the <code>Thing</code> level,
-	properties MAY have additional semantic annotations based on
-	JSON-LD 1.1 keywords.
+<span class="testspec" 
+      id="td-property-semantic">
+<ul>
+<li>	
 	CANNOT BE TESTED
+</li>
+<li>	
 	EXAMPLE EXISTS
+</li>
+</ul>
 </span>
-<span class="rfc2119-assertion" id="td-property-defaults">
-	When a Thing Description instance is processed and interpreted by
-	a JSON-LD 1.1 processor,
-	each <code>property</code> MUST contain the vocabulary terms
-	<code>observable</code> and <code>writable</code> due to the
-	<a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>
-	of Linked Data.
+<span class="testspec" 
+      id="td-property-defaults">
+<ul>
+<li>	
 	NOT TESTED
+</li>
+<li>	
+	NOT CLEAR HOW TO TEST
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-actions">
+<ul>
+<li>	
+	NOT TESTED
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-action-keys">
+<ul>
+<li>	
+	ASSERTION NOT CLEAR
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-action-objects">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE DOES NOT EXIST
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-action-arrays">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE EXISTS
+</li>
+<li>	
+	COUNTER EXAMPLE DOES NOT EXIST
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-action-semantic">
+<ul>
+<li>	
+	CANNOT BE TESTED
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-events">
+<ul>
+<li>	
+	HOW TO TEST COUNTER EXAMPLE? 
+</li>
+<li>	
+	WHAT IS A COUNTER EXAMPLE?
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-event-keys">
+<ul>
+<li>	
+	ASSERTION NOT CLEAR
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-event-arrays">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE DOES NOT EXIST EXPICITLY FOR THIS
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-event-semantic">
+<ul>
+<li>	
+	CANNOT BE TESTED
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-forms">
+<ul>
+<li>	
+	HOW TO TEST COUNTEREXAMPLE? 
+</li>
+<li>	
+	WHAT IS A COUNTEREXAMPLE?
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-form-protocolbindings">
+<ul>
+<li>	
+	Ege: CANNOT BE TESTED
+</li>
+<li>	
+	McCool: CONSIDER TESTING WITH SHEX
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-form-contenttype">
+<ul>
+<li>	
+	NOT TESTED
+</li>
+<li>	
 	HOW TO TEST
-</span><
-<span class="rfc2119-assertion" id="td-actions">
-	Actions offered by a Thing MUST be collected
-	in the JSON-object based <code>actions</code> field
-	with (unique) Action names as JSON keys.
-	NOT TESTED
+</li>
+</ul>
 </span>
-<span class="rfc2119-assertion" id="td-action-keys">
-	Each optional vocabulary term
-	as defined in the class <a href="#action" class="sec-ref"><code>Action</code></a>
-	and its superclass
-	<a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
-	MUST be serialized as a JSON key within an Action object.
-	ASSERTION NOT CLEAR
+<span class="testspec" 
+      id="td-links">
+<ul>
+<li>	
+	HOW TO TEST COUNTEREXAMPLE? 
+</li>
+<li>	
+	WHAT IS A COUNTEREXAMPLE?
+</li>
+</ul>
 </span>
-<span class="rfc2119-assertion" id="td-action-objects">
-	The type of the fields <code>subscription</code>, <code>data</code>, and <code>cancellation</code>
-	MUST be serialized as a JSON object.
+<span class="testspec" 
+      id="td-security">
+<ul>
+<li>	
+	HOW TO TEST COUNTEREXAMPLE? 
+</li>
+<li>	
+	WHAT IS A COUNTEREXAMPLE?
+</li>
+</ul>
+</span>
+<span class="testspec" 
+	id="td-security-mandatory">
+<ul>
+<li>	
 	TESTED
-	EXAMPLE DOESN'T EXIST
-</span>
-<span class="rfc2119-assertion" id="td-action-arrays">
-	The type of the fields <code>forms</code>, <code>scopes</code>,
-	and <code>security</code>
-	MUST be serialized as a JSON array.
-	TESTED
+</li>
+<li>	
 	EXAMPLE EXISTS
-	COUNTER EXAMPLE DOESN'T EXIST
+</li>
+<li>	
+	COUNTEREXAMPLE DOESN'T EXIST
+</li>
+</ul>
 </span>
-<span class="rfc2119-assertion" id="td-action-semantic">
-	Definitions within the <code>actions</code> field
-	MAY have additional semantic annotations based on JSON-LD 1.1 keywords.
-	CANNOT BE TESTED
-</span>
-<span class="rfc2119-assertion" id="td-events">
-	In such a case these variables in the URI MUST be collected
-	in the JSON-object based <code>uriVariables</code> field
-	with the associated (unique) variables names as JSON keys.
-	HOW TO TEST COUNTER EXAMPLE? WHAT IS COUNTER EXAMPLE?
-</span>
-<span class="rfc2119-assertion" id="td-event-keys">
-	Each optional vocabulary term
-	as defined in the class <a href="#event" class="sec-ref"><code>Event</code></a>,
-	as well as its two superclasses
-	<a href="#interactionpattern" class="sec-ref"><code>InteractionPattern</code></a>
-	and <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
-	MUST be serialized as a JSON key within an Event object.
-	ASSERTION NOT CLEAR
-</span>
-<span class="rfc2119-assertion" id="td-event-arrays">
-	The type of the fields <code>forms</code>, <code>required</code>,
-	and <code>enum</code>, <code>scopes</code>, and <code>security</code>
-	MUST be serialized as a JSON array.
-	TESTED
-	EXAMPLE DOESN'T EXIST EXCIPICITLY FOR THIS
-</span>
-<span class="rfc2119-assertion" id="td-event-semantic">
-	Definitions within the <code>events</code> field
-	MAY have additional semantic anotations based on JSON-LD 1.1 keywords.
-	CANNOT BE TESTED
-</span>
-<span class="rfc2119-assertion" id="td-forms">
-	Each mandatory and optional vocabulary term
-	as defined in the class <a href="#form" class="sec-ref"><code>Form</code></a>,
-	MUST be serialized as a JSON key.
-	HOW TO TEST COUNTER EXAMPLE? WHAT IS COUNTER EXAMPLE?
-</span>
-<span class="rfc2119-assertion" id="td-form-protocolbindings">
-	If required, <code>forms</code>
-	MAY be supplemented with protocol-specific vocabulary terms
-	identified with a prefix.
-	CANNOT BE TESTED
-</span>
-<span class="rfc2119-assertion" id="td-form-contenttype">
-	When a Thing Description instance is processed and interpreted
-	by a JSON-LD 1.1 processor,
-	each <code>forms</code> (array) entry
-	MUST contain a <code>contenttype</code>
-	due to the
-	<a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>
-	of Linked Data.
-	NOT TESTED
-	HOW TO TEST
-</span>
-<span class="rfc2119-assertion" id="td-links">
-	Each mandatory and optional vocabulary term
-	as defined in the class <a href="#link" class="sec-ref"><code>Link</code></a>,
-	MUST be serialized as a JSON key.
-	HOW TO TEST COUNTER EXAMPLE? WHAT IS COUNTER EXAMPLE?
-</span>
-<span class="rfc2119-assertion" id="td-security">
-	Each mandatory and optional vocabulary term
-	as defined in the class
-	<a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>,
-	MUST be serialized as a JSON key.
-	HOW TO TEST COUNTER EXAMPLE? WHAT IS COUNTER EXAMPLE?
-</span>
-<span class="rfc2119-assertion" id="td-security-mandatory">
-	Every form in a Thing MUST have a security configuration either provided
-	in the form itself,
-	at the interaction level directly above it
-	(if security is not configured in the form),
-	or at the Thing level
-	(if security is not configured in either the form or at the
-	interaction level).
-	TESTED
-	EXAMPLE EXISTS
-	COUNTER EXAMPLE DOESN'T EXIST
-</span>
-<span class="rfc2119-assertion" id="td-security-binding">
-	The security configuration metadata provided in a Thing Description
-	MUST accurately reflect the
-	security requirements of the Thing.
-	HOW TO TEST? PENETRATION TEST?
-</span>
-<span class="rfc2119-assertion" id="td-version">
-	The version container MAY be used to provide additional application and/or device specific version information based on terms from non-TD namespaces.
-	TESTED
-	EXAMPLE EXISTS
-</span>
-<span class="rfc2119-assertion" id="td-media-type">
-	The media type <code>application/td+json</code>
-	MUST be also associated with the JSON-LD context
-	<code>http://www.w3.org/ns/td</code>.
-	ASSERTION NOT CLEAR
-</span>
-<span class="rfc2119-assertion" id="td-writable-observable-default">
-	If the key terms <code>writable</code> and/or <code>observable</code>
-	are not present within a <code>properties</code> definition,
-	the default value defined in <a href="#sec-vocabulary-definition"></a>
-	MUST be assumed.
-	HOW TO TEST?
-</span>
-<span class="rfc2119-assertion" id="td-media-type-default">
-	If the <code>contenttype</code> key term is not present within a
-	<code>forms</code> definition, the default value as defined in
-	<a href="#sec-vocabulary-definition"></a>
-	MUST be assumed.
-	HOW TO TEST?
-</span>
-<span class="rfc2119-assertion" id="td-jsonld-preprocessing-context">
-	Before starting JSON-LD 1.1 processing of a Thing Description instance,
-	there MUST be a <code>@context</code> key from JSON-LD 1.1 as defined
-	in Section
-	<a href="#sec-thing-as-a-whole-json"></a>.
-	HOW TO TEST? (HOW TO DISGUISH WHETHER IT SHOULD BE A JSON-LD WHICH LACKS THE @CONTEXT)
-</span>
-<span class="rfc2119-assertion" id="td-jsonld-preprocessing-prefix">
-	Before starting JSON-LD 1.1 processing of a Thing Description instance,
-	all external vocabulary terms used in the Thing Description MUST
-	provide their context URIs as prefix or within the <code>@context</code>
-	field.
+<span class="testspec" 
+      id="td-security-binding">
+<ul>
+<li>	
 	HOW TO TEST? 
+</li>
+<li>	
+	PENETRATION TEST?
+</li>
+</ul>
 </span>
-<span class="rfc2119-assertion" id="td-jsonld-preprocessing-defaults">
-	Before starting JSON-LD 1.1 processing of a Thing Description instance,
-	all mandatory vocabulary terms as defined in Section
-	<a href="#sec-vocabulary-definition"></a> that are missing from the instance
-	MUST be inserted explicitly with their default value.
+<span class="testspec" 
+      id="td-version">
+<ul>
+<li>	
+	TESTED
+</li>
+<li>	
+	EXAMPLE EXISTS
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-media-type">
+<ul>
+<li>	
+	ASSERTION NOT CLEAR
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-writable-observable-default">
+<ul>
+<li>	
+	HOW TO TEST?
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-media-type-default">
+<ul>
+<li>	
+	HOW TO TEST?
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-jsonld-preprocessing-context">
+<ul>
+<li>	
 	HOW TO TEST? 
+</li>
+<li>	
+	HOW TO DISGUISH WHETHER IT SHOULD BE A JSON-LD WHICH LACKS THE @CONTEXT?
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-jsonld-preprocessing-prefix">
+<ul>
+<li>	
+	HOW TO TEST? 
+</li>
+</ul>
+</span>
+<span class="testspec" 
+      id="td-jsonld-preprocessing-defaults">
+<ul>
+<li>	
+	HOW TO TEST? 
+</li>
+</ul>
 </span>


### PR DESCRIPTION
fix up spans in testspec.html to use class=testspec, add lists to structure content of test specs, remove copies of assertion text, generate plan.html with "npm run assertions"