### PR TITLE
Split the @context assertion into two as discussed in TD telecon.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1324,9 +1324,9 @@
       within <code>security</code> blocks in which case this requirement may be relaxed.
       </p>
 
-        <section><h3><code>Thing</code></h3><p>Describes a physical and/or virtual Thing (may represent one or more physical and/or virtual Things) in the Web of Things context. When a concrete Thing is defined in a Thing Description, it is called an "thing resource".</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Mandatory</th><th>Type</th></tr></thead><tbody><tr><td><code>@context</code></td><td>Known from JSON-LD, <code>@context</code> is used to define short-hand names called terms that are used throughout a TD document.</td><td>yes</td><td>array</td></tr><tr><td><code>@type</code></td><td>Known from JSON-LD, <code>@type</code> is used to state that a thing resource is an instance of a class. One or more classes can be specified.<br/><br/> Each string in the value array represents a class.</td><td>no</td><td>array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr><td><code>id</code></td><td>unique identifier of the Thing (URI, e.g. custom URN).</td><td>yes</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-name
-names"><td><code>name
-names</code></td><td>Name of the Thing.</td><td>yes</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+        <section><h3><code>Thing</code></h3><p>Describes a physical and/or virtual Thing (may represent one or more physical and/or virtual Things) in the Web of Things context.</p><p>When a concrete Thing is defined in a Thing Description, it is called a <dfn>thing resource</dfn></p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Mandatory</th><th>Type</th></tr></thead><tbody><tr><td><code>@context</code></td><td>Known from JSON-LD, <code>@context</code> is used to define short-hand names called terms that are used throughout a TD document.</td><td>yes</td><td>array</td></tr><tr><td><code>@type</code></td><td>Known from JSON-LD, <code>@type</code> is used to state that a thing resource is an instance of a class. One or more classes can be specified.<br/><br/> Each string in the value array represents a class.</td><td>no</td><td>array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr><td><code>id</code></td><td>unique identifier of the Thing (URI, e.g. custom URN).</td><td>yes</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-names
+name"><td><code>names
+name</code></td><td>Name of the Thing.</td><td>yes</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions
 description"><td><code>descriptions
 description</code></td><td>Provides additional (human-readable) information based on a default language.</td><td>no</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
@@ -1343,7 +1343,18 @@ description</code></td><td>Provides additional (human-readable) information base
 <tr class="rfc2119-table-assertion" id="td-vocab-forms"><td><code>forms</code></td><td>Indicates one or more endpoints at which operation(s) on this resource are accessible. In this version of TD, all operations that can be described at the Thing level are concerning how to interact with the Thing's <a href="#property">Property</a> interaction resources collectively at once.</td><td>no</td><td>array of <a href="#form"><code>Form</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-security"><td><code>security</code></td><td>Set of security definition names, chosen from those defined in securityDefinitions.  These must all be satisfied for access to resources at or below the current level, if not overridden at a lower level.</td><td>yes</td><td>array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions"><td><code>securityDefinitions</code></td><td>Set of named security configurations (definitions only).  Not actually applied unless names are used in a security section.</td><td>yes</td><td><a href="#securityscheme"><code>SecurityScheme</code></a></td></tr></tbody></table>
-<p id="meta-interactions-of-thing">Similar to <a href="#propertyaffordance" class="sec-ref">Pattern</a>, 
+<p>
+     <span class="rfc2119-assertion" id="td-context-ns-thing-mandatory">The mandatory
+     context definition <code>"http://www.w3.org/ns/td"</code> MUST be the first item in 
+     the JSON-LD context array <code>@context</code>.</span>
+     <span class="rfc2119-assertion" id="td-context-ns-thing-optional">The mandatory
+     context definition MAY be followed by one or more local namespaces.</span>
+</p>
+<p>
+     <span class="rfc2119-assertion" id="td-context-ns-thing-prefix">Each optional
+     namespace specifed for a Thing context MUST be bound to an unique prefix.</span>
+</p>
+<p id="meta-interactions-of-thing">Similar to <a href="#propertyaffordance" class="sec-ref">PropertyAffordance</a>, 
     <a href="#actionaffordance" class="sec-ref">ActionAffordance</a> and 
     <a href="#eventaffordance" class="sec-ref">EventAffordance</a> classes, all of which are 
     subclasses of <a href="#interactionaffordance" class="sec-ref">
@@ -1355,7 +1366,7 @@ description</code></td><td>Provides additional (human-readable) information base
     <code>readallproperties</code>, <code>writeallproperties</code>, 
     <code>readmultipleproperties</code> or <code>writemultipleproperties</code>.
     </span>
-    (See <a href="#td-forms-readall-example"> an example.</a>)
+    (See <a href="#td-forms-readall-example"> an example</a> for an usage of <code>form</code> in a <a>thing resource</a>.)
 </p>
 <p>
     For <code>readallproperties</code> operation's output, 
@@ -1366,15 +1377,6 @@ description</code></td><td>Provides additional (human-readable) information base
     For <code>readmultipleproperties</code> operation's input, payloads are
     assigned a string array type schema with its items each equal to one of the names of
     The Thing's property resources.
-</p>
-<p>
-     <span class="rfc2119-assertion" id="td-context-ns-thing-optional">The mandatory
-     context definition <code>"http://www.w3.org/ns/td"</code> MAY be followed by one or
-     more local namespaces.</span>
-</p>
-<p>
-     <span class="rfc2119-assertion" id="td-context-ns-thing-prefix">Each optional
-     namespace specifed for a Thing context MUST be bound to an unique prefix.</span>
 </p>
 </section>
 <section><h3><code>InteractionAffordance</code></h3><p>Three interaction affordance are defined as subclasses: Property-, Action- and Event-based affordance. When a concrete Property, Action or Event is defined in a Thing Description, it is called an "interaction resource". Interactions between Things can be as simple as one Thing accessing another Thing's data to get or (in the case the data is also writable) change the representation of data such as metadata, status or mode. A Thing may also be interested in getting asynchronously notified of future changes in another Thing, or may want to initiate a process served in another Thing that may take some time to complete and monitor the progress. Interactions between Things may involve exchanges of data between them. This data can be either given as input by the client Thing, returned as output by the server Thing or both.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Mandatory</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-title"><td><code>title</code></td><td>Provides a human-readable title (e.g., display a text for UI representation) of the interaction pattern based on a default language.</td><td>no</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
@@ -1460,11 +1462,13 @@ For example, for HTTP and Events, it indicates which of several available mechan
 <tr class="rfc2119-table-assertion" id="td-vocab-anchor"><td><code>anchor</code></td><td>By default, the context of a link is the URL of the representation it is associated with, and is serialised as a URI. When present, the anchor parameter overrides this with another URI, such as a fragment of this resource, or a third resource (i.e., when the anchor value is an absolute URI).</td><td>no</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr></tbody></table></section>
 <section><h3><code>VersionInfo</code></h3><p>Carries version information about the TD instance. If required, additional version information such as firmware and hardware version (term definitions outside of the TD namespace) can be extended here.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Mandatory</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-instance"><td><code>instance</code></td><td>Provides a version identicator of this TD instance.</td><td>yes</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
 <section><h3><code>ExpectedResponse</code></h3><p>Communication metadata for response messages (e.g., contentType of the response).</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Mandatory</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-contentType"><td><code>contentType</code></td><td>Assign a content type based on a media type [[!IANA-MEDIA-TYPES]] (e.g., 'application/json) and (optional) parameters (e.g., 'charset=utf-8').</td><td>yes</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>MultiLanguage</code></h3><p>Container to provide human-readable text in different languages using language tags described in [[!BCP47]]. Each used language tags code MUST be decleared as vocabulary term member of this container (e.g., en, de, ja, zh-Hans, zh-Hant).</p>
+<section><h3><code>MultiLanguage</code></h3><p>Container to provide human-readable text in different languages using language tags described in [[!BCP47]]. Each used language tags code MUST be decleared as vocabulary term member of this container (e.g., en, de, ja, zh-Hans, zh-Hant). See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
 <p>
+<span class="rfc2119-assertion" id="td-context-ns-multilanguage-content-negotiation">
 Note that in protocols such as HTTP that have an ability to negotiate content based on languages, 
-those terms (e.g. <code>description</code> and <code>title</code>) intended for carrying texts in a default language SHOULD be used instead of this container
+those terms (e.g. <code>description</code> and <code>title</code>) intended for carrying texts in a default language SHOULD be used instead of <code>MultiLanguage</code> container
 when the texts are served as a result such negotiation.
+</span>
 </p>
 </section>
 

--- a/ontology/td.ttl
+++ b/ontology/td.ttl
@@ -888,7 +888,7 @@ For example, for HTTP and Events, it indicates which of several available mechan
                          owl:allValuesFrom :Form
                        ];
        
-       rdfs:comment "Describes a physical and/or virtual Thing (may represent one or more physical and/or virtual Things) in the Web of Things context. When a concrete Thing is defined in a Thing Description, it is called an \"thing resource\"."@en .
+       rdfs:comment "Describes a physical and/or virtual Thing (may represent one or more physical and/or virtual Things) in the Web of Things context."@en .
 
 
 ###  http://www.w3.org/ns/td#MultiLanguage

--- a/templates.txt
+++ b/templates.txt
@@ -29,6 +29,9 @@ prefix jsonld: <http://www.w3.org/ns/json-ld#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix : <http://w3c.github.io/wot-thing-description/#>
 template :fields(?class) {
+    if(?class = <http://www.w3.org/ns/td#Thing>, 
+        "<p>When a concrete Thing is defined in a Thing Description, it is called a <dfn>thing resource</dfn></p>",
+        "")
     "<table class=\"def\">"
         "<thead>"
             "<tr>"
@@ -341,8 +344,12 @@ prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix : <http://w3c.github.io/wot-thing-description/#>
 template :desc(?term) {
     format {
-        "%s"
+        "%s%s"
         if(strends(?desc, "."), ?desc, concat(?desc, "."))
+        if(?term = <http://www.w3.org/ns/td#MultiLanguage>, 
+            " See <a href=\"#titles-descriptions-serialization-json\"></a> for example usages of this container in a Thing Description instance.",
+            "")
+
     } ; separator = " "
 } where {
     ?term rdfs:comment ?desc .

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -21,7 +21,18 @@
     sh:order "1"^^xsd:integer ;
     sh:description
 """
-<p id="meta-interactions-of-thing">Similar to <a href="#propertyaffordance" class="sec-ref">Pattern</a>, 
+<p>
+     <span class=\"rfc2119-assertion\" id=\"td-context-ns-thing-mandatory\">The mandatory
+     context definition <code>"http://www.w3.org/ns/td"</code> MUST be the first item in 
+     the JSON-LD context array <code>@context</code>.</span>
+     <span class=\"rfc2119-assertion\" id=\"td-context-ns-thing-optional\">The mandatory
+     context definition MAY be followed by one or more local namespaces.</span>
+</p>
+<p>
+     <span class=\"rfc2119-assertion\" id=\"td-context-ns-thing-prefix\">Each optional
+     namespace specifed for a Thing context MUST be bound to an unique prefix.</span>
+</p>
+<p id="meta-interactions-of-thing">Similar to <a href="#propertyaffordance" class="sec-ref">PropertyAffordance</a>, 
     <a href="#actionaffordance" class="sec-ref">ActionAffordance</a> and 
     <a href="#eventaffordance" class="sec-ref">EventAffordance</a> classes, all of which are 
     subclasses of <a href="#interactionaffordance" class="sec-ref">
@@ -33,7 +44,7 @@
     <code>readallproperties</code>, <code>writeallproperties</code>, 
     <code>readmultipleproperties</code> or <code>writemultipleproperties</code>.
     </span>
-    (See <a href="#td-forms-readall-example"> an example.</a>)
+    (See <a href="#td-forms-readall-example"> an example</a> for an usage of <code>form</code> in a <a>thing resource</a>.)
 </p>
 <p>
     For <code>readallproperties</code> operation's output, 
@@ -44,15 +55,6 @@
     For <code>readmultipleproperties</code> operation's input, payloads are
     assigned a string array type schema with its items each equal to one of the names of
     The Thing's property resources.
-</p>
-<p>
-     <span class=\"rfc2119-assertion\" id=\"td-context-ns-thing-optional\">The mandatory
-     context definition <code>"http://www.w3.org/ns/td"</code> MAY be followed by one or
-     more local namespaces.</span>
-</p>
-<p>
-     <span class=\"rfc2119-assertion\" id=\"td-context-ns-thing-prefix\">Each optional
-     namespace specifed for a Thing context MUST be bound to an unique prefix.</span>
 </p>
 """^^rdf:HTML ;
     sh:property [
@@ -400,9 +402,11 @@
     sh:description
 """
 <p>
+<span class=\"rfc2119-assertion\" id=\"td-context-ns-multilanguage-content-negotiation\">
 Note that in protocols such as HTTP that have an ability to negotiate content based on languages, 
-those terms (e.g. <code>description</code> and <code>title</code>) intended for carrying texts in a default language SHOULD be used instead of this container
+those terms (e.g. <code>description</code> and <code>title</code>) intended for carrying texts in a default language SHOULD be used instead of <code>MultiLanguage</code> container
 when the texts are served as a result such negotiation.
+</span>
 </p>
 """^^rdf:HTML ;
     sh:property [


### PR DESCRIPTION
Related to PR #435, split @context requirements into two assertions as discussed in TD telecon.