### PR TITLE
Update TAG submit message to be consistent with WoT Architecture

### DIFF
--- a/explainer/TAG_W3C_Thing_Description.md
+++ b/explainer/TAG_W3C_Thing_Description.md
@@ -27,7 +27,7 @@ In the Thing Description specification, text and table entries highlighted with 
 - The related [WoT Architecture](https://github.com/w3c/wot-architecture) document is being submitted for TAG review at the same time.
     - Tests of implementations will be associated with this document
 - The [WoT Binding Templates](https://github.com/w3c/wot-binding-templates) informative WG note describing an optional WoT building block.
-- The [WoT Scripting API](https://github.com/w3c/wot-binding-templates) informative WG note describing an optional WoT building block.
+- The [WoT Scripting API](https://github.com/w3c/wot-scripting-api) informative WG note describing an optional WoT building block.
 
 During the TAG review period, we plan to update the test results to reduce the number of at-risk assertions as much as possible before CR submission. 
 
@@ -36,10 +36,4 @@ We'd prefer the TAG provide feedback as (please select one):
   - [x] open issues in our Github repo for each point of feedback
   - [ ] open a single issue in our Github repo for the entire review
   - [ ] leave review feedback as a comment in this issue and @-notify [github usernames]
-
---------------------------
-
-_Please preview the issue and check that the links work before submitting_
-
-For background, see our [explanation of how to write a good explainer](https://w3ctag.github.io/explainers).
 

--- a/explainer/TAG_W3C_Thing_Description.md
+++ b/explainer/TAG_W3C_Thing_Description.md
@@ -2,23 +2,34 @@ Góðan dag TAG！
 
 I'm requesting a TAG review of:
 
-  - Name: Web of Things (WoT) Thing Description
-  - Specification URL: tbd for the freezed version for TAG review
+  - Name: _Web of Things (WoT) Thing Description_
+  - Specification URL: http://w3c.github.io/wot-thing-description/
   - Explainer, Requirements Doc, or Example code:  https://github.com/w3c/wot-thing-description/blob/master/explainer/Explainer.md
   - Tests: https://w3c.github.io/wot-thing-description/testing/report.html
   - Primary contacts: @sebastiankb, @takuki, @mmccool, @vcharpenay
 
 Further details (optional):
 
-  - Relevant time constraints or deadlines: if possible end of March
-  - [x] I have read and filled out the [Self-Review Questionnare on Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/). The [assessment is here](url). 
+  - Relevant time constraints or deadlines: 
+     * TAG review feedback need by April 5th
+     * CR transition planned for April 9th
+        - last possible date to make June 25 deadline for REC
+        - end of WG charter is June 30
+
+  - [x] I have read and filled out the [Self-Review Questionnare on Security and Privacy](https://www.w3.org/TR/security-privacy-questionnaire/). The [assessment is here](https://github.com/w3c/wot-architecture/blob/master/proposals/security_and_privacy.md); this assessment is shared with all _Web of Things_ documents.
   - [X] I have reviewed the TAG's [API Design Principles](https://w3ctag.github.io/design-principles/)
 
 You should also know that...
 
 In the Thing Description specification, text and table entries highlighted with a yellow background indicates a feature associated with an at-risk assertion for which insufficient implementation experience exists. When an entire section is at-risk the words "This section is at risk." will be placed at the start of the section and highlighted with a yellow background.
 
-In the meantime of the TAG review, we are continue and update the test results to reduce the number of at-risk assertions before CR submit. 
+- The [WoT Security and Privacy Considerations](https://github.com/w3c/wot-security/) document provides extra discussion of security with an IoT focus.
+- The related [WoT Architecture](https://github.com/w3c/wot-architecture) document is being submitted for TAG review at the same time.
+    - Tests of implementations will be associated with this document
+- The [WoT Binding Templates](https://github.com/w3c/wot-binding-templates) informative WG note describing an optional WoT building block.
+- The [WoT Scripting API](https://github.com/w3c/wot-binding-templates) informative WG note describing an optional WoT building block.
+
+During the TAG review period, we plan to update the test results to reduce the number of at-risk assertions as much as possible before CR submission. 
 
 We'd prefer the TAG provide feedback as (please select one):
 


### PR DESCRIPTION
Refer to same questionnaire responses as WoT Architecture, so that document covers both submissions.