### PR TITLE
Clarify WoT/OpenAPI relationship

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -976,20 +976,16 @@ _:b6 &lt;http://www.w3.org/ns/td#href&gt; &quot;https://mylamp.example.com/statu
       or already in wide use with those protocols.  
       The current set of HTTP security schemes is partly based on 
       <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject">OpenAPI 3.0.1</a> (see also [[?OPENAPI]]). 
-      Note however that while the HTTP security schemes, 
+      However while the HTTP security schemes, 
       vocabulary and syntax given in this specification share many similarities 
-      with OpenAPI they are not fully compatible.  
-      Also, since OpenAPI primarily targets web services built around HTTP, it does not 
-      cover the full set of use cases required for the IoT.  
-      Security schemes appropriate 
-      for IoT-centered protocols such as CoAP [[?RFC7252]] and MQTT [[?MQTT]] are therefore also included.
+      with OpenAPI they are not compatible.  
       </p>
     
       <p class="ednote" title="Security Scheme Extensions">
       The vocabulary extension mechanism of the 
       WoT Thing Description allows for additional security schemes if needed.
-      However, for more information about what additional security schemes 
-      or modifications are under discussion for the core WoT vocabulary
+      For more information about what additional security schemes 
+      or modifications are under discussion
       (and to file issues if you have a request) please visit the 
       <a href="https://github.com/w3c/wot-security">WoT Security TF repository.</a>
       </p>


### PR DESCRIPTION
Addresses Issue https://github.com/w3c/wot-thing-description/issues/201

- Change wording so it simply states the security schemes for WoT and OpenAPI are "not compatible".
- Remove discussion of extra schemes for MQTT and CoAP (since these may not make it in... all are currently at-risk)

Note: There is an ed-note immediately following this pointing at the wot-security repository.  That has been updated to not mention the TD core vocabulary, since at best at this point we can only consider development of extension vocabularies, not new core vocab.   If we add a reference to a formal security scheme extension vocabulary (ontology) document, this would be a good place to put it (replacing the ed note).