### PR TITLE
Template for Implementation Report

### DIFF
--- a/testing/ex.html
+++ b/testing/ex.html
@@ -1,0 +1,331 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+	<title>Web of Things (WoT) Thing Description: Implementation Report</title>
+	<style type="text/css" xml:space="preserve">
+/*<![CDATA[*/
+body {
+    margin-left: 4%;
+    margin-right: 3%;
+}
+table {
+    border: black;
+    border-width: 1px;
+}
+h2 { font-size: 150% }
+h3 { font-size: 120%; font-weight: bold }
+h4 { font-size: 110%; font-weight: bold}
+.tocline { list-style: none; }
+th { background-color: rgb(180,255,180) }
+td { background-color: rgb(234,255,234) }
+.comment {color: green; font-style: italic}
+.remove {text-decoration: line-through;color: black;}
+.new { color: red; }
+.working {background-color: rgb(255,234,234); padding:0.2em;}
+.fill-in {background-color: rgb(255,234,234);}
+pre.example {
+   font-family: "Courier New", monospace;
+   white-space: pre;
+   background-color: rgb(204,204,255);
+   padding: 0.5em;
+   border: none;
+   border-width: 0;
+   margin-left: 0;
+   font-size: 100%;
+   width: 100%;
+}
+
+table { background-color: rgb(180,180,180) }
+
+table.testlist {
+   border: black;
+   border-width: 1px;
+}
+table.grammars th, table.commands th, able.attrs th, table.testlist th {
+   background-color: rgb(180,255,180);
+   font-size: 10pt;
+   vertical-align: top; text-align: left;
+}
+table.grammars td, table.commands td, table.attrs td, table.testlist td {
+   background-color: rgb(234,255,234);
+   font-size: 10pt;
+   vertical-align: top; text-align: left;
+}
+
+table.attrs {margin-top: 5px}
+/*]]>*/
+</style>
+<link rel="stylesheet" type="text/css" href="http://www.w3.org/StyleSheets/general.css">
+        
+<style type="text/css">
+<!--
+.new1 {color: green;}
+-->
+</style>
+  </head>
+  <body>
+	<div class="head">
+			<a href="http://www.w3.org/" shape="rect">
+				<img src="http://www.w3.org/Icons/w3c_home" alt="W3C" width="72" height="48">
+			</a>
+			<h1 id="h_ir">
+	            Web of Things (WoT) Thing Description:<br/>
+		        Implementation Report
+            </h1>
+	  <p>
+				<b>Version</b>: 8 November 2018</p>
+	  <p>
+				<b>Contributors</b>:<br>
+	  </p>
+	  <p>
+      Sebastian Kaebisch (Siemens AG) (Editor in Chief)<br/>
+      Takuki Kamiya (Fujitsu Laboratories of America, Inc.)<br/>
+      Others (TBD)
+	   </p>
+
+<p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="http://www.w3.org/"><acronym title="World Wide Web Consortium">W3C</acronym></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="http://www.ercim.org/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+<hr title="Separator for header">
+</div>
+<h2 id="h_toc">
+<a id="toc" shape="rect" name="toc">Table of Contents</a>
+</h2>
+<ul>
+	<li class="tocline">1. <a href="#intro" shape="rect">Introduction</a>
+	<ul>
+		<li class="tocline">1.1 <a href="#objectives" shape="rect">Implementation report objectives</a></li>
+		<li class="tocline">1.2 <a href="#non_objectives" shape="rect">Implementation report non-objectives</a></li>
+	</ul>
+	</li>
+	<li class="tocline">2. <a href="#cr_work" shape="rect">Work during the Candidate Recommendation period</a></li>
+	<li class="tocline">3. <a href="#participate" shape="rect">Participating in the implementation report</a></li>
+	<li class="tocline">4. <a href="#pr_entrance_crit" shape="rect">Entrance criteria for the Proposed Recommendation phase</a></li>
+	<li class="tocline">5. <a href="#report_reqs" shape="rect">Implementation report requirements</a>
+	<ul>
+		<li class="tocline">5.1 <a href="#DetailedReqs" shape="rect">Detailed requirements for implementation report</a></li>
+		<li class="tocline">5.2 <a href="#NotesOnTesting" shape="rect">Notes on testing</a></li>
+		<li class="tocline">5.3 <a href="#out_of_scope" shape="rect">Out of scope</a></li>
+	</ul>
+	</li>
+	<li class="tocline">6. <a href="#systems" shape="rect">Systems</a></li>
+	<li class="tocline">7. <a href="#test_class" shape="rect">Test results</a> 
+    <ul>
+		<li class="tocline">7.1 <a href="#intro_class" shape="rect">Classification of test assertions</a></li>
+	    <li class="tocline">7.2 <a href="#emma_test_assertions" shape="rect">Test assertion results</a></li>
+	</ul>
+	</li>
+	<li class="tocline">
+	<a href="#appendices" shape="rect">Appendices</a>
+	<ul>
+        <li class="tocline">Appendix A. <a href="#ackB" shape="rect">Acknowledgements</a></li>
+	</ul>
+	</li>
+</ul>
+<h2 id="h_intro"><a id="intro" name="intro">1. Introduction</a> </h2>
+<p>The <a href="http://www.w3.org/TR/wot/td">Web of Things (WoT) Thing Description Specification</a>
+   entered the Candidate Recommendation period on XX February 2019.</p>
+
+<p> The planned date for entering Proposed Recommendation is XX March 2019.
+This document
+summarizes the results from the Web of Things (WoT) TD implementation reports received and
+describes the process that the Web of Things (WoT) Working Group followed in preparing the report.</p>
+
+<h4 id="h_objectives"><a id="objectives" name="objectives">1.1 Implementation report objectives</a></h4>
+<ol>
+	<li>Must verify that the specification is implementable.</li>
+</ol>
+<h4 id="h_non_objectives"><a id="non_objectives" name="non_objectives">1.2 Implementation report non-objectives</a></h4>
+<ol>
+	<li>The IR does not attempt conformance testing of implementations.</li>
+</ol>
+<h2 id="h_cr_work"><a id="cr_work" name="cr_work">2. Work during the Candidate Recommendation period</a></h2>
+<p>During the CR period, the Working Group carried out the following activities:</p>
+<ol>
+	<li>Clarification and improvement of the exposition of the specification<br/></li>
+	<li>Disposing of comments that were communicated to the WG during the CR period. 
+        These comments and their resolution are detailed in the 
+          <a href="http://www.w3.org/TR/2019/PR-xxx/disp.html">Disposition of Comments</a> 
+          document for the CR period.</li>
+	<li>Preparation of this Implementation Report.</li>
+</ol>
+<h2 id="h_participate"><a id="participate" name="participate">3. Participating in the implementation report</a></h2>
+<p>Implementors were invited to contribute to the assessment of the W3C Web of Things (WoT)
+Thing Description Specification by submitting  implementation reports describing the 
+coverage of their implementations with respect to the test assertions outlined 
+in the <a href="#test_assertions" shape="rect">table below</a>.</p>
+<p>Implementation reports, comments on this document, or requests made for
+further information were  posted to the Working Group's public
+mailing list <a href="mailto:wot-wg@w3.org">wot-wg@w3.org</a>
+(<a href="http://lists.w3.org/Archives/Public/www-wot/">archive</a>)
+and as issues on the github repository i
+<a href="https://github.com/w3c/wot-thing-description">https://github.com/w3c/wot-thing-description</a>.</p>
+<h2 id="h_pr_entrance_crit"><a id="pr_entrance_crit" name="pr_entrance_crit">
+4. Entrance criteria for the Proposed Recommendation phase</a></h2>
+<p>The Web of Things (WoT) Working Group established the following
+entrance criteria for the Proposed Recommendation phase in the
+Request for CR:</p>
+<ol>
+<li>Sufficient reports of implementation experience have been
+gathered to demonstrate that Things can be described by Thing Descriptions 
+in sufficient detail to allow interoperabilty.</li>
+<li>Specific Implementation Report Requirements (<a href="#report_reqs">outlined below</a>) have been met.</li>
+<li>The Working Group has formally addressed and responded to all 
+    public comments received by the Working Group.</li>
+</ol>
+<p>All three of these criteria have been met. A total of N 
+implementations were documented by M different organizations.
+The testimonials below indicate the broad base of support 
+for the specification. All of the required features had at least
+two implementations. 
+All of the optional features received at least two implementations.
+However, these optional features do not have 
+conformance requirements that have an impact on interoperability. </p>
+<h2 id="h_report_reqs"><a id="report_reqs" name="report_reqs">5. Implementation report requirements</a></h2>
+<h4 id="h_DetailedReqs">
+<a id="DetailedReqs" shape="rect" name="DetailedReqs">5.1 Detailed requirements for implementation report</a></h4>
+<ol>
+	<li>Testimonials from implementers are included in the IR when
+provided to document the utility and implementability of the
+specification.</li>
+	<li>IR must cover all specified features in the specification. For
+each feature the IR should indicate:
+    <ul>
+	     <li>Feature status: required, optional, other.</li>
+	     <li>Feature utility/usefulness based on feedback from
+implementers.</li>
+	     <li>Implementability of the feature specification.</li>
+    </ul>
+    </li>
+    <li>Feature status is a factor in test coverage in the report:
+    <ul>
+		<li>Required specification features must have at least two
+implementations. Implementations that do not implement a required
+specification feature must document the reason for not implementing
+the feature.</li>
+		<li>Optional specification features must have at least one
+implementation. Implementations that do not implement an optional specification
+feature should document the reason for not implementing the
+feature. </li>
+	</ul>
+	</li>
+</ol>
+<div>
+<h4 id="h_NotesOnTesting"><a id="NotesOnTesting" name="NotesOnTesting">5.2 Notes on testing</a></h4>
+<ol>
+    <li>A implementation report must indicate the outcome of evaluating 
+the implementation with respect to each of the test assertions. Possible
+outcomes are "<code>pass</code>", "<code>fail</code>" or
+"<code>not-impl</code>". "</li>
+</ol>
+</div>
+<h4 id="h_out_of_scope"><a id="out_of_scope" name="out_of_scope">5.3 Out of scope</a></h4>
+<div style="margin-left: 2em;">
+<p>This implementation Report will not cover:</p>
+<ul>
+    <li>Combinations of protocols and security schemes not listed in [!BEST-PRACTICES].</li>
+</ul>
+</div>
+<a id="test-systems" name="test-systems"></a>
+<h2 id="h_systems"><a id="test-systems" name="test-systems"></a>
+<a id="systems" name="systems">6. Systems</a></h2>
+<p>This section contains testimonials on the WoT Thing Description specification
+from the N companies and universities that submitted implementation reports.</p>
+<div class="working">
+
+<h3 id="att_ir">Company Name</h3>   
+<h4 id="att_ir_summary">Exec Summary</h4>
+<p>Testimonial and Implementation Description</p>
+
+</div>
+<a id="test-results-xml" name="test-results-xml">
+
+</a><h2 id="h_test_class"><a id="test-results-xml" name="test-results-xml"></a>
+<a id="test_class" name="test_class">7. Test results</a></h2>
+<p>The aim of this section is to describe the range of test assertions
+developed for the 
+<a href="http://www.w3.org/TR/xxx">Web of Things (WoT) Thing Description Specification</a> 
+and summarize the results from the implementation 
+reports received in the CR period.
+The table lists all the assertions that were derived
+from the 
+<a href="http://www.w3.org/TR/xxx">Web of Things (WoT) Thing Description Specification</a>.
+</p> 
+<p>The <b>ID</b> column uniquely identifies the assertion.
+The <b>Feature</b> column indicates the specific elements or attributes which the test assertion applies to.
+The <b>Spec</b> column identifies the section of the specification from which the assertion was derived.
+The <b>Req</b> column is a Y/N value indicating whether the test assertion is for a feature which is required.
+The <b>Sub</b> column is a Y/N value indicating whether the test assertion is a subconstraint which is dependent on the
+implementation of the preceding non subconstraint feature test assertion.
+The <b>Assertion</b> column specifies the semantics of the feature or the constraint which must be met.
+The <b>Result</b> column is annotated with the number of 'pass', 'fail', and 'not implemented' (P/F/NI) in
+the set of implementation reports.
+</p>
+<h4 id="h_intro_class">
+<a id="intro_class" name="intro_class">7.1 Classification of test assertions</a>
+</h4>
+<p>
+ Test assertions are classified into two types,
+ basic test assertions which test for the presence of each feature, and sub 
+ constraints which only apply if that particular feature is implemented.
+ Sub constraints are 
+ marked with 'SUB CONSTRAINT:' in the 'Assertion' field and 'Y' in the Sub field.</p>
+
+<h4 id="test_assertions_h"><a id="test_assertions" name="test_assertions">7.2 Test assertion results</a></h4>
+
+<table class="testlist" summary="assertions and tests" cellspacing="2" cellpadding="2">
+			<tbody>
+				<tr>
+					<th>ID</th>
+					<th>Feature</th>
+					<th>Spec</th>
+					<th>Req</th>
+					<th>Sub</th>
+					<th>Assertion</th>
+					<th colspan="3">Results</th>
+
+				</tr>
+	            <tr>
+					<th colspan="6"></th>
+					<th>P</th>
+					<th>F</th>
+					<th>NI</th>
+				</tr>
+				<tr>
+					<th colspan="9">Section Title</th>
+				</tr>
+				<tr>
+					<td valign="top">number</td>
+					<td valign="top">identifier</td>
+					<td valign="top">
+						<a href="http://www.w3.org/TR/wot-td" target="spec">link</a>
+					</td>
+                    <td>req</td><td>sub</td>
+					<td valign="top">Assertion Text</td>
+					<td>pass</td>
+					<td>fail</td>
+					<td>not-impl</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<h1 id="h_appendices">
+			<a id="appendices" name="appendices">Appendices</a></h1>
+
+<!-- automatically extracted assertion list will go here -->
+<h2 id="h_assertions">
+<a id="assertionsB" name="assertions">Appendix A -
+Normative Assertions</a>
+</h2>
+		
+<h2 id="h_ack">
+			<a id="ackB" name="ack">Appendix B -
+Acknowledgements</a>
+		</h2>
+		<p>The Web of Things Working Group would like to acknowledge the contributions of several individuals:</p>
+		<ul>
+		<li>TBD</li>
+		</ul>
+<div class="navbar">
+			<hr>
+		</div>
+</body></html>

--- a/testing/plan.html
+++ b/testing/plan.html
@@ -226,7 +226,7 @@ EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
   When a Thing Description instance is processed and interpreted by 
   a JSON-LD 1.1 processor, 
   each <code>property</code> MUST contain the vocabulary terms 
-  <code>observable</code> and <code>writable</code> due to the 
+  <code>observable</code> and <code>readOnly</code> due to the 
   <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>
   of Linked Data.
   </span><ul><li><span class="testspec" id="td-property-defaults">
@@ -375,7 +375,7 @@ EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
   When a Thing Description instance is processed and interpreted 
   by a JSON-LD 1.1 processor, 
   each <code>forms</code> (array) entry 
-  MUST contain a <code>contenttype</code> 
+  MUST contain a <code>contentType</code> 
   due to the
   <a href="https://en.wikipedia.org/wiki/Open-world_assumption">open-world assumption</a>
   of Linked Data.
@@ -469,19 +469,13 @@ EXAMPLE EXIST BUT NOT EXPLICITELY DONE FOR THIS ASSERTION
 	ASSERTION NOT CLEAR
 </li>
 </ul>
-</span></li></ul></dd><dt><a href="../index.html#td-writable-observable-default">td-writable-observable-default</a>: <strong>MUST</strong></dt><dd class="td-writable-observable-default"><span class="rfc2119-assertion" id="td-writable-observable-default">
-  If the key terms <code>writable</code> and/or <code>observable</code> 
+</span></li></ul></dd><dt><a href="../index.html#td-readOnly-observable-default">td-readOnly-observable-default</a>: <strong>MUST</strong></dt><dd class="td-readOnly-observable-default"><span class="rfc2119-assertion" id="td-readOnly-observable-default">
+  If the key terms <code>readOnly</code> and/or <code>observable</code> 
   are not present within a <code>properties</code> definition,
   the default value defined in <a href="#sec-vocabulary-definition"></a>
   MUST be assumed.
-  </span><ul><li><span class="testspec" id="td-writable-observable-default">
-<ul>
-<li>	
-	HOW TO TEST?
-</li>
-</ul>
-</span></li></ul></dd><dt><a href="../index.html#td-media-type-default">td-media-type-default</a>: <strong>MUST</strong></dt><dd class="td-media-type-default"><span class="rfc2119-assertion" id="td-media-type-default">
-  If the <code>contenttype</code> key term is not present within a 
+  </span><ul><li><strong>NO TEST SPECIFICATION</strong></li></ul></dd><dt><a href="../index.html#td-media-type-default">td-media-type-default</a>: <strong>MUST</strong></dt><dd class="td-media-type-default"><span class="rfc2119-assertion" id="td-media-type-default">
+  If the <code>contentType</code> key term is not present within a 
   <code>forms</code> definition, the default value as defined in
   <a href="#sec-vocabulary-definition"></a>
   MUST be assumed.   


### PR DESCRIPTION
I took the EMMA implementation report from [here](https://www.w3.org/2002/mmi/2008/emma-ir/) and ripped out all EMMA-specific material, creating a template for our own implementation report.   See testing/ex.html.

I have not yet updated my tool to put extracted assertions in the table although that would be possible; but I figure we should discuss first.

At any rate there are other sections in here we can start filling out, like the descriptions of the various implementations and testimonials.

(Never mind the plan.html, I updated the extracted assertions while I was at it).