### PR TITLE
Update terminology and references

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,36 +92,30 @@
                 , date: "26 December 2017"
                 }
               , "WOT-ARCHITECTURE" : {
-                  title: "Web of Things Architecture"
+                  title: "Web of Things (WoT) Architecture"
                 , href: "https://w3c.github.io/wot-architecture/"
                 , authors:  [
-                    "Kazuo Kajimoto"
-                  , "Matthias Kovatsch"
-                  , "Uday Davuluru"
+                    "Matthias Kovatsch"
+                  , "Ryuichi Matsukura"
+                  , "Michael Lagally"
+                  , "Toru Kawaguchi"
+                  , "Kunihiko Toumura"
+                  , "Kazuo Kajimoto"
                   ]
                 , publisher: "W3C"
-                , date: "20 August 2017"
+                , date: "May 2019"
                 }
               , "WOT-SECURITY-CONSIDERATIONS" : {
-                title: "Web of Things Security and Privacy Considerations"
+                title: "Web of Things (WoT) Security and Privacy Considerations"
                 , href: "https://w3c.github.io/wot-security/"
                 , authors:  [
                   , "Michael McCool"
                   , "Elena Reshetova"
                   ]
                 , publisher: "W3C"
-                , date: "28 August 2017"
+                , date: "March 2019"
                 }
-	      , "WoT-Binding-Templates" : {
-                  title: "Web of Things Protocol Binding Templates"
-                , href: "https://w3c.github.io/wot-binding-templates/"
-                , authors:  [
-                    "Michael Koster"
-                  ]
-                , publisher: "W3C"
-                , date: "12 January 2018"
-                }
-	      , "MQTT" : {
+	            , "MQTT" : {
                   title: "MQTT Version 5.0"
                 , href: "http://docs.oasis-open.org/mqtt/mqtt/v5.0/cos01/mqtt-v5.0-cos01.html"
                 , authors:  [
@@ -134,7 +128,7 @@
                 , date: "31 October 2018"
                 , status: "Candidate OASIS Standard 01"
                 }
-	      , "draft-ietf-ace-oauth-authz" : {
+	            , "draft-ietf-ace-oauth-authz" : {
                   title: "Authentication and Authorization for Constrained Environments (ACE) using the OAuth 2.0 Framework (ACE-OAuth)"
                 , href: "https://tools.ietf.org/html/draft-ietf-ace-oauth-authz-24"
                 , authors:  [
@@ -176,13 +170,19 @@
             };
     </script>
 <style>
+a[href].internalDFN {
+    color: inherit;
+    border-bottom: 1px solid #99c;
+    text-decoration: none;
+}
+
 .example {
 		border-color: #EA1252;
 		background: #FEF11E;
 		counter-increment: example;
 		overflow: auto;
 		clear: both;
-	}
+}
 
 .with-default .with-default-control {
     margin-top: 1em;
@@ -882,12 +882,18 @@
 
   <section id="terminology"> 
   <h2>Terminology</h2>
-  <p>The generic WoT terminology is defined in [[WOT-ARCHITECTURE]]: 
-  <dfn data-lt="Things">Thing</dfn>, 
-  <dfn data-lt="Thing Descriptions">Thing Description</dfn> 
-    (in short <dfn>TD</dfn>), 
-  <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  
-  <dfn>WoT Interface</dfn> etc.
+  <p>The fundamental WoT terminology such as
+  <dfn>Thing</dfn>, 
+  <dfn>Consumer</dfn>,
+  <dfn>Interaction Model</dfn>,
+  <dfn>Interaction Affordance</dfn>,
+  <dfn>Property</dfn>,
+  <dfn>Action</dfn>,
+  <dfn>Event</dfn>,
+  <dfn>Protocol Binding</dfn>,
+  <dfn>Servient</dfn>,
+  <dfn>WoT Runtime</dfn>,
+  etc. is defined in [[WOT-ARCHITECTURE]], Section 2.
   </p>
 
   <p>
@@ -940,7 +946,7 @@
     </dt>
     <dd>
         A class name (like <code>Thing</code>), a property name (like
-        <code>forms</code>) or a property value (like <code>readproperty</code>).
+        <code>forms</code>), or a property value (like <code>readproperty</code>).
     </dd>
   </dl>
   </section>
@@ -2169,7 +2175,7 @@ In summary, this requires the following:
 <p>
 Please note that the definition of the Event affordance is defined flexible
 in order to adopt existing (e.g., WebSub) or customer-oriented event mechanisms (e.g., Webhooks).
-For this reason, <code>subscription</code> and <code>cancellation</code> can be defined according to the desired mechanism. Please find further details in [[WoT-Binding-Templates]].
+For this reason, <code>subscription</code> and <code>cancellation</code> can be defined according to the desired mechanism.
 Example <a href="#t2t-event-example-serialization"></a> provides a Thing-to-Thing (T2T) use case that offers an event and uses <code>subscription</code> and <code>cancellation</code>.
 </p>
 
@@ -3544,13 +3550,11 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       <h4>Other Protocol Bindings</h4>
 
       <p>
-
           The number of WoT Protocol Bindings a WoT Thing can implement
-          is not restricted. Other bindings, e.g. for CoAP, MQTT or OPC UA
+          is not restricted. Other bindings, e.g., for CoAP, MQTT, or OPC UA
           will be standardized in separate documents such as a protocol vocabulary similar to HTTP in RDF [[HTTP-in-RDF10]]
           or specifications including default value definitions. Such protocols can be simply integrated into the TD by the 
-          usage of the context extension mechanism (<a href="#content-extension-section"></a>). A general guideline for Protocol Bindings is given in
-          [[WoT-Binding-Templates]].
+          usage of the context extension mechanism (<a href="#content-extension-section"></a>).
       </p>
   </section>
 </section>

--- a/index.template.html
+++ b/index.template.html
@@ -92,36 +92,30 @@
                 , date: "26 December 2017"
                 }
               , "WOT-ARCHITECTURE" : {
-                  title: "Web of Things Architecture"
+                  title: "Web of Things (WoT) Architecture"
                 , href: "https://w3c.github.io/wot-architecture/"
                 , authors:  [
-                    "Kazuo Kajimoto"
-                  , "Matthias Kovatsch"
-                  , "Uday Davuluru"
+                    "Matthias Kovatsch"
+                  , "Ryuichi Matsukura"
+                  , "Michael Lagally"
+                  , "Toru Kawaguchi"
+                  , "Kunihiko Toumura"
+                  , "Kazuo Kajimoto"
                   ]
                 , publisher: "W3C"
-                , date: "20 August 2017"
+                , date: "May 2019"
                 }
               , "WOT-SECURITY-CONSIDERATIONS" : {
-                title: "Web of Things Security and Privacy Considerations"
+                title: "Web of Things (WoT) Security and Privacy Considerations"
                 , href: "https://w3c.github.io/wot-security/"
                 , authors:  [
                   , "Michael McCool"
                   , "Elena Reshetova"
                   ]
                 , publisher: "W3C"
-                , date: "28 August 2017"
+                , date: "March 2019"
                 }
-	      , "WoT-Binding-Templates" : {
-                  title: "Web of Things Protocol Binding Templates"
-                , href: "https://w3c.github.io/wot-binding-templates/"
-                , authors:  [
-                    "Michael Koster"
-                  ]
-                , publisher: "W3C"
-                , date: "12 January 2018"
-                }
-	      , "MQTT" : {
+	            , "MQTT" : {
                   title: "MQTT Version 5.0"
                 , href: "http://docs.oasis-open.org/mqtt/mqtt/v5.0/cos01/mqtt-v5.0-cos01.html"
                 , authors:  [
@@ -134,7 +128,7 @@
                 , date: "31 October 2018"
                 , status: "Candidate OASIS Standard 01"
                 }
-	      , "draft-ietf-ace-oauth-authz" : {
+	            , "draft-ietf-ace-oauth-authz" : {
                   title: "Authentication and Authorization for Constrained Environments (ACE) using the OAuth 2.0 Framework (ACE-OAuth)"
                 , href: "https://tools.ietf.org/html/draft-ietf-ace-oauth-authz-24"
                 , authors:  [
@@ -176,13 +170,19 @@
             };
     </script>
 <style>
+a[href].internalDFN {
+    color: inherit;
+    border-bottom: 1px solid #99c;
+    text-decoration: none;
+}
+
 .example {
 		border-color: #EA1252;
 		background: #FEF11E;
 		counter-increment: example;
 		overflow: auto;
 		clear: both;
-	}
+}
 
 .with-default .with-default-control {
     margin-top: 1em;
@@ -552,12 +552,18 @@
 
   <section id="terminology"> 
   <h2>Terminology</h2>
-  <p>The generic WoT terminology is defined in [[WOT-ARCHITECTURE]]: 
-  <dfn data-lt="Things">Thing</dfn>, 
-  <dfn data-lt="Thing Descriptions">Thing Description</dfn> 
-    (in short <dfn>TD</dfn>), 
-  <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  
-  <dfn>WoT Interface</dfn> etc.
+  <p>The fundamental WoT terminology such as
+  <dfn>Thing</dfn>, 
+  <dfn>Consumer</dfn>,
+  <dfn>Interaction Model</dfn>,
+  <dfn>Interaction Affordance</dfn>,
+  <dfn>Property</dfn>,
+  <dfn>Action</dfn>,
+  <dfn>Event</dfn>,
+  <dfn>Protocol Binding</dfn>,
+  <dfn>Servient</dfn>,
+  <dfn>WoT Runtime</dfn>,
+  etc. is defined in [[WOT-ARCHITECTURE]], Section 2.
   </p>
 
   <p>
@@ -610,7 +616,7 @@
     </dt>
     <dd>
         A class name (like <code>Thing</code>), a property name (like
-        <code>forms</code>) or a property value (like <code>readproperty</code>).
+        <code>forms</code>), or a property value (like <code>readproperty</code>).
     </dd>
   </dl>
   </section>
@@ -1596,7 +1602,7 @@ In summary, this requires the following:
 <p>
 Please note that the definition of the Event affordance is defined flexible
 in order to adopt existing (e.g., WebSub) or customer-oriented event mechanisms (e.g., Webhooks).
-For this reason, <code>subscription</code> and <code>cancellation</code> can be defined according to the desired mechanism. Please find further details in [[WoT-Binding-Templates]].
+For this reason, <code>subscription</code> and <code>cancellation</code> can be defined according to the desired mechanism.
 Example <a href="#t2t-event-example-serialization"></a> provides a Thing-to-Thing (T2T) use case that offers an event and uses <code>subscription</code> and <code>cancellation</code>.
 </p>
 
@@ -2971,13 +2977,11 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       <h4>Other Protocol Bindings</h4>
 
       <p>
-
           The number of WoT Protocol Bindings a WoT Thing can implement
-          is not restricted. Other bindings, e.g. for CoAP, MQTT or OPC UA
+          is not restricted. Other bindings, e.g., for CoAP, MQTT, or OPC UA
           will be standardized in separate documents such as a protocol vocabulary similar to HTTP in RDF [[HTTP-in-RDF10]]
           or specifications including default value definitions. Such protocols can be simply integrated into the TD by the 
-          usage of the context extension mechanism (<a href="#content-extension-section"></a>). A general guideline for Protocol Bindings is given in
-          [[WoT-Binding-Templates]].
+          usage of the context extension mechanism (<a href="#content-extension-section"></a>).
       </p>
   </section>
 </section>


### PR DESCRIPTION
I updated the term definitions imported from WoT Architecture based on which are used in the TD spec.

I updated the WoT Architecture reference and removed the wrongly normative reference to WoT Binding Templates. It is enough to reference the Binding Templates from the Arch spec.