### PR TITLE
Recovering the tweak (#476 and #491) to avoid getting the egregious link presentation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -951,26 +951,7 @@ _:b6 &lt;http://www.w3.org/ns/td#href&gt; &quot;https://mylamp.example.com/statu
 
   </section>
 
-  <section>
-  <h1>Conformance</h1>
-  <p>
-  As well as all sections marked as non-normative, 
-  all authoring guidelines, diagrams, examples, and notes in this specification 
-  are non-normative. 
-  Everything else in this specification is normative.
-  </p>
-  <p>
-  The key words 
-  <em title="MUST" class="rfc2119">MUST</em>, 
-  <em title="MUST NOT" class="rfc2119">MUST NOT</em>, 
-  <em title="REQUIRED" class="rfc2119">REQUIRED</em>, 
-  <em title="SHOULD" class="rfc2119">SHOULD</em>, 
-  <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em>, 
-  <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em>, 
-  <em title="MAY" class="rfc2119">MAY</em>,
-  and <em title="OPTIONAL" class="rfc2119">OPTIONAL</em> 
-  in this specification are to be interpreted as described in [[!RFC2119]].
-  </p>
+  <section id="conformance">
   <p>
   A Thing Description instance complies with this specification if it follows 
   the normative statements in Section 

--- a/index.template.html
+++ b/index.template.html
@@ -687,26 +687,7 @@ _:b6 &lt;http://www.w3.org/ns/td#href&gt; &quot;https://mylamp.example.com/statu
 
   </section>
 
-  <section>
-  <h1>Conformance</h1>
-  <p>
-  As well as all sections marked as non-normative, 
-  all authoring guidelines, diagrams, examples, and notes in this specification 
-  are non-normative. 
-  Everything else in this specification is normative.
-  </p>
-  <p>
-  The key words 
-  <em title="MUST" class="rfc2119">MUST</em>, 
-  <em title="MUST NOT" class="rfc2119">MUST NOT</em>, 
-  <em title="REQUIRED" class="rfc2119">REQUIRED</em>, 
-  <em title="SHOULD" class="rfc2119">SHOULD</em>, 
-  <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em>, 
-  <em title="RECOMMENDED" class="rfc2119">RECOMMENDED</em>, 
-  <em title="MAY" class="rfc2119">MAY</em>,
-  and <em title="OPTIONAL" class="rfc2119">OPTIONAL</em> 
-  in this specification are to be interpreted as described in [[!RFC2119]].
-  </p>
+  <section id="conformance">
   <p>
   A Thing Description instance complies with this specification if it follows 
   the normative statements in Section 


### PR DESCRIPTION
This tweak was introduced by @k-toumura -san twice, but was later overridden multiple times. 