### PR TITLE
op member in form has context-dependent enumerated values (issue #236)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4249,7 +4249,8 @@ returned by a target Thing acting as a server.
                             "enum": [
                                 "readproperty",
                                 "writeproperty",
-                                "observeproperty"
+                                "observeproperty",
+                                "unobserveproperty"
                             ]
                         },
                         {
@@ -4259,7 +4260,8 @@ returned by a target Thing acting as a server.
                                 "enum": [
                                     "readproperty",
                                     "writeproperty",
-                                    "observeproperty"
+                                    "observeproperty",
+                                    "unobserveproperty"
                                 ]
                             }
                         }

--- a/index.html
+++ b/index.html
@@ -1397,7 +1397,7 @@
     the <code>forms</code> term. 
     <span class="rfc2119-assertion" id="td-op-for-thing">
     When a <code>forms</code> term member is present in a Thing instance, 
-    the value(s) of <code>op</code> in the <code>forms</code> MUST be one of 
+    the value(s) in the <code>op</code> term member of the <code>forms</code> MUST be one or more of 
     <code>readallproperties</code>, <code>writeallproperties</code>, 
     <code>readmultipleproperties</code> or <code>writemultipleproperties</code>.
     </span>
@@ -1436,8 +1436,8 @@
     class="sec-ref">InteractionAffordance</a>. 
     <span class="rfc2119-assertion" id="td-op-for-property">
     When a <code>forms</code> term member is present in a Property instance, 
-    the value(s) of <code>op</code> in the <code>forms</code> MUST be one of 
-    <code>readproperty</code>, <code>writeproperty</code> or <code>observeproperty</code>.
+    the value(s) in the <code>op</code> term member of the <code>forms</code> MUST be one or more of 
+    <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code> or <code>unobserveproperty</code>.
     </span>
 </p>
 <p class="note">
@@ -1456,7 +1456,7 @@
     class="sec-ref">InteractionAffordance</a>.
     <span class="rfc2119-assertion" id="td-op-for-action">
     When a <code>forms</code> term member is present in an Action instance, 
-    the value(s) of <code>op</code> in the <code>forms</code> MUST be 
+    the value in the <code>op</code> term member of the <code>forms</code> MUST be 
     <code>invokeaction</code>.
     </span>
 </p>
@@ -1468,8 +1468,8 @@
     class="sec-ref">InteractionAffordance</a>.
     <span class="rfc2119-assertion" id="td-op-for-event">
     When a <code>forms</code> term member is present in an Event instance, 
-    the value(s) of <code>op</code> in the <code>forms</code> MUST be one of 
-    <code>subscribeevent</code> or <code>unsubscribeevent</code>.
+    the value(s) in the <code>op</code> term member of the <code>forms</code> MUST be either or both of 
+    <code>subscribeevent</code> or/and <code>unsubscribeevent</code>.
     </span>
 </p>
 </section></section>

--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -350,7 +350,8 @@
                             "enum": [
                                 "readproperty",
                                 "writeproperty",
-                                "observeproperty"
+                                "observeproperty",
+                                "unobserveproperty"
                             ]
                         },
                         {
@@ -360,7 +361,8 @@
                                 "enum": [
                                     "readproperty",
                                     "writeproperty",
-                                    "observeproperty"
+                                    "observeproperty",
+                                    "unobserveproperty"
                                 ]
                             }
                         }

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -51,7 +51,7 @@
     the <code>forms</code> term. 
     <span class="rfc2119-assertion" id="td-op-for-thing">
     When a <code>forms</code> term member is present in a Thing instance, 
-    the value(s) of <code>op</code> in the <code>forms</code> MUST be one of 
+    the value(s) in the <code>op</code> term member of the <code>forms</code> MUST be one or more of 
     <code>readallproperties</code>, <code>writeallproperties</code>, 
     <code>readmultipleproperties</code> or <code>writemultipleproperties</code>.
     </span>
@@ -211,8 +211,8 @@
     class="sec-ref">InteractionAffordance</a>. 
     <span class="rfc2119-assertion" id="td-op-for-property">
     When a <code>forms</code> term member is present in a Property instance, 
-    the value(s) of <code>op</code> in the <code>forms</code> MUST be one of 
-    <code>readproperty</code>, <code>writeproperty</code> or <code>observeproperty</code>.
+    the value(s) in the <code>op</code> term member of the <code>forms</code> MUST be one or more of 
+    <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code> or <code>unobserveproperty</code>.
     </span>
 </p>
 <p class="note">
@@ -240,7 +240,7 @@
     class="sec-ref">InteractionAffordance</a>.
     <span class="rfc2119-assertion" id="td-op-for-action">
     When a <code>forms</code> term member is present in an Action instance, 
-    the value(s) of <code>op</code> in the <code>forms</code> MUST be 
+    the value in the <code>op</code> term member of the <code>forms</code> MUST be 
     <code>invokeaction</code>.
     </span>
 </p>
@@ -280,8 +280,8 @@
     class="sec-ref">InteractionAffordance</a>.
     <span class="rfc2119-assertion" id="td-op-for-event">
     When a <code>forms</code> term member is present in an Event instance, 
-    the value(s) of <code>op</code> in the <code>forms</code> MUST be one of 
-    <code>subscribeevent</code> or <code>unsubscribeevent</code>.
+    the value(s) in the <code>op</code> term member of the <code>forms</code> MUST be either or both of 
+    <code>subscribeevent</code> or/and <code>unsubscribeevent</code>.
     </span>
 </p>
 """^^rdf:HTML ;


### PR DESCRIPTION
Property - "readproperty", "writeproperty", "observeproperty", "unobserveproperty"
Action - "invokeaction"
Event - "subscribeevent", "unsubscribeevent"
Thing - "readallproperties", "writeallproperties", "readmultipleproperties", "writemultipleproperties"
