### PR TITLE
WIP: Major editorial pass

### DIFF
--- a/index.html
+++ b/index.html
@@ -1623,17 +1623,17 @@ op can be assigned one or more interaction verb(s) each representing a semantic 
 For example, for HTTP and Events, it indicates which of several available mechanisms should be used for asynchronous notifications such as long polling, websub (also see https://www.w3.org/TR/websub/), or server sent events (also see https://www.w3.org/TR/eventsource/). Please note that there is no restriction on the sub-protocol selection and other mechanisms can also be announced by this subprotocol term.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-security--Form"><td><code>security</code></td><td>Set of security definition names, chosen from those defined in securityDefinitions.  These must all be satisfied for access to resources.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an OAuth2SecurityScheme active on that form.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table>
-<p>Possible values for the <code>contentCoding</code> property can be found e.g. in
-the <a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
-IANA HTTP content coding registry</a>.
-</p>
-
 <p>The list of possible operation types of a form is fixed. It only includes the
 well-known types necessary to implement the WoT interaction model described in
 [[WOT-ARCHITECTURE]]. Future versions of the standard may extend this list but
 <span class="rfc2119-assertion" id="well-known-operation-types-only">
 operations types SHOULD NOT be arbitrarily set by servients
 </span>.
+</p>
+
+<p>Possible values for the <code>contentCoding</code> property can be found e.g. in
+the <a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
+IANA HTTP content coding registry</a>.
 </p>
 </section>
 <section><h3><code>Link</code></h3><p>A link can be viewed as a statement of the form "link context has a link relation type resource at link target, which has target attributes".</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Link"><td><code>href</code></td><td>target IRI of a link or submission target of a form.</td><td>mandatory</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
@@ -2007,8 +2007,8 @@ In summary, this requires the following:
 
   <p>
   <span class="rfc2119-assertion" id="td-context">
-  The root JSON object of a TD serialization MUST include
-  a member with the name <code>@context</code> and a value of type
+  The root element of a <a>TD Serialization</a> MUST be a JSON object and it MUST
+  include a member with the name <code>@context</code> and a value of type
   string or array that contains <code>https://www.w3.org/2019/td/v1</code>.
   </span>
   In general, this URI is used to identify the
@@ -2083,8 +2083,10 @@ In summary, this requires the following:
   The value assigned to <code>properties</code> in a <code>Thing</code> instance
   is a <a>Map</a> of instances of <code>PropertyAffordance</code>.
   <span class="rfc2119-assertion" id="td-properties">
-    A map of <code>PropertyAffordance</code> instances MUST be serialized as an object
-    with a (unique) JSON name to identify each Property affordance object.
+    All name-value pairs of a <a>Map</a> of <code>PropertyAffordance</code> instances
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    instance of <code>PropertyAffordance</code>, MUST be serialized as a JSON object.
   </span></p>
 
   <p>
@@ -2092,10 +2094,12 @@ In summary, this requires the following:
     All name-value pairs of an instance of <code>PropertyAffordance</code>,
     where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
     <code>PropertyAffordance</code>, <code>InteractionAffordance</code>, or <code>DataSchema</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>PropertyAffordance</code> instance, with the
+    <a>Vocabulary Term</a> as name.
   </span>
   See <a href="#data-schema-serialization-json" class="sec-ref"></a> for
-  details on the <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> <a>Superclass</a>.
+  details on serializing <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> instances.
   </p>
 
   <p><span class="rfc2119-assertion" id="td-property-arrays">
@@ -2152,15 +2156,19 @@ In summary, this requires the following:
     In a <code>Thing</code> instance, the value assigned to <code>actions</code>
     is a <a>Map</a> of instances of <code>ActionAffordance</code>.
     <span class="rfc2119-assertion" id="td-actions">
-    A map of <code>ActionAffordance</code> instances MUST be serialized as an object
-    with a (unique) JSON name to identify each Action affordance object.
+    All name-value pairs of a <a>Map</a> of <code>ActionAffordance</code> instances
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    instance of <code>ActionAffordance</code>, MUST be serialized as a JSON object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-action-names">
     All name-value pairs of an instance of <code>ActionAffordance</code>,
     where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
     <code>ActionAffordance</code> or <code>InteractionAffordance</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>ActionAffordance</code> instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
@@ -2225,15 +2233,19 @@ In summary, this requires the following:
     In a <code>Thing</code> instance, the value assigned to <code>events</code>
     is a map of instances of <code>EventAffordance</code>.
     <span class="rfc2119-assertion" id="td-events">
-    A map of <code>EventAffordance</code> instances MUST be serialized as an object
-    with a (unique) JSON name to identify each Event affordance object.
+    All name-value pairs of a <a>Map</a> of <code>EventAffordance</code> instances
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    instance of <code>EventAffordance</code>, MUST be serialized as a JSON object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-event-names">
     All name-value pairs of an instance of <code>EventAffordance</code>,
     where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
     <code>EventAffordance</code> or <code>InteractionAffordance</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>EventAffordance</code> instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
@@ -2287,7 +2299,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p><span class="rfc2119-assertion" id="td-forms">
     All name-value pairs of an instance of <code>Form</code>,
     where the name is a <a>Vocabulary Term</a> included in the <a>Signature</a> of <code>Form</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>Form</code> instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-form-protocolbindings">
@@ -2473,7 +2487,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p><span class="rfc2119-assertion" id="td-links">
     All name-value pairs of an instance of <code>Link</code>,
     where the name is a <a>Vocabulary Term</a> included in the <a>Signature</a> of <code>Link</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>Link</code> instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>A TD snippet of a link object in the <code>links</code> array is given below:</p>
@@ -2500,8 +2516,10 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     <code>securityDefinitions</code> is a <a>Map</a> of instances of
     <code>SecurityScheme</code>.
     <span class="rfc2119-assertion" id="td-security">
-    A <a>Map</a> of <code>SecurityScheme</code> instances MUST be serialized as JSON object
-    with a (unique) JSON name to identify each Security configuration object.
+    All name-value pairs of a <a>Map</a> of <code>SecurityScheme</code> instances
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    instance of <code>SecurityScheme</code>, MUST be serialized as a JSON object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-security-schemes">
@@ -2509,7 +2527,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     <code>SecurityScheme</code>,
     where the name is a <a>Vocabulary Term</a> included in the
     <a>Signatures</a> of that <a>Subclass</a> or <code>SecurityScheme</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>SecurityScheme</code> <a>Subclass</a>'s instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
@@ -2807,7 +2827,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     All name-value pairs of an instance of one of the <a>Subclasses</a> of
     <code>DataSchema</code>, where the name is a <a>Vocabulary Term</a> included in the
     <a>Signatures</a> of that <a>Subclass</a> or <code>DataSchema</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>DataSchema</code> <a>Subclass</a>'s instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema-objects">

--- a/index.html
+++ b/index.html
@@ -2112,7 +2112,7 @@ In summary, this requires the following:
   <p>
   <span class="rfc2119-assertion" id="td-property-names">
     All name-value pairs of an instance of <code>PropertyAffordance</code>,
-    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    where the name is a <a>Vocabulary Term</a> included in (one of) the <a>Signatures</a> of
     <code>PropertyAffordance</code>, <code>InteractionAffordance</code>, or <code>DataSchema</code>,
     MUST be serialized as members of the JSON object that results from
     serializing the <code>PropertyAffordance</code> instance, with the
@@ -2184,7 +2184,7 @@ In summary, this requires the following:
 
   <p><span class="rfc2119-assertion" id="td-action-names">
     All name-value pairs of an instance of <code>ActionAffordance</code>,
-    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    where the name is a <a>Vocabulary Term</a> included in (one of) the <a>Signatures</a> of
     <code>ActionAffordance</code> or <code>InteractionAffordance</code>,
     MUST be serialized as members of the JSON object that results from
     serializing the <code>ActionAffordance</code> instance, with the
@@ -2261,7 +2261,7 @@ In summary, this requires the following:
 
   <p><span class="rfc2119-assertion" id="td-event-names">
     All name-value pairs of an instance of <code>EventAffordance</code>,
-    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    where the name is a <a>Vocabulary Term</a> included in (one of) the <a>Signatures</a> of
     <code>EventAffordance</code> or <code>InteractionAffordance</code>,
     MUST be serialized as members of the JSON object that results from
     serializing the <code>EventAffordance</code> instance, with the
@@ -2546,10 +2546,10 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     All name-value pairs of an instance of one of the <a>Subclasses</a> of
     <code>SecurityScheme</code>,
     where the name is a <a>Vocabulary Term</a> included in the
-    <a>Signatures</a> of that <a>Subclass</a> or <code>SecurityScheme</code>,
-    MUST be serialized as members of the JSON object that results from
-    serializing the <code>SecurityScheme</code> <a>Subclass</a>'s instance, with the
-    <a>Vocabulary Term</a> as name.
+    <a>Signature</a> of that <a>Subclass</a> or in the <a>Signature</a> of
+    <code>SecurityScheme</code>, MUST be serialized as members of the JSON object
+    that results from serializing the <code>SecurityScheme</code> <a>Subclass</a>'s
+    instance, with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
@@ -2846,10 +2846,10 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p><span class="rfc2119-assertion" id="td-data-schema">
     All name-value pairs of an instance of one of the <a>Subclasses</a> of
     <code>DataSchema</code>, where the name is a <a>Vocabulary Term</a> included in the
-    <a>Signatures</a> of that <a>Subclass</a> or <code>DataSchema</code>,
-    MUST be serialized as members of the JSON object that results from
-    serializing the <code>DataSchema</code> <a>Subclass</a>'s instance, with the
-    <a>Vocabulary Term</a> as name.
+    <a>Signature</a> of that <a>Subclass</a> or in the <a>Signature</a> of
+    <code>DataSchema</code>, MUST be serialized as members of the JSON object
+    that results from serializing the <code>DataSchema</code> <a>Subclass</a>'s
+    instance, with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema-objects">

--- a/index.html
+++ b/index.html
@@ -1308,14 +1308,17 @@ a[href].internalDFN {
         </p>
 
         <p>
-            In addition, the <a>TD Information Model</a> defines another partial function defined
-            on the <a>Signature</a> of a <a>Class</a>, that takes a <a>Vocabulary Term</a> as
-            input and returns an <a>Object</a>, which is the <dfn>Default Value</dfn> for some
-            assignment. This function allows to relax the constraint defined above on the
-            <a>Assignment Function</a>:
+            In addition, the <a>TD Information Model</a> defines a global function on
+            pairs of <a>Vocabulary Terms</a>. The function takes a <a>Class</a> name and
+            another <a>Vocabulary Term</a> as input and
+            returns an <a>Object</a>. If the returned <a>Object</a> is different from
+            <code>null</code>, it represents the <dfn>Default Value</dfn> for some
+            assignment on the input <a>Vocabulary Term</a> in an instance of the input
+            <a>Class</a>. This function allows to relax the constraint
+            defined above on the <a>Assignment Function</a>:
             an <a>Object</a> is an instance of a <a>Class</a> if it includes all mandatory
             assignments <em>or</em> if <a>Default Value</a> exist for the missing
-            assignments. All <a>Default Values</a> are given in a single table in
+            assignments. All <a>Default Values</a> are given in the table of
             <a href="#sec-default-values"></a>.
         </p>
 
@@ -1671,101 +1674,101 @@ IANA HTTP content coding registry</a>.
       <table class="def">
           <thead>
               <tr>
+                  <th><a>Class</a></th>
                   <th><a>Vocabulary term</a></th>
                   <th>Default value</th>
-                  <th>Class</th>
               </tr>
           </thead>
           <tbody>
               <tr class="rfc2119-default-assertion" id="td-default-contentType">
+                  <td></td>
                   <td>
                       <code>contentType</code>
                   </td>
                   <td><code>application/json</code></td>
-                  <td></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-safe">
+                  <td></td>
                   <td>
                       <code>safe</code>
                   </td>
                   <td><code>false</code></td>
-                  <td></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-idempotent">
+                  <td></td>
                   <td>
                       <code>idempotent</code>
                   </td>
                   <td><code>false</code></td>
-                  <td></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-op-properties">
+                  <td><code>PropertyAffordance</code></td>
                   <td>
                       <code>op</code>
                   </td>
                   <td>Array of strings with values <code>readproperty</code> followed by 
                       <code>writeproperty</code></td>
-                  <td><code>PropertyAffordance</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-op-actions">
+                  <td><code>ActionAffordance</code></td>
                   <td>
                       <code>op</code>
                   </td>
                   <td><code>invokeaction</code></td>
-                  <td><code>ActionAffordance</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-op-events">
+                  <td><code>EventAffordance</code></td>
                   <td>
                       <code>op</code>
                   </td>
                   <td><code>subscribeevent</code></td>
-                  <td><code>EventAffordance</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-in-1">
+                  <td><code>BasicSecurityScheme</code></br>
+                    <code>DigestSecurityScheme</code></br>
+                    <code>BearerSecurityScheme</code></br>
+                    <code>PoPSecurityScheme</code></td>
                   <td>
                       <code>in</code>
                   </td>
                   <td><code>header</code></td>
-                  <td><code>BasicSecurityScheme</code></br>
-                      <code>DigestSecurityScheme</code></br>
-                      <code>BearerSecurityScheme</code></br>
-                      <code>PoPSecurityScheme</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-in-2">
+                  <td><code>APIKeySecurityScheme</code></td>
                   <td>
                       <code>in</code>
                   </td>
                   <td><code>query</code></td>
-                  <td><code>APIKeySecurityScheme</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-qop">
+                  <td><code>DigestSecurityScheme</code></td>
                   <td>
                       <code>qop</code>
                   </td>
                   <td><code>auth</code></td>
-                  <td><code>DigestSecurityScheme</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-alg">
+                  <td><code>BearerSecurityScheme</code></br>
+                    <code>PoPSecurityScheme</code></td>
                   <td>
                       <code>alg</code>
                   </td>
                   <td><code>ES256</code></td>
-                  <td><code>BearerSecurityScheme</code></br>
-                      <code>PoPSecurityScheme</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-format">
+                  <td><code>BearerSecurityScheme</code></br>
+                    <code>PoPSecurityScheme</code></td>
                   <td>
                       <code>format</code>
                   </td>
                   <td><code>jwt</code></td>
-                  <td><code>BearerSecurityScheme</code></br>
-                      <code>PoPSecurityScheme</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-flow">
+                  <td><code>OAuth2SecurityScheme</code></td>
                   <td>
                       <code>flow</code>
                   </td>
                   <td><code>implicit</code></td>
-                  <td><code>OAuth2SecurityScheme</code></td>
               </tr>
           </tbody>
       </table>

--- a/index.html
+++ b/index.html
@@ -920,20 +920,21 @@ a[href].internalDFN {
         in a given format and deserialize it from that format. If two TDs have different
         serializations but are semantically equivalent, a <a>TD Processor</a> must be able to
         construct a canonical (i.e., identical) representation when deserializing them.
-        For instance, a TD in which default values were omitted is equivalent to a TD that
-        would include default values. Moreover, a <a>TD Processor</a> must also detect semantically
+        For instance, a TD in which Default Values were omitted is equivalent to a TD that
+        would include Default Values. Moreover, a <a>TD Processor</a> must also detect semantically
         inconsistent TDs, for which no representation should exist. A <a>TD Processor</a> is
         typically a sub-system of a <a>WoT Runtime</a>.
     </dd>
     <dt>
         <dfn id="dfn-td-serialization">TD Serialization</dfn>
         or
-        <dfn id="dfn-td-document">TD document</dfn>
+        <dfn id="dfn-td-document">TD Document</dfn>
     </dt>
     <dd>
         Textual or binary representation of a TD that can be stored and exchanged between
-        <a>Servients</a>. A TD serialization follows a given format, provided as a content type
-        when exchanging it. The reference serialization format for TDs is JSON.
+        <a>Servients</a>. A TD Serialization follows a given representation format, 
+        identified by a media type when exchanged over the network.
+        The default representation format for TDs is JSON-based as defined by this specification.
     </dd>
     <dt>
         <dfn id="dfn-vocab">Vocabulary</dfn>
@@ -1164,7 +1165,7 @@ a[href].internalDFN {
           <a href="#preliminary-definitions"></a>. The main elements of
           the <a>TD Information Model</a> are then presented in
           <a href="#class-definitions"></a>. Certain object properties may be
-          omitted in a TD when default values exist. A list of defaults
+          omitted in a TD when <a>Default Values</a> exist. A list of defaults
           is given in <a href="#sec-default-values"></a>.
       </p>
 
@@ -1651,7 +1652,7 @@ operations types SHOULD NOT be arbitrarily set by servients
       <p>
           <span class="rfc2119-assertion" id="td-vocabulary-defaults">
             When assignments in a TD are missing, a <a>TD Processor</a> MUST follow
-            the default value assignments expressed in the table of
+            the <a>Default Value</a> assignments expressed in the table of
             <a href="#sec-default-values"></a>.
           </span>
       </p>
@@ -2011,7 +2012,7 @@ In summary, this requires the following:
   string or array that contains <code>https://www.w3.org/2019/td/v1</code>.
   </span>
   In general, this URI is used to identify the
-  TD representation format version defined by this document
+  TD representation format version defined by this document.
   For JSON-LD processing [[?json-ld11]],
   the <code>@context</code> specifies the Thing Description context file
   and optionally additional term definitions.
@@ -2537,7 +2538,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p>
   Here is a more complex example: a TD snippet showing digest authentication
   on a proxy combined with bearer token authentication on the <a>Thing</a>.
-  Here the default value of <code>in</code> in the <code>digest</code> scheme,
+  Here the <a>Default Value</a> of <code>in</code> in the <code>digest</code> scheme,
   <code>header</code>, is omitted, but still applies.
   Note that the corresponding private security configuration
   such as username/password and tokens must be configured in the <a>Consumer</a>
@@ -2798,7 +2799,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <code>ActionAffordance</code> instances,
   the values assigned to <code>subscription</code>, <code>data</code>, and <code>cancellation</code> in
   <code>EventAffordance</code> instances,
-  and the value assigned to <code>uriVariables</code> in instances of <a>Subclasses</a> of <code>InteractionAffordance<code>
+  and the value assigned to <code>uriVariables</code> in instances of <a>Subclasses</a> of <code>InteractionAffordance</code>
   (when a <a href="#form-serialization-json">form object</a> uses a URI Template).
   </p>
 
@@ -3489,11 +3490,11 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         needs to know what HTTP method to use when submitting a form. In the general case,
         a Thing Description can explicitly include a term indicating the method, i.e.,
         <code>htv:methodName</code>. For the
-        sake of conciseness, the HTTP <a>Protocol Binding</a> defines default values for each operation type,
+        sake of conciseness, the HTTP <a>Protocol Binding</a> defines <a>Default Values</a> for each operation type,
         which also aims at convergence of the methods expected by <a>Things</a> (e.g., GET to read, PUT to write).
         <span class="rfc2119-assertion" id="td-default-http-method">
             When no method is indicated in a form representing an HTTP
-            <a>Protocol Binding</a>, a default value MUST be assumed as shown in
+            <a>Protocol Binding</a>, a <a>Default Value</a> MUST be assumed as shown in
             the following table.
         </span>
     </p>
@@ -3538,7 +3539,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </table>
 
     <p>
-        For example, the following default values should be assumed for forms in the introductory TD example:
+        For example, the following <a>Default Values</a> should be assumed for forms in the introductory TD example:
     </p>
 
     <aside class="example with-default">
@@ -3655,9 +3656,9 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
       <p>
           The number of <a>Protocol Bindings</a> a <a>Thing</a> can implement
-          is not restricted. Other <a>Protocol Bindings</a>, e.g., for CoAP, MQTT, or OPC UA
-          will be standardized in separate documents such as a protocol vocabulary similar to HTTP in RDF [[HTTP-in-RDF10]]
-          or specifications including default value definitions. Such protocols can be simply integrated into the TD by the 
+          is not restricted. Other <a>Protocol Bindings</a> (e.g., for CoAP, MQTT, or OPC UA)
+          are intended to be standardized in separate documents such as a protocol <a>Vocabulary</a> similar to <em>HTTP Vocabulary in RDF 1.0</em> [[HTTP-in-RDF10]]
+          or specifications including <a>Default Value</a> definitions. Such protocols can be simply integrated into the TD by the
           usage of the context extension mechanism (<a href="#content-extension-section"></a>).
       </p>
   </section>
@@ -4172,7 +4173,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </p>
 
     <p>
-        The following JSON Schema for validating TD instances does not require the terms with default values to be present. Thus the terms with default values are optional. (see also <a href="#sec-default-values"></a>)
+        The following JSON Schema for validating TD instances does not require the terms with <a>Default Values</a> to be present. Thus the terms with <a>Default Values</a> are optional. (see also <a href="#sec-default-values"></a>)
 
     <pre class="advisement">
     {
@@ -5397,7 +5398,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
             <h3>Thing Description JSON-LD Context</h3>
 
             <p>
-                A JSON TD document can be transformed in RDF (to then be uploaded
+                A TD document can be transformed into RDF (to then be uploaded
                 to an RDF store for further analytics) by a standard JSON-LD processor.
                 The following procedure loads the context of the TD, given by the
                 term <code>@context</code>, and generates RDF triples:
@@ -5410,7 +5411,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
             </p>
             
             <p>
-                When applying this procedure to the introductory TD example with all default values,
+                When applying this procedure to the introductory TD example with all <a>Default Values</a>,
                 the following triples are obtained:
             </p>
             
@@ -5532,7 +5533,7 @@ _:b8 &lt;https://www.w3.org/2019/wot-security#in&gt; &quot;header&quot; .</pre>
             </p>
 
             <p>
-                Then, after expanding JSON strings to full IRIs, all map structures of the JSON
+                Then, after expanding JSON strings to full IRIs, all map structures of the
                 TD document must be turned into RDF triples. In a simple case, a
                 triple is produced for every key/value pair in the map. For instance, the
                 very first triple of the example above was produced from <code>"name": "myLampThing"</code>.
@@ -5605,7 +5606,7 @@ _:b8 &lt;https://www.w3.org/2019/wot-security#in&gt; &quot;header&quot; .</pre>
             </p>
 
             <p>
-                Default values require special care when translating the <a>TD Information Model</a>
+                <a>Default Values</a> require special care when translating the <a>TD Information Model</a>
                 into OWL.
             </p>
 

--- a/index.html
+++ b/index.html
@@ -1855,6 +1855,10 @@ In summary, this requires the following:
         Values that are of type <code>double</code>
         MUST be serialized as JSON number.
   </span></li>
+  <li><span class="rfc2119-assertion" id="td-boolean-type">
+        Values that are of type <code>boolean</code>
+        MUST be serialized as JSON boolean.
+  </span></li>
   </ul>
 
   <p>
@@ -2067,12 +2071,21 @@ In summary, this requires the following:
 
   <p><span class="rfc2119-assertion" id="td-arrays">
   All values assigned to
-  <code>security</code>,
   <code>links</code>, and
   <code>forms</code>
   in an instance of <a>Class</a> <code>Thing</code>
-  MUST be serialized as JSON arrays.
+  MUST be serialized as JSON arrays containing JSON objects
+  as defined in <a href="#form-serialization-json"></a>
+  and <a href="#links-serialization-json"></a>, respectively.
   </span></p>
+
+  <p>
+      <span class="rfc2119-assertion" id="td-security-activation">
+          The value assigned to <code>security</code> in an instance
+          of <a>Class</a> <code>Thing</code> MUST be serialized as
+          a JSON string or as a JSON array whose elements are JSON strings.
+      </span>
+  </p>
 
 </section> <!-- end of id="sec-thing-as-a-whole-json"-->
 

--- a/index.html
+++ b/index.html
@@ -1245,7 +1245,9 @@ a[href].internalDFN {
             in this specification. An <a>Object</a> whose elements only have numbers
             as names is called an <dfn>Array</dfn>. Similarly, an <a>Object</a> whose
             elements only have <a>Term</a>s (that do not belong to any <a>Vocabulary</a>)
-            as names is called a <dfn>Map</dfn>.
+            as names is called a <dfn>Map</dfn>. All names appearing in some name-value pair
+            in a <a>Map</a> are assumed to be <em>unique</em> within the scope of the
+            <a>Map</a>.
         </p>
 
         <p>
@@ -1256,23 +1258,24 @@ a[href].internalDFN {
         </p>
 
         <p>
-            The <a>Signature</a> of a <a>Class</a> allows to construct two relations that further
-            define <a>Classes</a>: an <dfn>Assignment Relation</dfn> and a <dfn>Type Relation</dfn>.
-            The <a>Assignment Relation</a> of a <a>Class</a> takes a <a>Vocabulary Term</a> as input
+            The <a>Signature</a> of a <a>Class</a> allows to construct two functions that further
+            define <a>Classes</a>: an <dfn>Assignment Function</dfn> and a <dfn>Type Function</dfn>.
+            The <a>Assignment Function</a> of a <a>Class</a> takes a <a>Vocabulary Term</a> as input
             and returns either <code>true</code> or <code>false</code> as output.
-            The <a>Type Relation</a> of a <a>Class</a> also takes a <a>Vocabulary Term</a>
-            as input and returns another <a>Class</a> as output.
+            The <a>Type Function</a> of a <a>Class</a> also takes a <a>Vocabulary Term</a>
+            as input and returns another <a>Class</a> as output. These functions are <em>partial</em>:
+            their domain is limited to the <a>Signature</a> of the <a>Class</a> being defined.
         </p>
 
         <p>
-            On the basis of these two relations, two constraints on <a>Class</a> instantiation
+            On the basis of these two functions, two constraints on <a>Class</a> instantiation
             can be defined as follows:
             <ul>
                 <li>
                     an <a>Object</a> is an instance of a <a>Class</a> if for every <a>Term</a>
-                    for which the <a>Assignment Relation</a> of the <a>Class</a> returns
+                    for which the <a>Assignment Function</a> of the <a>Class</a> returns
                     <code>true</code>, it includes a name-value pair with the <a>Vocabulary Term</a>
-                    as name. In other words, the <a>Assignment Relation</a> indicates whether
+                    as name. In other words, the <a>Assignment Function</a> indicates whether
                     a <a>Vocabulary Term</a> in the <a>Signature</a> of the <a>Class</a> is mandatory.
                     <a>Vocabulary Terms</a> that are not mandatory, but are in the <a>Signature</a>
                     of a <a>Class</a> are optional.
@@ -1282,7 +1285,7 @@ a[href].internalDFN {
                     if for every <a>Vocabulary Term</a>
                     in the <a>Signature</a> of the <a>Class</a> used as name in some name-value pair
                     of the <a>Object</a>, the value of that pair is an instance of the
-                    <a>Class</a> returned by the <a>Type Relation</a> of the <a>Class</a> for the
+                    <a>Class</a> returned by the <a>Type Function</a> of the <a>Class</a> for the
                     given <a>Vocabulary Term</a>.
                 </li>
             </ul>
@@ -1298,16 +1301,18 @@ a[href].internalDFN {
             as a set of <a>Class</a> definitions,
             which include a <a>Class</a> name (a <a>Vocabulary Term</a>),
             a <a>Signature</a> (a set of <a>Vocabulary Terms</a>),
-            an <a>Assignment Relation</a>,
-            and a <a>Type Relation</a>.
+            an <a>Assignment Function</a>,
+            and a <a>Type Function</a>.
             These <a>Class</a> definitions are provided as tables in <a href="#class-definitions"></a>.
+            By convention, <a>Simple Types</a> are denoted by names starting with lowercase.
         </p>
 
         <p>
-            In addition, the <a>TD Information Model</a> defines another relation for each
-            <a>Class</a> that takes a <a>Vocabulary Term</a> as input and returns an <a>Object</a>,
-            which is the <dfn>Default Value</dfn> for some assignment. This relation allows
-            to relax the constraint defined above on the <a>Assignment Relation</a>:
+            In addition, the <a>TD Information Model</a> defines another partial function defined
+            on the <a>Signature</a> of a <a>Class</a>, that takes a <a>Vocabulary Term</a> as
+            input and returns an <a>Object</a>, which is the <dfn>Default Value</dfn> for some
+            assignment. This function allows to relax the constraint defined above on the
+            <a>Assignment Function</a>:
             an <a>Object</a> is an instance of a <a>Class</a> if it includes all mandatory
             assignments <em>or</em> if <a>Default Value</a> exist for the missing
             assignments. All <a>Default Values</a> are given in a single table in
@@ -1824,7 +1829,9 @@ In summary, this requires the following:
 
   <p>
     Every <a>Simple Type</a> mentioned in
-    <a href="#class-definitions"></a> maps to a JSON
+    <a href="#class-definitions"></a> (<code>string</code>, <code>anyURI</code>,
+    <code>dateTime</code>, <code>integer</code>, <code>unsignedInt</code>,
+    <code>double</code>, <code>boolean</code>) maps to a JSON 
     type (string, number, boolean), as per the rules listed below. These
     rules apply to values in name-value pairs:
   </p>
@@ -1848,7 +1855,7 @@ In summary, this requires the following:
     XSD built-in dateTime datatype
   </a>, itself inspired by the ISO standard for dates and times [[ISO8601]].</li>
   <li><span class="rfc2119-assertion" id="td-integer-type">
-        Values that are of type <code>integer</code>
+        Values that are of type <code>integer</code> or <code>unsignedInt</code>
         MUST be serialized as JSON numbers without a fraction or exponent part.
   </span></li>
   <li><span class="rfc2119-assertion" id="td-number-type">

--- a/index.html
+++ b/index.html
@@ -644,17 +644,17 @@ a[href].internalDFN {
   <p>
   This document describes a formal model and a common representation 
   for a Web of Things (WoT) Thing Description. 
-  A Thing Description describes the metadata and interfaces of Things, 
-  where a Thing is an abstraction of a physical or virtual entity that 
+  A Thing Description describes the metadata and interfaces of <a>Things</a>,
+  where a <a>Thing</a> is an abstraction of a physical or virtual entity that
   provides interactions to and participates in the Web of Things. 
   Thing Descriptions provide a set of interactions based on a small vocabulary 
   that makes it possible both to integrate diverse devices and 
   to allow diverse applications to interoperate. 
   Thing Descriptions, by default, are encoded in a JSON format that also allows
   JSON-LD processing. The latter provides a powerful foundation to represent
-  knowledge about Things in a machine-understandable way.
-  A Thing Description instance can be hosted by the Thing itself or hosted 
-  externally when a Thing has resource restrictions (e.g., limited memory space) 
+  knowledge about <a>Things</a> in a machine-understandable way.
+  A Thing Description instance can be hosted by the <a>Thing</a> itself or hosted
+  externally when a <a>Thing</a> has resource restrictions (e.g., limited memory space)
   or when a Web of Things-compatible legacy device is retrofitted 
   with a Thing Description.
   </p>
@@ -689,19 +689,19 @@ a[href].internalDFN {
   <section id="introduction" class="informative">
   <h1>Introduction</h1>
   <p>
-  The Thing Description (TD) model is a central building block in the W3C Web of
-  Things (WoT) and can be considered as the entry point of a Thing 
+  The WoT Thing Description (TD) is a central building block in the W3C Web of
+  Things (WoT) and can be considered as the entry point of a <a>Thing</a>
   (much like the <i>index.html</i> of a Web site). A TD instance has four main
   components: textual metadata about the <a href="#thing">Thing</a> itself,
   a set of <a href="#interactionaffordance">Interaction Affordances</a>
-  that indicate how the Thing can be used,
+  that indicate how the <a>Thing</a> can be used,
   <a href="#sec-data-schema-vocabulary-definition">schemas</a> for the data
-  exchanged with the Thing for machine-understandability, 
+  exchanged with the <a>Thing</a> for machine-understandability,
   and, finally, <a href="#sec-web-linking-vocabulary-definition">Web links</a> to 
-  express any formal or informal relation to other Things or documents on the Web.
+  express any formal or informal relation to other <a>Things</a> or documents on the Web.
   </p>
   <p>
-  The Interaction Model of W3C WoT defines three types of Interaction Affordances:
+  The <a>Interaction Model</a> of W3C WoT defines three types of <a>Interaction Affordances</a>:
   Properties (<a href="#propertyaffordance"><code>PropertyAffordance</code></a> class)
   can be used for sensing and controlling parameters, such as getting the current value or 
   setting an operation state.
@@ -714,19 +714,19 @@ a[href].internalDFN {
   See [[!wot-architecture] for details.
   </p>
   <p>
-  In general, the TD provides metadata for different Protocol Bindings
+  In general, the TD provides metadata for different <a>Protocol Bindings</a>
   identified by URI schemes [[iana-uri-schemes]] (e.g., <code>http</code>, <code>coap</code>, etc.),
   content types based on media types (e.g., <code>application/json</code>, <code>application/xml</code>, <code>application/cbor</code>, <code>application/exi</code> etc.) [[iana-media-types]],
   and security mechanisms (for authentication,
   authorization, confidentiality, etc.).
   Serialization of TD instances is based on JSON [[rfc8259]], where JSON names refer to terms of
   the TD vocabulary, as defined in this specification document. In addition the JSON serialization of TDs
-  follows the syntax of JSON-LD 1.1 [[json-ld11]] to enable extensions and rich semantic processing.
+  follows the syntax of JSON-LD 1.1 [[?json-ld11]] to enable extensions and rich semantic processing.
   </p>
   <p>
   <a href="#simple-thing-description-sample">Example 1</a> shows a TD instance and
-  illustrates the Interaction Model with Properties, Actions, and Events
-  by describing a lamp Thing with the name <i>MyLampThing</i>. 
+  illustrates the <a>Interaction Model</a> with Properties, Actions, and Events
+  by describing a lamp <a>Thing</a> with the name <i>MyLampThing</i>.
   </p>
 <aside class="example" id="simple-thing-description-sample" title="Thing Description Sample">
     <pre>{
@@ -782,7 +782,7 @@ a[href].internalDFN {
   </p>
   <p>
   The <a href="#eventaffordance">Event affordance</a> enables a mechanism for asynchronous messages
-  to be sent by a Thing.
+  to be sent by a <a>Thing</a>.
   Here, a subscription to be notified upon a possible overheating event 
   of the lamp can be obtained by using HTTP with its long polling
   subprotocol on <code>https://mylamp.example.com/oh</code>.
@@ -799,7 +799,7 @@ a[href].internalDFN {
   Specification of at least one security scheme at the top level is mandatory,
   and gives the default access requirements for every resource.
   However, security schemes can also be specified per-form,
-  with configurations given at the form level overriding configurations given at the Thing level,
+  with configurations given at the form level overriding configurations given at the <code>Thing</code> level,
   allowing for the specification of fine-grained access control.
   It is also possible to use a special <code>nosec</code> security scheme to
   indicate that no access control mechanisms are used.
@@ -818,7 +818,7 @@ a[href].internalDFN {
         prefix <code>saref</code> as referring to the SAREF vocabulary namespace [[smartM2M]].
         The SAREF vocabulary includes terms to describe lighting devices and other home automation
         devices that one can embed in a TD as semantic labels as values for the <code>@type</code>
-        property. In the present example, the Thing is labelled with <code>saref:LightingDevice</code>,
+        property. In the present example, the <a>Thing</a> is labelled with <code>saref:LightingDevice</code>,
         the <code>status</code> property affordance is labelled with <code>saref:OnOffState</code>
         and the <code>toggle</code> action affordance with <code>saref:ToggleCommand</code>.
   </p>
@@ -874,11 +874,11 @@ a[href].internalDFN {
 <p>
         The declaration mechanism inside some
         <code>@context</code> is specified by JSON-LD. A TD instance complies to version 1.1 of
-        this specification [[json-ld11]]. The TD instance can be also processed as an RDF
+        this specification [[?json-ld11]]. The TD instance can be also processed as an RDF
         document (details are given in <a href="#note-jsonld11-processing"></a>).
 </p>
 
-  </section>
+</section>
 
   <section id="terminology"> 
   <h2>Terminology</h2>
@@ -892,8 +892,10 @@ a[href].internalDFN {
   <dfn>Event</dfn>,
   <dfn>Protocol Binding</dfn>,
   <dfn>Servient</dfn>,
+  <dfn>WoT Interface</dfn>,
   <dfn>WoT Runtime</dfn>,
-  etc. is defined in [[WOT-ARCHITECTURE]], Section 2.
+  etc. is defined in <a href="https://w3c.github.io/wot-architecture/#terminology">section 3</a>
+  of the WoT Architecture document [[WOT-ARCHITECTURE]].
   </p>
 
   <p>
@@ -916,12 +918,12 @@ a[href].internalDFN {
     <dd>
         A system that can serialize some internal representation of a TD
         in a given format and deserialize it from that format. If two TDs have different
-        serializations but are semantically equivalent, a TD processor must be able to
+        serializations but are semantically equivalent, a <a>TD Processor</a> must be able to
         construct a canonical (i.e., identical) representation when deserializing them.
         For instance, a TD in which default values were omitted is equivalent to a TD that
-        would include default values. Moreover, a TD processor must also detect semantically
-        inconsistent TDs, for which no representation should exist. A TD processor is
-        typically a sub-system of a WoT runtime.
+        would include default values. Moreover, a <a>TD Processor</a> must also detect semantically
+        inconsistent TDs, for which no representation should exist. A <a>TD Processor</a> is
+        typically a sub-system of a <a>WoT Runtime</a>.
     </dd>
     <dt>
         <dfn id="dfn-td-serialization">TD Serialization</dfn>
@@ -930,14 +932,14 @@ a[href].internalDFN {
     </dt>
     <dd>
         Textual or binary representation of a TD that can be stored and exchanged between
-        servients. A TD serialization follows a given format, provided as a content type
+        <a>Servients</a>. A TD serialization follows a given format, provided as a content type
         when exchanging it. The reference serialization format for TDs is JSON.
     </dd>
     <dt>
         <dfn id="dfn-vocab">Vocabulary</dfn>
     </dt>
     <dd>
-        A collection of vocabulary terms, identified by a namespace IRI.
+        A collection of Vocabulary Terms, identified by a namespace IRI.
     </dd>
     <dt>
         <dfn id="dfn-vocab-term">Term</dfn>
@@ -945,22 +947,23 @@ a[href].internalDFN {
         <dfn id="dfn-vocab-term">Vocabulary Term</dfn>
     </dt>
     <dd>
-        A character string. When a term is part of a vocabulary, it is called
-        a vocabulary term. For the sake of readability, a vocabulary term is
-        always denoted with its local name in this document (i.e. without its
+        A character string. When a Term is part of a Vocabulary, it is called
+        a Vocabulary Term. For the sake of readability, a Vocabulary Term is
+        always denoted with its local name in this document (i.e., without its
         namespace IRI).
     </dd>
   </dl>
 
   <p>
-      These definitions are further developed in Section <a href="#preliminary-definitions"></a>.
+      These definitions are further developed in <a href="#preliminary-definitions"></a>.
   </p>
-  </section>
+</section>
 
-  <section>
+<section>
   <h1>Namespaces</h1>
+
   <p>
-      The TD information model presented in this document has its foundations in
+      The <a>TD Information Model</a> presented in this document has its foundations in
       RDF, with a mapping to JSON. This mapping is provided as a JSON-LD context
       file, available at the following URI:
   </p>
@@ -969,22 +972,27 @@ a[href].internalDFN {
     <code>https://www.w3.org/2019/td/v1</code>
   </p>
 
+  <p>
+    This URI also identifies Thing Description instances of the representation format version
+    specified by this document.
+  </p>
+
   <section>
 
     <h2>Reference Namespaces</h2>
 
     <p>
-        All terms defined in the context are grouped by vocabulary, mirroring the
-        structure of the present document (see
-        <a href="#thing-description-json-ld-context"></a> for more details on the
-        context). Each vocabulary is assigned a year-based namespace URI, as follows:
+        All terms defined in the JSON-LD context are grouped by vocabulary,
+        mirroring the structure of the present document
+        (see <a href="#thing-description-json-ld-context"></a> for more details on the context).
+        Each <a>Vocabulary</a> is assigned a year-based namespace URI as follows:
     </p>
   
     <table class="def">
     <thead>
         <tr>
             <th>Vocabulary</th>
-            <th>Namespace URI</th>
+            <th>Namespace IRI</th>
         </tr>
     </thead>
     <tbody>
@@ -1008,18 +1016,19 @@ a[href].internalDFN {
     </table>
   
     <p>
-        Vocabularies are independent from each other. They may be reused and
-        extended in other W3C recommendations. For every breaking change in the
-        design of a vocabulary, it will be assigned a new year-based namespace URI.
-        Note that to maintain the general coherence of the TD information model,
+        The <a>Vocabularies</a> are independent from each other.
+        They may be reused and extended in other W3C recommendations.
+        For every breaking change in the design of a vocabulary,
+        it will be assigned a new year-based namespace URI.
+        Note that to maintain the general coherence of the <a>TD Information Model</a>,
         the JSON-LD context itself is versioned, such that every version has its own URI
         (<code>v1</code>, <code>v1.1</code>, <code>v2</code>, ...).
     </p>
 
     <p>
-        Because a vocabulary under some namespace URI can only undergo non-breaking
+        Because a <a>Vocabulary</a> under some namespace IRI can only undergo non-breaking
         changes, its content can be safely cached or embedded in applications. One 
-        advantage of exposing relatively static content under a namespace URI is to
+        advantage of exposing relatively static content under a namespace IRI is to
         optimize payload sizes of messages exchanged between constrained devices. It
         also avoids any privacy leakage resulting from devices accessing publicly
         available vocabularies private networks (see also
@@ -1033,15 +1042,19 @@ a[href].internalDFN {
     <h2>Alternative Namespaces</h2>
 
     <p>
-        For convenience, generic namespace URIs redirect to the latest year-based
-        URI for each vocabulary. They are defined as follows:
+        For convenience, generic namespace IRIs redirect to the latest year-based IRI for each vocabulary.
+        Their usage is intended for applications with powerful infrastructures,
+        like analytics on large production plants or buildings based on knowledge graphs
+        that can manage different versions of these <a>Vocabularies</a>
+        and can dynamically dereference newer versions.
+        These alternative namespaces are defined as follows:
     </p>
   
     <table class="def">
     <thead>
         <tr>
             <th>Vocabulary</th>
-            <th>Namespace URI</th>
+            <th>Namespace IRI</th>
         </tr>
     </thead>
     <tbody>
@@ -1065,11 +1078,8 @@ a[href].internalDFN {
     </table>
   
     <p>
-        Embedding generic namespace URIs in applications is however not encouraged,
-        since newer versions of the vocabularies may break functionalities. Their
-        usage should be reserved for applications with powerful infrastructures, like
-        analytics on large production plants or buildings based on knowledge graphs
-        that may include devices referencing different versions of these vocabularies.
+        Embedding these generic namespace IRIs in Thing-to-Thing applications is however not encouraged,
+        since newer versions of the <a>Vocabularies</a> may break functionalities.
     </p>
 
   </section>
@@ -1079,16 +1089,15 @@ a[href].internalDFN {
   <section id="conformance">
   <p>
   A Thing Description instance complies with this specification if it follows 
-  the normative statements in Section 
+  the normative statements in
   <a href="#sec-vocabulary-definition"></a>
-  and Section 
+  and
   <a href="#sec-td-serialization"></a> 
   regarding Thing Description serialization.
   </p>
   <p>
-  A JSON Schema [[?JSON-SCHEMA-VALIDATION]] is provided in Appendix 
-  <a href="#json-schema-for-validation"></a>
-  to validate Thing Description instances based on JSON serialization.
+  A JSON Schema [[?JSON-SCHEMA-VALIDATION]] to validate Thing Description instances
+  is provided in Appendix <a href="#json-schema-for-validation"></a>.
   </p>
 
   <p>
@@ -1112,65 +1121,68 @@ a[href].internalDFN {
 
   <section id="sec-vocabulary-definition" class="normative">
     <h1>Information Model</h1>
-    <!-- h1>Vocabulary</h1 -->
-    <p>This section introduces the TD information model. 
-      The TD information model serves as the conceptual basis 
-      for the serialization and processing of Thing Description described 
-      in later sections in this document.<p>
+
+    <p>
+      This section introduces the <a>TD Information Model</a>.
+      The <a>TD Information Model</a> serves as the conceptual basis
+      for the processing of Thing Descriptions and their serialization,
+      which is described separately in <a href="#sec-td-serialization"></a>.
+    <p>
 
       <section>
       <h2>Overview</h2>
     
       <p>
-        The TD information model is built upon the following, independent vocabularies: 
+        The <a>TD Information Model</a> is built upon the following, independent <a>Vocabularies</a>:
         <ul>
             <li>
-                the <em>core</em> TD vocabulary, which reflects the
-                <a href="https://www.w3.org/TR/wot-architecture/#sec-interaction-model">WoT interaction model</a> 
-                including property, action and event affordances [[!WOT-ARCHITECTURE]]
+                the <em>core</em> TD <a>Vocabulary</a>, which reflects the
+                <a>Interaction Model</a> with the <a>Properties</a>, <a>Actions</a>, and <a>Events</a>
+                <a>Interaction Affordances</a> [[!WOT-ARCHITECTURE]]
             </li>
             <li>
-                the <em>Data Schema</em> vocabulary, including (a subset of) the terms defined in 
-                JSON Schema [[?JSON-SCHEMA-VALIDATION]]
+                the <em>Data Schema</em> <a>Vocabulary</a>, including (a subset of)
+                the terms defined by JSON Schema [[?JSON-SCHEMA-VALIDATION]]
             </li>
             <li>
-                the <em>WoT Security</em> vocabulary, defining security mechanisms 
-                and configuration requirements to implement them
+                the <em>WoT Security</em> <a>Vocabulary</a>, identifying security mechanisms
+                and requirements for their configuration
             </li>
             <li>
-                the <em>Web Linking</em> vocabulary, encoding the main principles of RESTful
+                the <em>Web Linking</em> <a>Vocabulary</a>, encoding the main principles of RESTful
                 communication using Web links and forms
             </li>
         </ul>
       </p>
 
       <p>
-          Each of these vocabularies is essentially a set of terms that can
+          Each of these <a>Vocabularies</a> is essentially a set of <a>Terms</a> that can
           be used to build data structures, interpreted as objects in the
           traditional object-oriented sense. Objects are instances of classes
-          and have properties. In the context of WoT, they denote Things and
-          their affordances. A formal definition of objects is given in
-          Section <a href="#preliminary-definitions"></a>. The main elements of
-          the TD information model are then presented in Section
+          and have properties. In the context of W3C WoT, they denote <a>Things</a> and
+          their <a>Interaction Affordances</a>. A formal definition of objects is given in
+          <a href="#preliminary-definitions"></a>. The main elements of
+          the <a>TD Information Model</a> are then presented in
           <a href="#class-definitions"></a>. Certain object properties may be
-          omitted in a <a>TD</a> when default values exist. A list of defaults
-          is given in Section <a href="#sec-default-values"></a>.
+          omitted in a TD when default values exist. A list of defaults
+          is given in <a href="#sec-default-values"></a>.
       </p>
 
       <p>
-          The UML diagram showed next gives an overview of the TD information model.
+          The UML diagram shown next gives an overview of the <a>TD Information Model</a>.
           It represents all classes as tables and the assocations that exist between
           classes, starting from the class <a href="#thing"><code>Thing</code></a>,
           as directed arrows. For the sake of readability, the diagram was split in
-          four parts, one for each of the four base vocabularies.
+          four parts, one for each of the four base <a>Vocabularies</a>.
       </p>
       
       <!--<p><a href="http://visualdataweb.de/webvowl/#iri=https://rawgit.com/w3c/wot-thing-description/TD-JSON-LD-1.1/ontology/td.ttl">Click here for the visualization</a></p>-->
      
 
       <p class="ednote">
-            The following diagrams are automatically generated from the ontology files. The layout will be improved in one of the next TD updates.
-             </p>
+          The following diagrams are automatically generated from the ontology files.
+          The layout will be improved upon publication of Working Drafts.
+      </p>
 
 
     <figure id="td-core-model">
@@ -1200,100 +1212,112 @@ a[href].internalDFN {
         <h2>Preliminaries</h2>
 
         <p>
+            To provide a model that can be easily processes by both,
+            simple rules on a tree-based document (i.e., raw JSON processing)
+            and rich Semantic Web tooling (i.e., JSON-LD processing),
+            this document defines the following formal preliminaries
+            to construct the <a>TD Information Model</a> accordingly.
+        </p>
+
+        <p>
             All definitions in this section refer to <em>sets</em>, which
             intuitively are collections of elements that can themselves be sets.
             All arbitrarily complex data structures can be defined in terms
-            of sets. In particular, an <dfn>object</dfn> is a data structure
+            of sets. In particular, an <dfn>Object</dfn> is a data structure
             recursively defined as follows:
         </p>
 
         <ul>
             <li>
-                a <a>term</a> which may or not belong to a <a>vocabulary</a>,
-                is an <a>object</a>.
+                a <a>Term</a>, which may or may not belong to a <a>Vocabulary</a>,
+                is an <a>Object</a>.
             </li>
             <li>
-                a set of name-value pairs where the name is a <a>term</a> and the
-                value is another <a>object</a>, is also an <a>object</a>.
+                a set of name-value pairs where the name is a <a>Term</a> and the
+                value is another <a>Object</a>, is also an <a>Object</a>.
             </li>
         </ul>
 
         <p>
-            Though this definition does not prevent <a>object</a>s to include multiple
+            Though this definition does not prevent <a>Objects</a> to include multiple
             name-value pairs with the same name, they are generally not considered
-            in this specification. An <a>object</a> whose elements only have numbers
-            as names is called an <dfn>array</dfn>. Similarly, an <a>object</a> whose
-            elements only have <a>term</a>s that do not belong to any <a>vocabulary</a>
-            as names is called a <dfn>map</dfn>.
+            in this specification. An <a>Object</a> whose elements only have numbers
+            as names is called an <dfn>Array</dfn>. Similarly, an <a>Object</a> whose
+            elements only have <a>Term</a>s (that do not belong to any <a>Vocabulary</a>)
+            as names is called a <dfn>Map</dfn>.
         </p>
 
         <p>
-            Moreover, <a>object</a>s can be instances of some <dfn>class</dfn> (also
-            called <dfn>type</dfn>). A <a>class</a>, which is denoted by a <a>term</a>, is
-            first defined by a set of <a>term</a>s called a <dfn>signature</dfn>. A
-            <a>class</a> whose <a>signature</a> is empty is called a <dfn>simple type</dfn>.
+            Moreover, <a>Object</a>s can be instances of some <dfn>Class</dfn>.
+            A <a>Class</a>, which is denoted by a <a>Vocabulary Term</a>, is
+            first defined by a set of <a>Vocabulary Terms</a> called a <dfn>Signature</dfn>. A
+            <a>Class</a> whose <a>Signature</a> is empty is called a <dfn>Simple Type</dfn>.
         </p>
 
         <p>
-            The <a>signature</a> of a class allows to construct two relations that further
-            define <a>class</a>es: an <dfn>assignment relation</dfn> and a <dfn>type
-            relation</dfn>. The <a>assignment relation</a> of a <a>class</a> takes a
-            <a>term</a> as input and returns either <code>true</code> or <code>false</code>
-            as output. The <a>type relation</a> of a <a>class</a> also takes a <a>term</a>
-            as input and returns another <a>class</a> as output.
+            The <a>Signature</a> of a <a>Class</a> allows to construct two relations that further
+            define <a>Classes</a>: an <dfn>Assignment Relation</dfn> and a <dfn>Type Relation</dfn>.
+            The <a>Assignment Relation</a> of a <a>Class</a> takes a <a>Vocabulary Term</a> as input
+            and returns either <code>true</code> or <code>false</code> as output.
+            The <a>Type Relation</a> of a <a>Class</a> also takes a <a>Vocabulary Term</a>
+            as input and returns another <a>Class</a> as output.
         </p>
 
         <p>
-            On the basis of these two relations, constraints on <a>class</a> instantiation
+            On the basis of these two relations, two constraints on <a>Class</a> instantiation
             can be defined as follows:
             <ul>
                 <li>
-                    an <a>object</a> is an instance of a <a>class</a> if for every <a>term</a>
-                    for which the <a>assignment relation</a> of the <a>class</a> returns
-                    <code>true</code>, it includes a name-value pair with the <a>term</a>
-                    as name. In other words, the <a>assignment relation</a> indicates whether
-                    an assignment for every <a>term</a> in the <a>class</a>'s <a>signature</a>
-                    is mandatory or optional.
+                    an <a>Object</a> is an instance of a <a>Class</a> if for every <a>Term</a>
+                    for which the <a>Assignment Relation</a> of the <a>Class</a> returns
+                    <code>true</code>, it includes a name-value pair with the <a>Vocabulary Term</a>
+                    as name. In other words, the <a>Assignment Relation</a> indicates whether
+                    a <a>Vocabulary Term</a> in the <a>Signature</a> of the <a>Class</a> is mandatory.
+                    <a>Vocabulary Terms</a> that are not mandatory, but are in the <a>Signature</a>
+                    of a <a>Class</a> are optional.
                 </li>
                 <li>
-                    an <a>object</a> is an instance of a <a>class</a> if for every <a>term</a>
-                    of the <a>class</a>'s signature used as name in some name-value pair
-                    of the <a>object</a>, the value of that pair is an instance of the
-                    <a>class</a> returned by the class's <a>type relation</a> for the 
-                    given <a>term</a>.
+                    an <a>Object</a> is an instance of a <a>Class</a>
+                    if for every <a>Vocabulary Term</a>
+                    in the <a>Signature</a> of the <a>Class</a> used as name in some name-value pair
+                    of the <a>Object</a>, the value of that pair is an instance of the
+                    <a>Class</a> returned by the <a>Type Relation</a> of the <a>Class</a> for the
+                    given <a>Vocabulary Term</a>.
                 </li>
             </ul>
         </p>
 
         <p>
-            A <a>class</a> is a <dfn>subclass</dfn> of some other <a>class</a> if every
+            A <a>Class</a> is a <dfn>Subclass</dfn> of some other <a>Class</a> if every
             instance of the former is also an instance of the latter.
         </p>
 
         <p>
-            Given all definitions above, the TD information model is to be understood
-            as a set of <a>class</a> definitions, which include a <a>class</a> name, a
-            <a>signature</a> (elements of which are called property names), an
-            <a>assignment relation</a> and a <a>type relation</a>. These class definitions
-            are provided as tables in Section <a href="#class-definitions"></a>.
+            Given all definitions above, the <a>TD Information Model</a> is to be understood
+            as a set of <a>Class</a> definitions,
+            which include a <a>Class</a> name (a <a>Vocabulary Term</a>),
+            a <a>Signature</a> (a set of <a>Vocabulary Terms</a>),
+            an <a>Assignment Relation</a>,
+            and a <a>Type Relation</a>.
+            These <a>Class</a> definitions are provided as tables in <a href="#class-definitions"></a>.
         </p>
 
         <p>
-            In addition, the TD information model defines another relation for each
-            <a>class</a> that takes a <a>term</a> as input and returns an <a>object</a>,
-            i.e. a <dfn>default value</dfn> for some assignment. This relation allows
-            to relax the constraint defined above on the <a>assignment relation</a>:
-            an <a>object</a> is an instance of a <a>class</a> if it includes all mandatory
-            assignments <em>or</em> if <a>default value</a>s exist for the missing
-            assignments. All default values are given in a single table in Section
+            In addition, the <a>TD Information Model</a> defines another relation for each
+            <a>Class</a> that takes a <a>Vocabulary Term</a> as input and returns an <a>Object</a>,
+            which is the <dfn>Default Value</dfn> for some assignment. This relation allows
+            to relax the constraint defined above on the <a>Assignment Relation</a>:
+            an <a>Object</a> is an instance of a <a>Class</a> if it includes all mandatory
+            assignments <em>or</em> if <a>Default Value</a> exist for the missing
+            assignments. All <a>Default Values</a> are given in a single table in
             <a href="#sec-default-values"></a>.
         </p>
 
         <p>
             The formalization introduced here does not consider the possible relation
-            between objects as abstract data structures and physical world objects
-            like WoT Things. However, care was given to the possibility of re-interpreting
-            all <a>vocabulary terms</a> involved in the TD information model as RDF
+            between <a>Objects</a> as abstract data structures and physical world objects
+            such as <a>Things</a>. However, care was given to the possibility of re-interpreting
+            all <a>Vocabulary Terms</a> involved in the <a>TD Information Model</a> as RDF
             resources, so as to integrate them in a larger model of the physical world
             (an ontology). This aspect is dealt with in Appendix
             <a href="#thing-description-ontology"></a>.
@@ -1307,8 +1331,8 @@ a[href].internalDFN {
 
         <p>
             <span class="rfc2119-assertion" id="td-vocabulary">
-                A TD processor MUST be able to detect that a <a>TD</a> does not
-                meet class instantiation constraints on all classes defined in Section
+                A <a>TD Processor</a> MUST be able to detect that a TD does not
+                meet <a>Class</a> instantiation constraints on all <a>Classes</a> defined in
                 <a href="#sec-core-vocabulary-definition"></a>,
                 <a href="#sec-data-schema-vocabulary-definition"></a>,
                 <a href="#sec-security-vocabulary-definition"></a>,
@@ -1474,10 +1498,11 @@ when the texts are served as a result such negotiation.
       <section id="sec-data-schema-vocabulary-definition">
       <h2>Data Schema Vocabulary Definitions</h2>
       <p>
-        The data schema definition reflecting a very common subset of the terms defined in JSON Schema [[?JSON-SCHEMA-VALIDATION]]. It is noted
-        that data schema definitions within Thing Description instances are not limited to this defined subset and MAY use additional terms you 
-        find in JSON Schema. In that case it is recommended to use context association for that additional terms as described in 
-        <a href="#content-extension-section"></a>, otherwise these terms are semantically ignored (also see <a href="#note-jsonld11-processing"></a>).
+        The data schema definition is reflecting a very common subset of the terms defined by JSON Schema [[?JSON-SCHEMA-VALIDATION]]. It is noted
+        that data schema definitions within Thing Description instances are not limited to this defined subset and MAY use additional terms
+        found in JSON Schema. In that case, it is recommended to use context extension for the additional terms as described in
+        <a href="#content-extension-section"></a>, otherwise these terms are semantically ignored by <a>TD Processors</a>
+        (also see <a href="#note-jsonld11-processing"></a>).
       </p>
 
         <section><h3><code>DataSchema</code></h3><p>A JSON specification.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types)</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display a text for UI representation) of the interaction pattern based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
@@ -1511,22 +1536,22 @@ when the texts are served as a result such negotiation.
 <tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema"><td><code>required</code></td><td>Defines which members of the object type are mandatory.</td><td>optional</td><td>array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
 <section><h3><code>StringSchema</code></h3><p>A JSON string value specification ("type": "string").</p></section>
 <section><h3><code>NullSchema</code></h3><p>A JSON null value specification ("type": "null"). If the type of null then it has only one acceptable value, namely null. E.g., it can be used as part of oneOf declaration, where it is used to indicate, that a data schema can also be null.</p></section>
+
       </section>
     
       <section id="sec-security-vocabulary-definition">
       <h2>Security Vocabulary Definitions</h2>
-    
+
       <p>
-      For the core TD vocabulary only well-established security  
-      mechanisms are supported, such as those built into protocols supported by WoT  
-      or already in wide use with those protocols.  
+      This specification provides a selection of well-established security mechanisms
+      that are directly built into protocols eligable as <a>Protocol Bindings</a> for W3C WoT
+      or are widely in use with those protocols.
       The current set of HTTP security schemes is partly based on 
       <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject">OpenAPI 3.0.1</a> (see also [[?OPENAPI]]). 
-      However while the HTTP security schemes, 
-      vocabulary and syntax given in this specification share many similarities 
-      with OpenAPI they are not compatible.  
+      However while the HTTP security schemes, <a>Vocabulary</a>, and syntax
+      given in this specification share many similarities with OpenAPI, they are not compatible.
       </p>
-    
+
         <section><h3><code>SecurityScheme</code></h3><p></p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme"><td><code>scheme</code></td><td>Identification of security mechanism being configured.</td><td>mandatory</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g. <code>nosec</code>, <code>basic</code>, <code>cert</code>, <code>digest</code>, <code>bearer</code>, <code>pop</code>, <code>psk</code>, <code>public</code>, <code>oauth2</code>, or <code>apikey</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable) information based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable) information in different languages.</td><td>optional</td><td><a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
@@ -1567,14 +1592,16 @@ when the texts are served as a result such negotiation.
 <tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme"><td><code>refresh</code></td><td>URI of the refresh server.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an OAuth2SecurityScheme active on that form.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme"><td><code>flow</code></td><td>Authorization flow (one of implicit, password, client, or code).</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+
       </section>
-    
+
       <section id="sec-web-linking-vocabulary-definition">
       <h2>Web Linking Vocabulary Definitions</h2>
+
       <p>
         The present model provides a representation for (typed) Web links exposed by
-        a Thing. The web linking definition reflecting a very common subset of the terms defined in 
-        Web Linking [[!RFC8288]]. The defined terms can be used, e.g., to describe the relation to another Thing such 
+        a <a>Thing</a>. The Web Linking definition is reflecting a very common subset of the terms defined in
+        Web Linking [[!RFC8288]]. The defined terms can be used, e.g., to describe the relation to another <a>Thing</a> such
         as a <i>Lamp Thing</i> is controlled by a <i>Switch Thing</i>.
      </p>
 
@@ -1595,6 +1622,11 @@ op can be assigned one or more interaction verb(s) each representing a semantic 
 For example, for HTTP and Events, it indicates which of several available mechanisms should be used for asynchronous notifications such as long polling, websub (also see https://www.w3.org/TR/websub/), or server sent events (also see https://www.w3.org/TR/eventsource/). Please note that there is no restriction on the sub-protocol selection and other mechanisms can also be announced by this subprotocol term.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-security--Form"><td><code>security</code></td><td>Set of security definition names, chosen from those defined in securityDefinitions.  These must all be satisfied for access to resources.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an OAuth2SecurityScheme active on that form.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or array of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table>
+<p>Possible values for the <code>contentCoding</code> property can be found e.g. in
+the <a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
+IANA HTTP content coding registry</a>.
+</p>
+
 <p>The list of possible operation types of a form is fixed. It only includes the
 well-known types necessary to implement the WoT interaction model described in
 [[WOT-ARCHITECTURE]]. Future versions of the standard may extend this list but
@@ -1602,17 +1634,13 @@ well-known types necessary to implement the WoT interaction model described in
 operations types SHOULD NOT be arbitrarily set by servients
 </span>.
 </p>
-
-<p>Possible values for the <code>contentCoding</code> property can be found e.g. in
-the <a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
-IANA HTTP content coding registry</a>.
-</p>
 </section>
 <section><h3><code>Link</code></h3><p>A link can be viewed as a statement of the form "link context has a link relation type resource at link target, which has target attributes".</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Link"><td><code>href</code></td><td>target IRI of a link or submission target of a form.</td><td>mandatory</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-type--Link"><td><code>type</code></td><td>Target attribute providing a hint indicating what the media type [IANA-MEDIA-TYPES] of the result of dereferencing the link should be.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-rel--Link"><td><code>rel</code></td><td>A link relation type identifies the semantics of a link.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link"><td><code>anchor</code></td><td>By default, the context, or anchor, of a link conveyed in the Link header field is the URL of the representation it is associated with, as defined in RFC7231, Section 3.1.4.1, and is serialized as a URI.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr></tbody></table></section>
 <section><h3><code>ExpectedResponse</code></h3><p>Communication metadata for response messages (e.g., contentType of the response).</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type [[IANA-MEDIA-TYPES]] (e.g., 'application/json) and (optional) parameters (e.g., 'charset=utf-8').</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+
       </section>
 
     </section>
@@ -1622,16 +1650,16 @@ IANA HTTP content coding registry</a>.
 
       <p>
           <span class="rfc2119-assertion" id="td-vocabulary-defaults">
-            When assignments in a TD are missing, a TD processor MUST follow
-            the default value assignments expressed in the Table of Section
+            When assignments in a TD are missing, a <a>TD Processor</a> MUST follow
+            the default value assignments expressed in the table of
             <a href="#sec-default-values"></a>.
           </span>
       </p>
       
       <p>
-          The following table gives all <a>default value</a>s defined in the
-          classes of the TD information model. An empty cell in the last column
-          must be interpreted as applying to all classes.
+          The following table gives all <a>Default Values</a> defined in the
+          <a>Classes</a> of the <a>TD Information Model</a>. An empty cell in the last column
+          must be interpreted as applying to all <a>Classes</a>.
       </p>
 
       <table class="def">
@@ -1740,62 +1768,61 @@ IANA HTTP content coding registry</a>.
     </section>
 
   <section id="sec-td-serialization">
-  <h1>Thing Description Serialization</h1>
+  <h1>Thing Description Representation Format</h1>
 
   <p>
-  Thing Description instances are modeled and structured based on Section
+  Thing Description instances are modeled and structured based on
   <a href="#sec-vocabulary-definition"></a>.
+  This section defines a JSON-based representation format for <a>Things</a>,
+  a serialization of the <a>TD Information Model</a>.
+  </p>
 
-</p>
-
-<p>
+  <p>
     <span class="rfc2119-assertion" id="td-processor-serialization">
-        A TD processor MUST be able to serialize TDs in the JSON format and
-        deserialize TDs from that format, according to the rules noted
-        in Sections <a href="#td-basic-types-mapping"></a> and
+        A <a>TD Processor</a> MUST be able to serialize the <a>TD Information Model</a>
+        into the JSON format [[!RFC8259]] and
+        deserialize TD models from that format, according to the rules noted in
+        <a href="#td-basic-types-mapping"></a> and
         <a href="#td-class-serialization"></a>.
     </span>
-</p>
+  </p>
 
-<p>
-  The JSON serialization of TDs is aligned with the syntax of JSON-LD 1.1 [[json-ld11]]
+  <p>
+  The JSON serialization of the <a>TD Information Model</a> is aligned with
+  the syntax of JSON-LD 1.1 [[?json-ld11]]
   in order to streamline semantic evaluation.
-  Hence, TD serializations can be processed either as raw JSON
+  Hence, the TD representation format can be processed either as raw JSON
   or with a JSON-LD 1.1 processor,
   as further detailed in <a href="#note-jsonld11-processing"></a>.
-</p>
-
-
-
+  </p>
 
 <p>
 In order to support interoperable internationalization,
 <span class="rfc2119-assertion" id="td-json-open">TDs MUST be serialized according to the 
-requirements defined in Section 8.1 of RFC8259 [[RFC8259]] for open ecosystems.</span>
+requirements defined in Section 8.1 of RFC8259 [[!RFC8259]] for open ecosystems.</span>
 In summary, this requires the following:
 <ul>
-<li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[RFC3629]].</span</li>
+<li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[!RFC3629]].</span</li>
 <li><span class="rfc2119-assertion" id="td-json-open_no-byte-order">Implementations MUST NOT 
  add a byte order mark (U+FEFF) to the beginning of a networked-transmitted TD.</span></li>
-<li><span class="rfc2119-assertion" id="td-json-open_accept-byte-order">Implementations that parse TDs MAY ignore
+<li><span class="rfc2119-assertion" id="td-json-open_accept-byte-order"><a>TD Processors</a> MAY ignore
  the presence of a byte order mark rather than treating it as an error.</span></li>
 </ul>
 </p>
 
-  <section id="json-serializiation-section">
-  <h2>Basic Representation Format Assumptions</h2>
-   
+<section id="td-basic-types-mapping">
+<h2>Mapping to JSON Types</h2>
+
   <p>
-    As a fundamental basis, every <a>object</a> in a <a>TD</a>
-    is serialized as a JSON object and every name-value pair in the original
-    <a>object</a> is serialized as a member of the JSON object.
+    The <a>TD Information Model</a> is constructed,
+    so that there is an easy mapping between model <a>Objects</a> and JSON types.
+    Every <a>Class</a> instances maps to a JSON object,
+    where each name-value pair of the <a>Class</a> instance
+    is a member of the JSON object.
   </p>
 
-  <section id="td-basic-types-mapping">
-  <h3>Mapping to JSON Types</h3>
-
   <p>
-    Every <a>simple type</a> mentioned in Section
+    Every <a>Simple Type</a> mentioned in
     <a href="#class-definitions"></a> maps to a JSON
     type (string, number, boolean), as per the rules listed below. These
     rules apply to values in name-value pairs:
@@ -1830,33 +1857,35 @@ In summary, this requires the following:
   </ul>
 
   <p>
-    Values that are themselves sets of property-value pairs (i.e. not of a <a>simple
-    type</a>) will be dealt with individually in Section <a href="#td-class-serialization"></a>.
+    Values that are themselves sets of property-value pairs (i.e., not of a <a>Simple
+    Type</a>) will be dealt with individually in <a href="#td-class-serialization"></a>.
+    These include <a>Arrays</a> and <a>Maps</a>.
   </p>
 
-  </section>
+</section>
   
-  <section id="omitting-default-values">
-  <h3>Omitting Default Values</h3>
+<section id="omitting-default-values">
+<h2>Omitting Default Values</h2>
 
   <p>
-  A Thing Description instance serialization may omit <a>vocabulary term</a>s for which
-  default values can be assigned, as listed in the table given in <a href="#sec-default-values"></a>.
+  A Thing Description serialization may omit <a>Vocabulary Term</a>
+  for which <a>Default Values</a> are defined,
+  as listed in the table given in <a href="#sec-default-values"></a>.
   </p>
 
   <p>
   The following example shows the TD instance from
   <a href="#simple-thing-description-sample">Example 1</a>
-  with a checkbox to also include the <a>vocabulary terms</a> with default values (=checkbox checked).
-  These terms can be omitted (=checkbox unchecked) to simplify the TD representation.
-  Note that a Thing Description processor interprets these omitted terms identically
-  as if these terms were explicitly present with the default values.
+  with a checkbox to also include the members with <a>Default Values</a> (=checkbox checked).
+  These members can be omitted (=checkbox unchecked) to simplify the TD serialization.
+  Note that a <a>TD Processor</a> interprets these omitted members identically
+  as if they were explicitly present with a given <a>Default Value</a>.
   </p>
 
   <aside class="example with-default">
     <div class="with-default-control">
       <input type="checkbox"/>
-      <span><i>with default values</i></span>
+      <span><i>with Default Values</i></span>
     </div>
 <pre>{
     "@context": "https://www.w3.org/2019/td/v1",
@@ -1953,37 +1982,37 @@ In summary, this requires the following:
     </aside>
 
     <p>
-    Please note that, depending on the Protocol Binding used,
-    additional protocol-specific <a>vocabulary terms</a> may apply,
-    which also have associated default values and can also be omitted as explained in this subsection.
+    Please note that, depending on the <a>Protocol Binding</a> used,
+    additional protocol-specific <a>Vocabulary Terms</a> may apply.
+    They may also have associated <a>Default Values</a>,
+    and hence can also be omitted as explained in this subsection.
     Further information can be found in <a href="#protocol-bindings"></a>.
     </p>
-    </section>
-
-  </section> <!-- end of section "Basic assumptions" -->
+  </section>
 
 <section id="td-class-serialization">
-  <h2>Information Model Serialization</h2>
+<h2>Information Model Serialization</h2>
 
   <section id="sec-thing-as-a-whole-json">
   <h3>Thing Root Object</h3>
 
   <p>
-    A <a>TD</a> is a data structure rooted at an <a>object</a>
-    of type <code>Thing</code>. In turn, a JSON <a>TD serialization</a>
+    A Thing Description is a data structure rooted at an <a>Object</a>
+    of type <a href="#thing"><code>Thing</code></a>.
+    In turn, a JSON serialization of the Thing Description
     is a JSON object, which is the root of a syntax tree constructed
-    from the abstract TD structure.
+    from the <a>TD Information Model</a>.
   </p>
 
   <p>
   <span class="rfc2119-assertion" id="td-context">
   The root JSON object of a TD serialization MUST include
   a member with the name <code>@context</code> and a value of type
-  string or array that contains
-  <code>https://www.w3.org/2019/td/v1</code> to identify the
-  TD representation format version defined by this document.
+  string or array that contains <code>https://www.w3.org/2019/td/v1</code>.
   </span>
-  For JSON-LD processing [[json-ld11]],
+  In general, this URI is used to identify the
+  TD representation format version defined by this document
+  For JSON-LD processing [[?json-ld11]],
   the <code>@context</code> specifies the Thing Description context file
   and optionally additional term definitions.
   </p>
@@ -1996,9 +2025,9 @@ In summary, this requires the following:
 </pre>
 
   <p><span class="rfc2119-assertion" id="td-context-toplevel">
-    All name-value pairs of an instance of <code>Thing</code> where the name
-    is a <a>term</a> included in the signature of <code>Thing</code> MUST be
-    serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of <code>Thing</code>,
+    where the name is a <a>Vocabulary Term</a> in the <a>Signature</a> of <code>Thing</code>,
+    MUST be serialized as JSON members of the root object.
   </span></p>
 
   <pre class="example">
@@ -2025,16 +2054,23 @@ In summary, this requires the following:
 
   <!-- should this be "the type" or "the elements of"? -->
   <p><span class="rfc2119-assertion" id="td-objects">
-  All values assigned to <code>properties</code>,
-  <code>actions</code>, <code>events</code>, <code>version</code>,
-  and <code>securityDefinitions</code> in an instance of <code>Thing</code>
+  All values assigned to
+  <code>version</code>,
+  <code>securityDefinitions</code>,
+  <code>properties</code>,
+  <code>actions</code>, and
+  <code>events</code>
+  in an instance of <a>Class</a> <code>Thing</code>
   MUST be serialized as JSON objects.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-arrays">
-  All values assigned to <code>forms</code>, <code>links</code>,
-  <code>scopes</code>, and <code>security</code> in an instance of
-  <code>Thing</code> MUST be serialized as JSON arrays.
+  All values assigned to
+  <code>security</code>,
+  <code>links</code>, and
+  <code>forms</code>
+  in an instance of <a>Class</a> <code>Thing</code>
+  MUST be serialized as JSON arrays.
   </span></p>
 
 </section> <!-- end of id="sec-thing-as-a-whole-json"-->
@@ -2043,32 +2079,32 @@ In summary, this requires the following:
 <h3><code>properties</code></h3>
   
   <p>
-  In a <code>Thing</code> instance, the value assigned to <code>properties</code> (at the
-  root level) is a map of instances of <code>PropertyAffordance</code>.
+  The value assigned to <code>properties</code> in a <code>Thing</code> instance
+  is a <a>Map</a> of instances of <code>PropertyAffordance</code>.
   <span class="rfc2119-assertion" id="td-properties">
-  A map of <code>PropertyAffordance</code> instances MUST be serialized as an object
-  with a (unique) JSON name to identify each Property affordance object.
+    A map of <code>PropertyAffordance</code> instances MUST be serialized as an object
+    with a (unique) JSON name to identify each Property affordance object.
   </span></p>
 
   <p>
   <span class="rfc2119-assertion" id="td-property-names">
-    All name-value pairs of an instance of <code>PropertyAffordance</code> where the name
-    is a <a>term</a> included in the signatures of <code>PropertyAffordance</code>,
-    <code>InteractionAffordance</code> and <code>DataSchema</code> MUST be
-    serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of <code>PropertyAffordance</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    <code>PropertyAffordance</code>, <code>InteractionAffordance</code>, or <code>DataSchema</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span>
   See <a href="#data-schema-serialization-json" class="sec-ref"></a> for
-  details on the <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> superclass.
+  details on the <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> <a>Superclass</a>.
   </p>
 
   <p><span class="rfc2119-assertion" id="td-property-arrays">
-  The value assigned to <code>forms</code> in an instance of <code>PropertyAffordance</code>
-  MUST be serialized as a JSON array. Each element in the array must be a JSON
-  object as defined in <a href="#form-serialization-json" class="sec-ref"></a>
+    The value assigned to <code>forms</code> in an instance of <code>PropertyAffordance</code>
+    MUST be serialized as a JSON array
+    containing one or more JSON object serializations as defined in <a href="#form-serialization-json"></a>.
   </span></p>
 
   <p>
-  A snippet for two Property affordances is given below:
+  A snippet for two <a>Property</a> affordances is given below:
   </p>
 
 <aside class="example" id="property-serialization-sample" title="Sample of Property serializations">
@@ -2113,32 +2149,33 @@ In summary, this requires the following:
 
   <p>
     In a <code>Thing</code> instance, the value assigned to <code>actions</code>
-    is a map of instances of <code>ActionAffordance</code>.
+    is a <a>Map</a> of instances of <code>ActionAffordance</code>.
     <span class="rfc2119-assertion" id="td-actions">
     A map of <code>ActionAffordance</code> instances MUST be serialized as an object
     with a (unique) JSON name to identify each Action affordance object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-action-names">
-    All name-value pairs of an instance of <code>ActionAffordance</code> where the name
-    is a <a>term</a> included in the signatures of <code>ActionAffordance</code> and
-    <code>InteractionAffordance</code> MUST be serialized as JSON members with the
-    <a>term</a> as name.
+    All name-value pairs of an instance of <code>ActionAffordance</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    <code>ActionAffordance</code> or <code>InteractionAffordance</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
   <span class="rfc2119-assertion" id="td-action-objects">
     The values assigned to <code>input</code> and <code>output</code> in an instance of
-    <code>ActionAffordance</code> MUST be a JSON object.
+    <code>ActionAffordance</code>
+    MUST be serialized as JSON objects.
   </span>
-  They rely on the the class <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
+  They rely on the the <a>Class</a> <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
   whose serialization is defined in <a href="#data-schema-serialization-json"></a>.
   </p>
 
   <p><span class="rfc2119-assertion" id="td-action-arrays">
     The value assigned to <code>forms</code> in an instance of <code>ActionAffordance</code>
-    MUST be serialized as a JSON array. Each element in the array must be a JSON
-    object as defined in <a href="#form-serialization-json" class="sec-ref"></a>
+    MUST be serialized as a JSON array
+    containing one or more JSON object serializations as defined in <a href="#form-serialization-json"></a>.
   </span></p>
 
   <p>
@@ -2192,26 +2229,27 @@ In summary, this requires the following:
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-event-names">
-    All name-value pairs of an instance of <code>EventAffordance</code> where the name
-    is a <a>term</a> included in the signatures of <code>EventAffordance</code> and
-    <code>InteractionAffordance</code> MUST be serialized as JSON members with the
-    <a>term</a> as name.
+    All name-value pairs of an instance of <code>EventAffordance</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    <code>EventAffordance</code> or <code>InteractionAffordance</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
   <span class="rfc2119-assertion" id="td-event-objects">
-  The values assigned to <code>subscription</code>,
-  <code>data</code>, and <code>cancellation</code>
-  in an instance of <code>EventAffordance</code>
-  MUST be a JSON object.
+    The values assigned to <code>subscription</code>,
+    <code>data</code>, and <code>cancellation</code>
+    in an instance of <code>EventAffordance</code>
+    MUST be serialized as JSON objects.
   </span>
-  They rely on the the class <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
+  They rely on the the <a>Class</a> <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
   whose serialization is defined in <a href="#data-schema-serialization-json"></a>.
   </p>
 
   <p><span class="rfc2119-assertion" id="td-event-arrays">
-  The value assigned to <code>forms</code> in an instance of <code>EventAffordance</code> MUST be a JSON array
-  containing one or more object serializations as defined in <a href="#form-serialization-json"></a>.
+  The value assigned to <code>forms</code> in an instance of <code>EventAffordance</code>
+  MUST be serialized as a JSON array
+  containing one or more JSON object serializations as defined in <a href="#form-serialization-json"></a>.
   </span></p>
 
   <p>
@@ -2246,9 +2284,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 <h3><code>forms</code></h3>
 
   <p><span class="rfc2119-assertion" id="td-forms">
-    All name-value pairs of an instance of <code>Form</code> where the name
-    is a <a>term</a> included in the signatures of <code>Form</code> MUST
-    be serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of <code>Form</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signature</a> of <code>Form</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-form-protocolbindings">
@@ -2290,7 +2328,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p><span class="rfc2119-assertion" id="td-uriVariables-dataschema">
   The serialization of each value in the map assigned to <code>uriVariables</code>
   in an instance of <code>Form</code> MUST
-  rely on the class <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
+  rely on the <a>Class</a> <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
   whose serialization is defined in <a href="#data-schema-serialization-json"></a>.
   </span></p>
 
@@ -2334,7 +2372,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 </pre>
 
   <p>
-  In some use cases, the form metadata of the Interaction Affordance not only
+  In some use cases, the form metadata of the <a>Interaction Affordance</a> not only
   describes the request, but also provides metadata for the expected response.
   For instance, an Action <code>takePhoto</code> defines an <code>input</code> schema
   to submit parameter settings of a camera (aperture priority, timer, etc.) using
@@ -2353,7 +2391,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   </span>
   <span class="rfc2119-assertion" id="td-forms-response">
   If present, the response object MUST contain a <code>contentType</code> member as
-  defined in the class definition of
+  defined in the <a>Class</a> definition of
   <a href="#expectedresponse" class="sec-ref"><code>ExpectedResponse</code></a>.
   </span>
   </p>
@@ -2384,14 +2422,14 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 </pre>
 
   <p>
-  When <code>forms</code> is present at the top level, it can be used to describe meta interactions offered by a Thing.
+  When <code>forms</code> is present at the top level, it can be used to describe meta interactions offered by a <a>Thing</a>.
   For example, the operation types "readallproperties" and "writeallproperties" are for meta
-  interactions with a Thing by which Consumers can read and write all properties at once.
+  interactions with a <a>Thing</a> by which <a>Consumers</a> can read and write all properties at once.
   In the example below, a <code>forms</code> member is included in the TD root object
-  and the Consumer can use the submission target
+  and the <a>Consumer</a> can use the submission target
   <code>https://mylamp.example.com/allproperties</code> both to read or write all
   Properties (i.e., <code>on</code>, <code>brightness</code>, and <code>timer</code>)
-  of the Thing in a single protocol transaction.
+  of the <a>Thing</a> in a single protocol transaction.
   </p>
 
 <pre class="example" id="td-forms-readall-example">
@@ -2432,9 +2470,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 <h3><code>links</code></h3>
 
   <p><span class="rfc2119-assertion" id="td-links">
-    All name-value pairs of an instance of <code>Link</code> where the name
-    is a <a>term</a> included in the signatures of <code>Link</code> MUST
-    be serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of <code>Link</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signature</a> of <code>Link</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>A TD snippet of a link object in the <code>links</code> array is given below:</p>
@@ -2458,24 +2496,25 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
     In a <code>Thing</code> instance, the value assigned to
-    <code>securityDefinitions</code> is a map of instances of
+    <code>securityDefinitions</code> is a <a>Map</a> of instances of
     <code>SecurityScheme</code>.
     <span class="rfc2119-assertion" id="td-security">
-    A map of <code>SecurityScheme</code> instances MUST be serialized as an object
+    A <a>Map</a> of <code>SecurityScheme</code> instances MUST be serialized as JSON object
     with a (unique) JSON name to identify each Security configuration object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-security-schemes">
-    All name-value pairs of an instance of one of the <a>subclass</a>es of
-    <code>SecurityScheme</code> where the name is a <a>term</a> included in the
-    signatures of that <a>subclass</a> and <code>SecurityScheme</code> MUST
-    be serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of one of the <a>Subclasses</a> of
+    <code>SecurityScheme</code>,
+    where the name is a <a>Vocabulary Term</a> included in the
+    <a>Signatures</a> of that <a>Subclass</a> or <code>SecurityScheme</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
   The following TD snippet shows a simple security configuration specifying
   basic username/password authentication in the header.
-  The value given for <code>in</code> is actually the default value (<code>header</code>)
+  The value given for <code>in</code> is actually the <a>Default Value</a> (<code>header</code>)
   and could be omitted.
   First, a named security configuration must be given
   in the <code>securityDefinitions</code> map.
@@ -2497,11 +2536,11 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   Here is a more complex example: a TD snippet showing digest authentication
-  on a proxy combined with bearer token authentication on the endpoint.
+  on a proxy combined with bearer token authentication on the <a>Thing</a>.
   Here the default value of <code>in</code> in the <code>digest</code> scheme,
   <code>header</code>, is omitted, but still applies.
   Note that the corresponding private security configuration
-  such as username/password and tokens must be configured in the Consumer
+  such as username/password and tokens must be configured in the <a>Consumer</a>
   to interact successfully.
   </p>
 
@@ -2530,7 +2569,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   At least one security definition MUST be activated through the
   <code>security</code> array at the Thing level (i.e., in the TD root object).
   </span>
-  This configuration can be seen as the default security mechanism required to interact with the Thing.
+  This configuration can be seen as the default security mechanism required to interact with the <a>Thing</a>.
   <span class="rfc2119-assertion" id="td-security-overrides">
   Security definitions MAY also be activated at the form level by including a
   <code>security</code> member in form objects,
@@ -2541,7 +2580,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p>
   The <code>nosec</code> security scheme is provided for the case that 
   no security is needed.
-  The minimal security configuration for a Thing is activation
+  The minimal security configuration for a <a>Thing</a> is activation
   of the <code>nosec</code> security scheme 
   at the Thing level, as shown in the following example:
   </p>
@@ -2564,7 +2603,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   To give a more complex example, 
-  suppose we have a Thing where all Interaction Affordances
+  suppose we have a <a>Thing</a> where all <a>Interaction Affordances</a>
   require basic authentication except for one, for which
   no authentication is required.
   For the <code>status</code> Property and the <code>toggle</code> Action,
@@ -2613,7 +2652,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   Security configurations can also can be specified for different forms
-  within the same Interaction Affordance. This may be required for devices that support
+  within the same <a>Interaction Affordance</a>. This may be required for devices that support
   multiple protocols, for example HTTP and CoAP [[?RFC7252]], which support different
   security mechanisms.  This is also useful when alternative authentication
   mechanisms are allowed.  Here is a TD snippet demonstrating three possible
@@ -2624,7 +2663,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   provides a way to combine security mechanisms in an "OR" fashion.
   In contrast, putting multiple security configurations in the same
   <code>security</code> member combines them in an "AND" fashion, 
-  since in that case they would all need to be satisfied to allow activation of the Interaction Affordance.
+  since in that case they would all need to be satisfied to allow activation of the <a>Interaction Affordance</a>.
   Note that activating one (default) configuration at the Thing level is still mandatory.
   </p>
 
@@ -2660,9 +2699,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   As another more complex example, OAuth2 makes use of scopes. 
   These are identifiers that 
   may appear in tokens and must match with corresponding identifiers in a resource to allow 
-  access to that resource (or Interaction Affordance in the case of W3C WoT).
+  access to that resource (or <a>Interaction Affordance</a> in the case of W3C WoT).
   For example, in the following, the <code>status</code> Property can be
-  read by Consumers using bearer tokens containing the scope <code>limited</code>,
+  read by <a>Consumers</a> using bearer tokens containing the scope <code>limited</code>,
   but the <code>configure</code> Action can only be invoked
   with a token containing the <code>special</code> scope.
   Scopes are not identical to roles, but are often associated with them;
@@ -2715,9 +2754,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 <h3><code>version</code></h3>
 
   <p><span class="rfc2119-assertion" id="td-version">
-    All name-value pairs of an instance of <code>VersionInfo</code> where the
-    name is a <a>term</a> included in the signatures of <code>VersionInfo</code>
-    MUST be serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of <code>VersionInfo</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signature</a> of <code>VersionInfo</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>The recommended version identification pattern value is to rely on the semantic versioning policy [[?SemVer]].</p>
@@ -2734,7 +2773,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   <span class="rfc2119-assertion" id="td-version-container">
-  The <code>version</code> map MAY be used to provide additional application-
+  The <code>version</code> <a>Map</a> MAY be used to provide additional application-
   and/or device-specific version information based on terms from non-TD vocabularies.
   </span>
   See <a href="#content-extension-section"></a> for how to include additional namespaces.
@@ -2747,44 +2786,44 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   The data schemas of WoT Thing Description defined through the
-  <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> class
+  <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> <a>Class</a>
   are based on a subset of the JSON Schema terms [[?JSON-SCHEMA-VALIDATION]].
   Thus, serializations of the TD data schemas can be fed directly into JSON Schema
-  validator implementations to validate the data exchanged with Things.
+  validator implementations to validate the data exchanged with <a>Things</a>.
   </p>
 
   <p>
-  Data schema serialization applies to <a href="#property-serialization-json">Property objects</a>,
+  Data schema serialization applies to <code>PropertyAffordance</code> instances,
   the values assigned to <code>input</code> and <code>output</code> in
-  <a href="#action-serialization-json">Action objects</a>,
+  <code>ActionAffordance</code> instances,
   the values assigned to <code>subscription</code>, <code>data</code>, and <code>cancellation</code> in
-  <a href="#event-serialization-json">Event objects</a>,
-  and the value assigned to <code>uriVariables</code> in Interaction Affordance objects in general
+  <code>EventAffordance</code> instances,
+  and the value assigned to <code>uriVariables</code> in instances of <a>Subclasses</a> of <code>InteractionAffordance<code>
   (when a <a href="#form-serialization-json">form object</a> uses a URI Template).
   </p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema">
-    All name-value pairs of an instance of one of the <a>subclass</a>es of
-    <code>DataSchema</code> where the name is a <a>term</a> included in the
-    signatures of that <a>subclass</a> and <code>DataSchema</code> MUST
-    be serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of one of the <a>Subclasses</a> of
+    <code>DataSchema</code>, where the name is a <a>Vocabulary Term</a> included in the
+    <a>Signatures</a> of that <a>Subclass</a> or <code>DataSchema</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema-objects">
   The value assigned to <code>properties</code> in an instance of
-  <code>ObjectSchema</code> MUST be a JSON object.
+  <code>ObjectSchema</code> MUST be serialized as a JSON object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema-arrays">
   The values assigned to <code>enum</code>,
   <code>required</code>,
   and <code>oneOf</code> in an instance of <code>DataSchema</code>
-  MUST be a JSON array.
+  MUST be serialized as a JSON array.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema-objects-arrays">
   The value assigned to <code>items</code> in an instance of
-  <code>ArraySchema</code> MUST be a JSON object or a JSON array containing JSON objects.
+  <code>ArraySchema</code> MUST be serialized as a JSON object or a JSON array containing JSON objects.
   </span></p>
 
   <p>
@@ -2830,7 +2869,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   The terms <code>readOnly</code> and <code>writeOnly</code> can be used signal
   which data items are exchanged in read interactions (i.e., when reading a Property)
   and which in write interactions (i.e., when writing a Property).
-  This can be used as workaround when Properties of an unconventional Thing
+  This can be used as workaround when Properties of an unconventional <a>Thing</a>
   exhibit different data for reading and writing, which can be the case when
   augmenting an existing device or service with a Thing Description.
   </p>
@@ -2887,7 +2926,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p>
   The vocabulary terms <code>title</code> and <code>description</code> are 
   used to provide human-readable texts for titles (e.g., a display
-  text for UI) and additional information useful for Consumers of TDs.
+  text for UI) and additional information useful for <a>Consumers</a> of TDs.
   When a default language is specified by assigned a value to <code>@language</code>
   in the <code>@context</code> of a <a href="#sec-thing-as-a-whole-json">Thing object</a>,
   that default language is associated with the string values assigned to
@@ -2935,7 +2974,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   enable human-readable texts in multiple languages using language tags defined in [[!BCP47]].
   <span class="rfc2119-assertion" id="td-multi-languages">
   If present, the values assigned to <code>titles</code> and <code>descriptions</code>
-  in any <a>object</a> in a <a>TD</a> instance
+  in any <a>Object</a> in a TD model
   MUST be serialized as JSON objects.
   The names of their members MUST be language tags as defined in [[!BCP47]]
   (e.g., "en", "de", "ja", "zh-Hans", "zh-Hant")
@@ -3058,11 +3097,11 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     instances with additional (e.g., domain-specific) semantics.
     In addition, it can also be used to specify some configurations
     and behaviors of the underlying communication protocols announced in the
-    Protocol Bindings serialized in <code>forms</code>.
+    <a>Protocol Bindings</a> serialized in <code>forms</code>.
     </p>
     <p>
     For this extension the Thing Description uses the <code>@context</code>
-    mechanism known from JSON-LD [[!json-ld11]].
+    mechanism known from JSON-LD [[?json-ld11]].
     <span class="rfc2119-assertion" id="td-additional-contexts">
     When a Thing Description uses multiple contexts,
     the <code>@context</code> member of the TD root object MUST be an array
@@ -3088,25 +3127,26 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
     <p>
     The context extension allows to add additional vocabulary to a Thing Description instance.
-    If the included namespaces are based on class definitions
+    If the included namespaces are based on <a>Class</a> definitions
     such as those provided by the RDF Schema or OWL,
     they can be used to annotate elements of the TD semantically
-    by associating the affiliation to a class.
+    by associating the <a>Object</a> to a <a>Class</a>.
     <span class="rfc2119-assertion" id="td-jsonld-keywords">
-    Thing Description instances MAY contain the JSON-LD [[json-ld11]] keyword
+    Thing Description instances MAY contain the JSON name
     <code>@type</code> for members that provide semantic annotations.
     </span>
+    <code>@type</code> is a JSON-LD keyword [[?json-ld11]] used to set the type of a node.
     <span class="rfc2119-assertion" id="td-at-type">
-    The <code>@type</code> member MUST be of type string
-    or array of strings for multiple annotations.
+    The value of the <code>@type</code> member MUST be a JSON string
+    or JSON array of strings for multiple annotations.
     </span>
     </p>
 
     <p>
     Additional vocabulary also allows to include additional <a>vocabulary terms</a>
-    within any class of the Information Model, which are serialized as additional
+    within any <a>Class</a> of the Information Model, which are serialized as additional
     JSON members in the corresponding objects.
-    Examples are additional version metadata for the Thing
+    Examples are additional version metadata for the <a>Thing</a>
     or units of measure for data items.
     </p>
 
@@ -3152,17 +3192,17 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   With the context extension in the Thing Description,
-  the communication metadata can be supplemented or new Protocol Bindings added
+  the communication metadata can be supplemented or new <a>Protocol Bindings</a> added
   through additional <a>vocabulary terms</a> serialized into a form object
   (see also <a href="#protocol-bindings"></a>).
   </p>
     
   <p>
-  The following TD example uses a fictional CoAP Protocol Binding,
-  as no such Protocol Binding is available at the time of writing of this specification.
+  The following TD example uses a fictional CoAP <a>Protocol Binding</a>,
+  as no such <a>Protocol Binding</a> is available at the time of writing of this specification.
   It assumes that there is a CoAP RDF vocabulary similar to [[HTTP-in-RDF10]]
   that is accessable via the namespace <code>http://www.example.org/coap-binding#</code>.
-  The supplemented <code>cov:methodName</code> member instructs the Consumer
+  The supplemented <code>cov:methodName</code> member instructs the <a>Consumer</a>
   which CoAP method has to be applied
   (e.g., <code>GET</code> for the CoAP Method Code 0.01,
   <code>POST</code> for the CoAP Method Code 0.02,
@@ -3213,8 +3253,8 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   For this example, we will use a fictional ACE security scheme
   based on [[?draft-ietf-ace-oauth-authz]] and that is, for this example,
   defined by the namespace at <code>http://www.example.org/ace-security#</code>.
-  Note that such addiational security schemes must be subclasses of the
-  class <a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>.
+  Note that such addiational security schemes must be <a>Subclasses</a> of the
+  <a>Class</a> <a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>.
   </p>
 
 <pre class="example">
@@ -3308,20 +3348,18 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 <h3>Security Configurations</h3>
  <p>
  To enable secure interoperation, 
- security configurations must accurately reflect the requirements of the Thing:
+ security configurations must accurately reflect the requirements of the <a>Thing</a>:
 <ul>
 <li>
  <span class="rfc2119-assertion" id="td-security-binding">
- If a Thing requires a specific access mechanism for a resource, that 
- mechanism MUST be specified in the Thing Description's security scheme configuration 
- for that resource. 
+ If a <a>Thing</a> requires a specific access mechanism for an interaction, that
+ mechanism MUST be specified in the security configuration of the Thing Description.
  </span>  
 </li>
 <li>
  <span class="rfc2119-assertion" id="td-security-no-extras">
- If a Thing does not require a specific access mechanism for a resource, that 
- mechanism MUST NOT be specified in the Thing Description's security scheme configuration 
- for that resource. 
+ If a <a>Thing</a> does not require a specific access mechanism for an interaction, that
+ mechanism MUST NOT be specified in the security configuration of the Thing Description.
  </span>  
 </li>
 </ul>
@@ -3336,18 +3374,18 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 <section id="behavior-data">
 <h3>Data Schemas</h3>
 <p>The data schemas provided in the TD should accurately represent the 
-data payloads returned and accepted by the described Thing
-in the interactions specified in the TD.  In general, Consumers should
+data payloads returned and accepted by the described <a>Thing</a>
+in the interactions specified in the TD.  In general, <a>Consumers</a> should
 follow the data schemas strictly, not generating anything not given
 in the WoT Thing Description, but should accept additional data from
-the Thing not given explicitly in the WoT Thing Decription.  In general, Things are <em>described</em> by WoT Thing Descriptions,
-but Consumers are <em>constrained</em> to follow WoT Thing Descriptions when
-interacting with Things.
+the <a>Thing</a> not given explicitly in the WoT Thing Decription.  In general, <a>Things</a> are <em>described</em> by WoT Thing Descriptions,
+but <a>Consumers</a> are <em>constrained</em> to follow WoT Thing Descriptions when
+interacting with <a>Things</a>.
 <ul>
 <li>
 <span class="rfc2119-assertion" 
       id="client-data-schema">
-A WoT Thing acting as a Consumer when interacting with another target Thing 
+A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another target <a>Thing</a>
 described in a WoT Thing Description MUST generate data  
 organized according to the data schemas given in the corresponding
 interactions.
@@ -3363,7 +3401,7 @@ data returned and accepted by each interaction.
 <li>
 <span class="rfc2119-assertion" 
       id="server-data-schema-extras">
-A Thing MAY return additional data from an interaction  
+A <a>Thing</a> MAY return additional data from an interaction
 even when such data is 
 not described in the data schemas given in its WoT Thing Description.
 </span>
@@ -3371,31 +3409,31 @@ not described in the data schemas given in its WoT Thing Description.
 <li>
 <span class="rfc2119-assertion" 
       id="client-data-schema-accept-extras">
-A WoT Thing acting as a Consumer when interacting with another Thing MUST accept without
+A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another <a>Thing</a> MUST accept without
 error any additional data  
-not described in the data schemas given in the target Thing's WoT Thing Description.
+not described in the data schemas given in the Thing Description of the target <a>Thing</a>.
 </span>
 </li>
 <li>
 <span class="rfc2119-assertion" 
       id="client-data-schema-no-extras">
-A WoT Thing acting as a Consumer when interacting with another Thing MUST NOT generate data  
-not described in the data schemas given in that Thing's WoT Thing Description.
+A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another <a>Thing</a> MUST NOT generate data
+not described in the data schemas given in the Thing Description of that <a>Thing</a>.
 </span>
 </li>
 <li>
 <span class="rfc2119-assertion" 
       id="client-uri-template">
-A WoT Thing acting as a Consumer when interacting with another Thing MUST generate URIs 
+A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another <a>Thing</a> MUST generate URIs
 according to the URI Templates, base URIs, and form href parameters
-given in the target Thing's WoT Thing Description.
+given in the Thing Description of the target <a>Thing</a>.
 </span>
 </li>
 <li>
 <span class="rfc2119-assertion" 
       id="server-uri-template">
 URI Templates, base URIs, and href members
-in a WoT Thing Description MUST accurately describe the WoT Interace of the Thing.
+in a WoT Thing Description MUST accurately describe the <a>WoT Interace</a> of the <a>Thing</a>.
 </span>
 </li>
 </ul>
@@ -3405,32 +3443,32 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
 <section>
   <h3>Protocol Bindings</h3>
 
-  <p>A Protocol Binding is the mapping from an Interaction Affordance to concrete messages of a 
-      specific protocol such as HTTP [[!RFC7231]], CoAP [[!RFC7252]], or MQTT [[!MQTT]]. Protocol Bindings of 
-      Interaction Affordances are serialized as <code>forms</code> as defined in <a href="#form-serialization-json"></a>.
+  <p>A <a>Protocol Binding</a> is the mapping from an <a>Interaction Affordance</a> to concrete messages of a
+      specific protocol such as HTTP [[!RFC7231]], CoAP [[!RFC7252]], or MQTT [[!MQTT]]. <a>Protocol Bindings</a> of
+      <a>Interaction Affordances</a> are serialized as <code>forms</code> as defined in <a href="#form-serialization-json"></a>.
     </p>
 
   <p>
     Every form in a WoT Thing Description must have a submission target,
     given by the <code>href</code> member. The URI scheme of this
-    submission target indicates what Protocol Binding the Thing implements
+    submission target indicates what <a>Protocol Binding</a> the <a>Thing</a> implements
     [[WoT-Architecture]].
     For instance, if the target starts with <code>http</code> or
-    <code>https</code>, a Consumer can then infer the Thing implements the
-    HTTP Protocol Binding and it should expect HTTP-specific terms in the
+    <code>https</code>, a <a>Consumer</a> can then infer the <a>Thing</a> implements the
+    HTTP <a>Protocol Binding</a> and it should expect HTTP-specific terms in the
     form instance (see next section, <a href="#http-binding-assertions"></a>).
     <ul>
         <li>
             <span class="rfc2119-assertion" id="bindings-requirements-scheme">
                 Every form in a WoT Thing Description MUST follow the requirements
-                of the Protocol Binding indicated by the URI scheme of its
+                of the <a>Protocol Binding</a> indicated by the URI scheme of its
                 <code>href</code> member.
             </span>
         </li>
         <li>
             <span class="rfc2119-assertion" id="bindings-server-accept">
                 Every form in a WoT Thing Description MUST accurately describe requests
-                (including request headers, if present) accepted by the Thing in an
+                (including request headers, if present) accepted by the <a>Thing</a> in an
                 interaction.
             </span>
         </li>
@@ -3441,21 +3479,21 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     <h4>HTTP Protocol Binding</h4>
 
     <p>
-        Per default the Thing Description supports the HTTP Protocol Binding and
+        Per default the Thing Description supports the HTTP <a>Protocol Binding</a> and
         includes the HTTP RDF vocabulary set definitions from [[HTTP-in-RDF10]] and can be 
         directly used within TD instances by the usage of the prefix <code>htv</code>, which 
         points to <code>http://www.w3.org/2011/http#</code>. 
     </p>
     <p>
-        To interact with a Thing that implements the HTTP Protocol Binding, a Consumer
+        To interact with a <a>Thing</a> that implements the HTTP <a>Protocol Binding</a>, a <a>Consumer</a>
         needs to know what HTTP method to use when submitting a form. In the general case,
         a Thing Description can explicitly include a term indicating the method, i.e.,
         <code>htv:methodName</code>. For the
-        sake of conciseness, the HTTP Protocol Binding defines default values for each operation type, 
-        which also aims at convergence of the methods expected by Things (e.g., GET to read, PUT to write).
+        sake of conciseness, the HTTP <a>Protocol Binding</a> defines default values for each operation type,
+        which also aims at convergence of the methods expected by <a>Things</a> (e.g., GET to read, PUT to write).
         <span class="rfc2119-assertion" id="td-default-http-method">
             When no method is indicated in a form representing an HTTP
-            Protocol Binding, a default value MUST be assumed as shown in
+            <a>Protocol Binding</a>, a default value MUST be assumed as shown in
             the following table.
         </span>
     </p>
@@ -3616,8 +3654,8 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       <h4>Other Protocol Bindings</h4>
 
       <p>
-          The number of Protocol Bindings a Thing can implement
-          is not restricted. Other Protocol Bindings, e.g., for CoAP, MQTT, or OPC UA
+          The number of <a>Protocol Bindings</a> a <a>Thing</a> can implement
+          is not restricted. Other <a>Protocol Bindings</a>, e.g., for CoAP, MQTT, or OPC UA
           will be standardized in separate documents such as a protocol vocabulary similar to HTTP in RDF [[HTTP-in-RDF10]]
           or specifications including default value definitions. Such protocols can be simply integrated into the TD by the 
           usage of the context extension mechanism (<a href="#content-extension-section"></a>).
@@ -3654,7 +3692,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
   <section id="sec-security-consideration-context">
   <h5>Context Dereferencing Privacy Risk</h5>
       <p>Deferencing the vocabulary files given in the <code>@context</code>
-          member of any JSON-LD [[json-ld11]] document can be a privacy risk.
+          member of any JSON-LD [[?json-ld11]] document can be a privacy risk.
           In the case of the WoT, an attacker can observe the network
           traffic produced by such deferences and can use the metadata
           of the dereference, such as the destination IP address,
@@ -3687,14 +3725,14 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       <dl><dt>Mitigation:</dt><dd>
           All identifiers should be mutable,
           and there should be a mechanism to update the <code>id</code>
-          of a Thing.
+          of a <a>Thing</a>.
           Specifically,
-          the <code>id</code> of a Thing should not be fixed in hardware.
+          the <code>id</code> of a <a>Thing</a> should not be fixed in hardware.
           This does, however, conflict with the Linked Data ideal that
           identifiers are fixed URIs.  In many circumstances it
           will be acceptable to only allow updates to identifiers if
-          a Thing is reinitialized.  In this case as a software entity the
-          old Thing ceases to exist and a new Thing is created.
+          a <a>Thing</a> is reinitialized.  In this case as a software entity the
+          old <a>Thing</a> ceases to exist and a new <a>Thing</a> is created.
           This can be sufficient to break a tracking chain when, for
           example, a device is sold to a new owner.
           Alternatively, if more frequent changes are desired during 
@@ -3718,7 +3756,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       </p>
       <dl><dt>Mitigation:</dt><dd>
           Only authorized users should be provided access
-          to the Thing Description for a Thing.
+          to the Thing Description for a <a>Thing</a>.
           If the TD is only distributed to authorized users 
           through secure and confidential channels, for
           example through a directory service that requires authentication,
@@ -3734,7 +3772,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       <dl><dt>Mitigation:</dt><dd>
           Obtain Thing Descriptions only through
           mutually authenticated channels.
-          This ensures that the Consumer and the server are both sure of the 
+          This ensures that the <a>Consumer</a> and the server are both sure of the
           identity of the other party to the communication.
           This is also necessary in order to deliver TDs only to authorized users.
       </dd></dl>
@@ -3775,13 +3813,13 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
           As an example application of this principle,
           consider how to obtain user consent.  
           Consent for usage of personally identifiable data
-          generated by a Thing is often obtained when a Thing is paired with system
+          generated by a <a>Thing</a> is often obtained when a <a>Thing</a> is paired with system
           consuming the data,
           which is frequently also when the Thing Description
           is registered with a local directory or the system consuming the 
           Thing Description in order to access the device.
-          In this case consent for using data from a Thing can be combined with
-          consent for accessing the Thing's Thing Description.
+          In this case, consent for using data from a <a>Thing</a> can be combined with
+          consent for accessing the Thing Description of the <a>Thing</a>.
           As a second example, if we consider a TD to contain personally
           identifiable information, then it should not be retained indefinitely
           or used for purposes other than those for which consent was given.
@@ -3810,7 +3848,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
         <p>
           <span class="rfc2119-assertion" id="iana-security-execution">
             Since WoT Thing Description is intended to be a pure data exchange format for
-            Thing metadata, the serialization SHOULD NOT be passed through a
+            <a>Thing</a> metadata, the serialization SHOULD NOT be passed through a
             code execution mechanism such as JavaScript's <code>eval()</code>
             function to be parsed.
           </span>
@@ -3823,7 +3861,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
           which typically follows links to remote contexts (i.e., TD context
           extensions, see <a href="#content-extension-section"></a>)
           automatically, resulting in the transfer of files
-          without the explicit request of the Consumer for each one. If remote
+          without the explicit request of the <a>Consumer</a> for each one. If remote
           contexts are served by third parties, it may allow them to gather
           usage patterns or similar information leading to privacy concerns.
           <span class="rfc2119-assertion" id="iana-security-remote">
@@ -3840,10 +3878,10 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
           Context Extensions (see <a href="#content-extension-section"></a>)
           that are loaded from the Web over non-secure connections,
           such as HTTP, run the risk of being altered by an attacker such that
-          they may modify the TD Information Model in a way that could
+          they may modify the <a>TD Information Model</a> in a way that could
           compromise security.
           <span class="rfc2119-assertion" id="iana-security-alter">
-          For this reason, Consumer again
+          For this reason, <a>Consumer</a> again
           SHOULD vet and cache remote contexts before allowing the system
           to use it.
           </span>
@@ -3855,7 +3893,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
           a JSON-LD 1.1 processor and, in the worst case, the resulting data
           might consume all of the recipient's resources.
           <span class="rfc2119-assertion" id="iana-security-expansion">
-          Consumers SHOULD treat any TD metadata with due skepticism.
+          <a>Consumers</a> SHOULD treat any TD metadata with due skepticism.
           </span>
         </p>
       </dd>
@@ -3871,7 +3909,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       <dt>Applications that use this media type:</dt>
       <dd>
         All participating entities in the W3C Web of Things, that is,
-        Things, Consumers, and Intermediaries as defined in the
+        <a>Things</a>, <a>Consumers</a>, and Intermediaries as defined in the
         <a href="https://w3c.github.io/wot-architecture">Web of Things (WoT) Architecture</a>.</dd>
       <dt>Fragment identifier considerations:</dt>
       <dd>See <a href="https://tools.ietf.org/html/rfc6839#section-3.1">RFC&nbsp;6839, section 3.1</a>.</dd>
@@ -3927,7 +3965,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     <section id="myLampThing-example-serialization">
     <h3>MyLampThing Example with CoAP Protocol Binding</h3>
   
-    <p>Feature list of the Thing:</p>
+    <p>Feature list of the <a>Thing</a>:</p>
   
     <ul>
         <li>Name: MyLampThing</li>
@@ -3936,8 +3974,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
         <li>Security: PSKSecurityScheme</li>
         <li>Protocol Binding: CoAP [[?RFC7252]] over TLS</li>
         <li>Serialization: default (JSON)</li>
-        <li>Comment: Also see Section <a href="#adding-protocol-bindings">Adding Protocol Bindings</a>. </li>
-  
+        <li>Comment: Also see <a href="#adding-protocol-bindings"></a>.</li>
     </ul>
   
   <pre class="example" title="MyLampThing with CoAP Protocol Binding">
@@ -3990,7 +4027,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     <section id="myLampThing-example-serialization">
     <h3>MyLightSensor Example with MQTT Protocol Binding</h3>
   
-    <p>Feature list of the Thing:</p>
+    <p>Feature list of the <a>Thing</a>:</p>
   
     <ul>
         <li>Name: MyLightSensor</li>
@@ -4029,25 +4066,25 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     <section id="webhook-example-serialization">
       <h3>Webhook Event Example</h3>
     
-      <p>Feature list of the Thing:</p>
+      <p>Feature list of the <a>Thing</a>:</p>
     
       <ul>
           <li>Name: WebhookThing</li>
-          <li>Context extension: use HTTP Protocol Binding supplements (htv prefix already included in TD context)</li>
+          <li>Context extension: use HTTP <a>Protocol Binding</a> supplements (htv prefix already included in TD context)</li>
           <li>Offered affordances: 1 Event</li>
           <li>Security: none</li>
           <li>Protocol Binding: HTTP</li>
           <li>Serializiation: default (JSON) </li>
           <li>Comment: <i>WebhookThing</i> provides an Event affordance <code>temperature</code>
-              which periodically pushes the latest temperature value to the Consumer using a Webhook mechanism,
-              where the Thing sends POST requests to a callback URI provided by the Consumer.
+              which periodically pushes the latest temperature value to the <a>Consumer</a> using a Webhook mechanism,
+              where the <a>Thing</a> sends POST requests to a callback URI provided by the <a>Consumer</a>.
               To describe this, the <code>subscription</code> member defines a write-only parameter <code>callbackURL</code>,
               which must be submitted through the <code>subscribeevent</code> form.
               The read-only parameter <code>subscriptionID</code> is returned by the subscription.
               The <i>WebhookThing</i> will then periodically POST to this callback URI with a payload defined by <code>data</code>.
-              To unsubscribe, the Consumer has to submit the <code>unsubscribeevent</code> form,
+              To unsubscribe, the <a>Consumer</a> has to submit the <code>unsubscribeevent</code> form,
               which makes use of a URI Template.
-              The <code>uriVariables</code> member informs the Consumer to include the <code>subscriptionID</code> string.
+              The <code>uriVariables</code> member informs the <a>Consumer</a> to include the <code>subscriptionID</code> string.
               This can be further automated by using a context extension to include proper semantic annotations.
               Alternatively, one can imagine unsubscribing using the <code>concellation</code> member similarly to <code>subscription</code>
               and combine this with a <code>unsubscribeevent</code> form that describes a POST request with payload to unsubscribe.
@@ -4126,7 +4163,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     </p>
     <p class="note">The Thing Description defined by this document allows for 
         adding external vocabularies by using <code>@context</code> mechanism 
-        known from JSON-LD [[json-ld11]], and the terms in those external vocabularies can be 
+        known from JSON-LD [[?json-ld11]], and the terms in those external vocabularies can be
         used in addition to the terms defined in Section <a href="#sec-vocabulary-definition">Information Model</a>. 
         For this reason, the below JSON schema is intentionally non-strict in that 
         regard. You can replace the value of <code>additionalProperties</code> schema 
@@ -5243,18 +5280,18 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
   <h1>Thing Templates</h1>
       
     <p>
-    A <em>Thing Template</em> is a description for a <em>class</em> of devices or things.
-    It describes the properties, actions, events and common metadata that are shared for an entire group of things,
-    to enable the common handling of thousands of devices by a cloud server, which is not practical on a per-thing basis.
+    A <em>Thing Template</em> is a description for a <em>class</em> of <a>Things</a>.
+    It describes the properties, actions, events and common metadata that are shared for an entire group of <a>Things</a>,
+    to enable the common handling of thousands of devices by a cloud server, which is not practical on a per-<a>Thing</a> basis.
     The Thing Template uses the same core vocabulary and information model from section 5.
     </p>
     <p>
     The Thing Template enables:
     <ul>
-    <li> management of multiple things by a cloud service. </li>
-    <li> simulation of devices/things that have not yet been developed.</li>
-    <li> common applications across devices from different manufacturers that share a common thing model.</li>
-    <li> combining multiple models into a thing.
+    <li> management of multiple <a>Things</a> by a cloud service. </li>
+    <li> simulation of devices/<a>Things</a> that have not yet been developed.</li>
+    <li> common applications across devices from different manufacturers that share a common <a>Thing</a> model.</li>
+    <li> combining multiple models into a <a>Thing</a>.
     </ul>
     </p>
     <p>
@@ -5262,19 +5299,19 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     (properties, actions and events), however it does not contain device-specific
     information, such as a serial number, GPS location, security information or concrete protocol endpoints.
     </p><p>
-    Since a Thing Template does not contain a Protocol Binding to specific endpoints and 
+    Since a Thing Template does not contain a <a>Protocol Binding</a> to specific endpoints and
     does not define a specific security mechanism, the <em>forms</em> and <em>securityDefinitions</em> and 
     <em>security</em> keys must not be present.
     </p><p>
-     The same Thing Template can be implemented by things from multiple vendors,
-    a thing can implement multiple thing templates, define additional metadata
+     The same Thing Template can be implemented by <a>Things</a> from multiple vendors,
+    a <a>Thing</a> can implement multiple Thing Templates, define additional metadata
     (vendor, location, security) and define bindings to concrete protocols.
-    To avoid conflicts between properties, actions and events from different thing templates
-    that are combined into a common thing, all thse identifiers must be unique within a thing.
+    To avoid conflicts between properties, actions and events from different Thing Templates
+    that are combined into a common <a>Thing</a>, all thse identifiers must be unique within a <a>Thing</a>.
     </p><p>
     A common Thing Template for a class of devices enables writing applications across vendors and
     creates a more attractive market for application developers.
-    A concrete Thing Description can implement multiple <em>Thing Templates</em> and
+    A concrete Thing Description can implement multiple Thing Templates and
     thus can aggregate function blocks into a combined device.
     </p><p>
     The business models of cloud vendors are typically built on managing thousands of identical devices.
@@ -5547,7 +5584,7 @@ _:b8 &lt;https://www.w3.org/2019/wot-security#in&gt; &quot;header&quot; .</pre>
 
             <p class="ednote">
                 The last two JSON-LD features (property-based data indexing and indexing without a
-                predicate) are still experimental; they have not been published in any Editor's
+                predicate) are still experimental; they have not been published in any Editors'
                 Draft yet.
             </p>
     
@@ -5562,13 +5599,13 @@ _:b8 &lt;https://www.w3.org/2019/wot-security#in&gt; &quot;header&quot; .</pre>
             <h3>Thing Description Ontology</h3>
 
             <p>
-                TD classes and properties have RDF foundations, in the form of a Web
+                TD <a>Classes</a> and name-value pairs (properties) have RDF foundations, in the form of a Web
                 ontology in the Web Ontology Language [[owl2-overview]]. Some assertions of
                 this document are also expressed as OWL axioms.
             </p>
 
             <p>
-                Default values require special care when translating the TD information model
+                Default values require special care when translating the <a>TD Information Model</a>
                 into OWL.
             </p>
 
@@ -5588,57 +5625,57 @@ _:b8 &lt;https://www.w3.org/2019/wot-security#in&gt; &quot;header&quot; .</pre>
     <li>General</li>
     <ul>
     <li>Added <a href="#multilanguage">multi-language</a> support for human-readable metadata (<code>descriptions</code> and <code>titles</code> <a>vocabulary terms</a>).</li>
-    <li>Renamed the <code>InteractionPattern</code> class to <a href="#interactionaffordance"><code>InteractionAffordance</code></a>.</li>
+    <li>Renamed the <code>InteractionPattern</code> <a>Class</a> to <a href="#interactionaffordance"><code>InteractionAffordance</code></a>.</li>
     <li>Added a <a href="#behavior">section</a> to describe behavioral constraints of a WoT system.</li>
     <li>Added a <a href="#sec-security-consideration">section</a> with security and privacy considerations.</li>
     <li>Added a <a href="#iana-section">section</a> with IANA considerations to register media type and CoAP Content Format.</li>
-    <li>Added an <a href="#thing-templates">appendix section</a> describing the concept of Thing Templates for describing classes of Things.</li>
+    <li>Added an <a href="#thing-templates">appendix section</a> describing the concept of Thing Templates for describing classes of <a>Things</a>.</li>
     <li>Added an <a href="#note-jsonld11-processing">appendix section</a> explaining the RDF representation of Thing Descriptions; it replaces the former subsection "Implementation Notes".</li>
     <li>Moved the full examples of Thing Description instances to the <a href="#example-serialization">appendix</a>.</li>
     </ul>
 
     <li>Thing</li>
     <ul>
-    <li>Added mandatory <code>@context</code> and optional <code>@type</code> <a>vocabulary terms</a> to the <a href="#thing">Thing</a> class.</li>
-    <li>Added optional <code>created</code> and <code>modified</code> <a>vocabulary terms</a> to the <a href="#thing">Thing</a> class to provide information as to when the TD instance was created or last modified, resp.</li>
-    <li>Added optional <code>version</code> <a>vocabulary term</a> to the <a href="#thing">Thing</a> class to provide version information.</li>
+    <li>Added mandatory <code>@context</code> and optional <code>@type</code> <a>vocabulary terms</a> to the <a href="#thing">Thing</a> <a>Class</a>.</li>
+    <li>Added optional <code>created</code> and <code>modified</code> <a>vocabulary terms</a> to the <a href="#thing">Thing</a> <a>Class</a> to provide information as to when the TD instance was created or last modified, resp.</li>
+    <li>Added optional <code>version</code> <a>vocabulary term</a> to the <a href="#thing">Thing</a> <a>Class</a> to provide version information.</li>
     <li>Added support for <a href="#meta-interactions-of-thing">meta interactions</a> through the operation types <code>readallproperties</code>, <code>writeallproperties</code>, <code>readmultipleproperties</code>, and <code>writemultipleproperties</code>.</li>
     </ul>
 
     <li>InteractionAffordance</li>
     <ul>
-    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#interactionaffordance">InteractionAffordance</a> class to make semantic annotations part of the Information Model.</li>
-    <li>Added optional <code>uriVariables</code> <a>vocabulary terms</a> to <a href="#interactionaffordance">InteractionAffordance</a> class to describe URI Template variables.</li>
-    <li>Added optional <code>safe</code> and <code>idempotent</code> <a>vocabulary terms</a> to the <a href="#actionaffordance">ActionAffordance</a> class to provide information about the safeness and idempotency of the Action.</li>
-    <li>Added optional <code>subscription</code> and <code>cancellation</code> <a>vocabulary terms</a> to the <a href="#eventaffordance">EventAffordance</a> class to describe data that needs to be passed upon subscription and cancellation, resp.</li>
-    <li>Renamed <code>label</code> to <code>title</code> in the <a href="#interactionaffordance">InteractionAffordance</a> class to be consistent with JSON Schema.</li>
-    <li>Removed <code>security</code> and <code>scopes</code> <a>vocabulary terms</a> from the <a href="#interactionaffordance">InteractionAffordance</a> class to simplify mechanism.</li>
-    <li>Removed the <code>writable</code> <a>vocabulary term</a> from the <a href="#propertyaffordance">PropertyAffordance</a> class and made Property affordances both readable and writable by default; this can be overridden using the <code>op</code> <a>vocabulary term</a> of the <a href="#form">Form</a> class.</li>
+    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#interactionaffordance">InteractionAffordance</a> <a>Class</a> to make semantic annotations part of the Information Model.</li>
+    <li>Added optional <code>uriVariables</code> <a>vocabulary terms</a> to <a href="#interactionaffordance">InteractionAffordance</a> <a>Class</a> to describe URI Template variables.</li>
+    <li>Added optional <code>safe</code> and <code>idempotent</code> <a>vocabulary terms</a> to the <a href="#actionaffordance">ActionAffordance</a> <a>Class</a> to provide information about the safeness and idempotency of the Action.</li>
+    <li>Added optional <code>subscription</code> and <code>cancellation</code> <a>vocabulary terms</a> to the <a href="#eventaffordance">EventAffordance</a> <a>Class</a> to describe data that needs to be passed upon subscription and cancellation, resp.</li>
+    <li>Renamed <code>label</code> to <code>title</code> in the <a href="#interactionaffordance">InteractionAffordance</a> <a>Class</a> to be consistent with JSON Schema.</li>
+    <li>Removed <code>security</code> and <code>scopes</code> <a>vocabulary terms</a> from the <a href="#interactionaffordance">InteractionAffordance</a> <a>Class</a> to simplify mechanism.</li>
+    <li>Removed the <code>writable</code> <a>vocabulary term</a> from the <a href="#propertyaffordance">PropertyAffordance</a> <a>Class</a> and made Property affordances both readable and writable by default; this can be overridden using the <code>op</code> <a>vocabulary term</a> of the <a href="#form">Form</a> <a>Class</a>.</li>
     </ul>
 
     <li>Link and Form</li>
     <ul>
-    <li>Renamed <code>mediaType</code> to <code>type</code> in the <a href="#link">Link</a> class to align with RFC 8288.</li>
-    <li>Added optional <code>response</code> <a>vocabulary term</a> to the <a href="#form">Form</a> class to describe possible response messages.</li>
-    <li>Renamed <code>mediaType</code> to <code>contentType</code> in the <a href="#form">Form</a> class to reflect that request might need to set also media type parameters.</li>
-    <li>Renamed <code>rel</code> to <code>op</code> in the <a href="#form">Form</a> class to resolve perceived conflicts with link relations.</li>
+    <li>Renamed <code>mediaType</code> to <code>type</code> in the <a href="#link">Link</a> <a>Class</a> to align with RFC 8288.</li>
+    <li>Added optional <code>response</code> <a>vocabulary term</a> to the <a href="#form">Form</a> <a>Class</a> to describe possible response messages.</li>
+    <li>Renamed <code>mediaType</code> to <code>contentType</code> in the <a href="#form">Form</a> <a>Class</a> to reflect that request might need to set also media type parameters.</li>
+    <li>Renamed <code>rel</code> to <code>op</code> in the <a href="#form">Form</a> <a>Class</a> to resolve perceived conflicts with link relations.</li>
     <li>Added <code>unobserveproperty</code> to the enumerated values for the <code>op</code> <a>vocabulary term</a>.</li>
     </ul>
 
     <li>DataSchema</li>
     <ul>
-    <li>Added missing <a href="#nullschema">NullSchema</a> class.</li>
-    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> class to make semantic annotations part of the Information Model.</li>
-    <li>Added optional <code>unit</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> class to provide unit metadata.</li>
-    <li>Added optional <code>oneOf</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> class to allow for alternative schemas.</li>
-    <li>Added optional <code>format</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> class to allow for pattern validation.</li>
+    <li>Added missing <a href="#nullschema">NullSchema</a> <a>Class</a>.</li>
+    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> <a>Class</a> to make semantic annotations part of the Information Model.</li>
+    <li>Added optional <code>unit</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> <a>Class</a> to provide unit metadata.</li>
+    <li>Added optional <code>oneOf</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> <a>Class</a> to allow for alternative schemas.</li>
+    <li>Added optional <code>format</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> <a>Class</a> to allow for pattern validation.</li>
     </ul>
 
     <li>Security Scheme</li>
     <ul>
-    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#securityscheme">SecurityScheme</a> class to make semantic annotations part of the Information Model.</li>
-    <li>Added <code>securityDefinitions</code> <a>vocabulary term</a> to the <a href="#thing">Thing</a> class to declare security definitions.</li>
-    <li>Redefined <code>security</code> <a>vocabulary term</a> in the <a href="#thing">Thing</a> and <a href="#form">Form</a> classes to be used to activate declared security definitions.</li>
+    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#securityscheme">SecurityScheme</a> <a>Class</a> to make semantic annotations part of the Information Model.</li>
+    <li>Added <code>securityDefinitions</code> <a>vocabulary term</a> to the <a href="#thing">Thing</a> <a>Class</a> to declare security definitions.</li>
+    <li>Redefined <code>security</code> <a>vocabulary term</a> in the <a href="#thing">Thing</a> and <a href="#form">Form</a> <a>Classes</a> to be used to activate declared security definitions.</li>
     <li>Clarified that the top-level <a href="#security-serialization-json"><code>securityDefinitions</code> and <code>security</code></a> configuration is mandatory.</li>
     <li>Removed all <code>Url</code> postfixes from security scheme <a>vocabulary terms</a>.</li>
     </ul>

--- a/index.html
+++ b/index.html
@@ -3433,7 +3433,7 @@ given in the Thing Description of the target <a>Thing</a>.
 <span class="rfc2119-assertion" 
       id="server-uri-template">
 URI Templates, base URIs, and href members
-in a WoT Thing Description MUST accurately describe the <a>WoT Interace</a> of the <a>Thing</a>.
+in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of the <a>Thing</a>.
 </span>
 </li>
 </ul>

--- a/index.template.html
+++ b/index.template.html
@@ -1434,8 +1434,8 @@ In summary, this requires the following:
 
   <p>
   <span class="rfc2119-assertion" id="td-context">
-  The root JSON object of a TD serialization MUST include
-  a member with the name <code>@context</code> and a value of type
+  The root element of a <a>TD Serialization</a> MUST be a JSON object and it MUST
+  include a member with the name <code>@context</code> and a value of type
   string or array that contains <code>https://www.w3.org/2019/td/v1</code>.
   </span>
   In general, this URI is used to identify the
@@ -1510,8 +1510,10 @@ In summary, this requires the following:
   The value assigned to <code>properties</code> in a <code>Thing</code> instance
   is a <a>Map</a> of instances of <code>PropertyAffordance</code>.
   <span class="rfc2119-assertion" id="td-properties">
-    A map of <code>PropertyAffordance</code> instances MUST be serialized as an object
-    with a (unique) JSON name to identify each Property affordance object.
+    All name-value pairs of a <a>Map</a> of <code>PropertyAffordance</code> instances
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    instance of <code>PropertyAffordance</code>, MUST be serialized as a JSON object.
   </span></p>
 
   <p>
@@ -1519,10 +1521,12 @@ In summary, this requires the following:
     All name-value pairs of an instance of <code>PropertyAffordance</code>,
     where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
     <code>PropertyAffordance</code>, <code>InteractionAffordance</code>, or <code>DataSchema</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>PropertyAffordance</code> instance, with the
+    <a>Vocabulary Term</a> as name.
   </span>
   See <a href="#data-schema-serialization-json" class="sec-ref"></a> for
-  details on the <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> <a>Superclass</a>.
+  details on serializing <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> instances.
   </p>
 
   <p><span class="rfc2119-assertion" id="td-property-arrays">
@@ -1579,15 +1583,19 @@ In summary, this requires the following:
     In a <code>Thing</code> instance, the value assigned to <code>actions</code>
     is a <a>Map</a> of instances of <code>ActionAffordance</code>.
     <span class="rfc2119-assertion" id="td-actions">
-    A map of <code>ActionAffordance</code> instances MUST be serialized as an object
-    with a (unique) JSON name to identify each Action affordance object.
+    All name-value pairs of a <a>Map</a> of <code>ActionAffordance</code> instances
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    instance of <code>ActionAffordance</code>, MUST be serialized as a JSON object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-action-names">
     All name-value pairs of an instance of <code>ActionAffordance</code>,
     where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
     <code>ActionAffordance</code> or <code>InteractionAffordance</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>ActionAffordance</code> instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
@@ -1652,15 +1660,19 @@ In summary, this requires the following:
     In a <code>Thing</code> instance, the value assigned to <code>events</code>
     is a map of instances of <code>EventAffordance</code>.
     <span class="rfc2119-assertion" id="td-events">
-    A map of <code>EventAffordance</code> instances MUST be serialized as an object
-    with a (unique) JSON name to identify each Event affordance object.
+    All name-value pairs of a <a>Map</a> of <code>EventAffordance</code> instances
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    instance of <code>EventAffordance</code>, MUST be serialized as a JSON object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-event-names">
     All name-value pairs of an instance of <code>EventAffordance</code>,
     where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
     <code>EventAffordance</code> or <code>InteractionAffordance</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>EventAffordance</code> instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
@@ -1714,7 +1726,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p><span class="rfc2119-assertion" id="td-forms">
     All name-value pairs of an instance of <code>Form</code>,
     where the name is a <a>Vocabulary Term</a> included in the <a>Signature</a> of <code>Form</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>Form</code> instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-form-protocolbindings">
@@ -1900,7 +1914,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p><span class="rfc2119-assertion" id="td-links">
     All name-value pairs of an instance of <code>Link</code>,
     where the name is a <a>Vocabulary Term</a> included in the <a>Signature</a> of <code>Link</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>Link</code> instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>A TD snippet of a link object in the <code>links</code> array is given below:</p>
@@ -1927,8 +1943,10 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     <code>securityDefinitions</code> is a <a>Map</a> of instances of
     <code>SecurityScheme</code>.
     <span class="rfc2119-assertion" id="td-security">
-    A <a>Map</a> of <code>SecurityScheme</code> instances MUST be serialized as JSON object
-    with a (unique) JSON name to identify each Security configuration object.
+    All name-value pairs of a <a>Map</a> of <code>SecurityScheme</code> instances
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    instance of <code>SecurityScheme</code>, MUST be serialized as a JSON object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-security-schemes">
@@ -1936,7 +1954,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     <code>SecurityScheme</code>,
     where the name is a <a>Vocabulary Term</a> included in the
     <a>Signatures</a> of that <a>Subclass</a> or <code>SecurityScheme</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>SecurityScheme</code> <a>Subclass</a>'s instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
@@ -2234,7 +2254,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     All name-value pairs of an instance of one of the <a>Subclasses</a> of
     <code>DataSchema</code>, where the name is a <a>Vocabulary Term</a> included in the
     <a>Signatures</a> of that <a>Subclass</a> or <code>DataSchema</code>,
-    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
+    MUST be serialized as members of the JSON object that results from
+    serializing the <code>DataSchema</code> <a>Subclass</a>'s instance, with the
+    <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema-objects">

--- a/index.template.html
+++ b/index.template.html
@@ -590,20 +590,21 @@ a[href].internalDFN {
         in a given format and deserialize it from that format. If two TDs have different
         serializations but are semantically equivalent, a <a>TD Processor</a> must be able to
         construct a canonical (i.e., identical) representation when deserializing them.
-        For instance, a TD in which default values were omitted is equivalent to a TD that
-        would include default values. Moreover, a <a>TD Processor</a> must also detect semantically
+        For instance, a TD in which Default Values were omitted is equivalent to a TD that
+        would include Default Values. Moreover, a <a>TD Processor</a> must also detect semantically
         inconsistent TDs, for which no representation should exist. A <a>TD Processor</a> is
         typically a sub-system of a <a>WoT Runtime</a>.
     </dd>
     <dt>
         <dfn id="dfn-td-serialization">TD Serialization</dfn>
         or
-        <dfn id="dfn-td-document">TD document</dfn>
+        <dfn id="dfn-td-document">TD Document</dfn>
     </dt>
     <dd>
         Textual or binary representation of a TD that can be stored and exchanged between
-        <a>Servients</a>. A TD serialization follows a given format, provided as a content type
-        when exchanging it. The reference serialization format for TDs is JSON.
+        <a>Servients</a>. A TD Serialization follows a given representation format, 
+        identified by a media type when exchanged over the network.
+        The default representation format for TDs is JSON-based as defined by this specification.
     </dd>
     <dt>
         <dfn id="dfn-vocab">Vocabulary</dfn>
@@ -834,7 +835,7 @@ a[href].internalDFN {
           <a href="#preliminary-definitions"></a>. The main elements of
           the <a>TD Information Model</a> are then presented in
           <a href="#class-definitions"></a>. Certain object properties may be
-          omitted in a TD when default values exist. A list of defaults
+          omitted in a TD when <a>Default Values</a> exist. A list of defaults
           is given in <a href="#sec-default-values"></a>.
       </p>
 
@@ -1078,7 +1079,7 @@ a[href].internalDFN {
       <p>
           <span class="rfc2119-assertion" id="td-vocabulary-defaults">
             When assignments in a TD are missing, a <a>TD Processor</a> MUST follow
-            the default value assignments expressed in the table of
+            the <a>Default Value</a> assignments expressed in the table of
             <a href="#sec-default-values"></a>.
           </span>
       </p>
@@ -1438,7 +1439,7 @@ In summary, this requires the following:
   string or array that contains <code>https://www.w3.org/2019/td/v1</code>.
   </span>
   In general, this URI is used to identify the
-  TD representation format version defined by this document
+  TD representation format version defined by this document.
   For JSON-LD processing [[?json-ld11]],
   the <code>@context</code> specifies the Thing Description context file
   and optionally additional term definitions.
@@ -1964,7 +1965,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p>
   Here is a more complex example: a TD snippet showing digest authentication
   on a proxy combined with bearer token authentication on the <a>Thing</a>.
-  Here the default value of <code>in</code> in the <code>digest</code> scheme,
+  Here the <a>Default Value</a> of <code>in</code> in the <code>digest</code> scheme,
   <code>header</code>, is omitted, but still applies.
   Note that the corresponding private security configuration
   such as username/password and tokens must be configured in the <a>Consumer</a>
@@ -2225,7 +2226,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <code>ActionAffordance</code> instances,
   the values assigned to <code>subscription</code>, <code>data</code>, and <code>cancellation</code> in
   <code>EventAffordance</code> instances,
-  and the value assigned to <code>uriVariables</code> in instances of <a>Subclasses</a> of <code>InteractionAffordance<code>
+  and the value assigned to <code>uriVariables</code> in instances of <a>Subclasses</a> of <code>InteractionAffordance</code>
   (when a <a href="#form-serialization-json">form object</a> uses a URI Template).
   </p>
 
@@ -2916,11 +2917,11 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         needs to know what HTTP method to use when submitting a form. In the general case,
         a Thing Description can explicitly include a term indicating the method, i.e.,
         <code>htv:methodName</code>. For the
-        sake of conciseness, the HTTP <a>Protocol Binding</a> defines default values for each operation type,
+        sake of conciseness, the HTTP <a>Protocol Binding</a> defines <a>Default Values</a> for each operation type,
         which also aims at convergence of the methods expected by <a>Things</a> (e.g., GET to read, PUT to write).
         <span class="rfc2119-assertion" id="td-default-http-method">
             When no method is indicated in a form representing an HTTP
-            <a>Protocol Binding</a>, a default value MUST be assumed as shown in
+            <a>Protocol Binding</a>, a <a>Default Value</a> MUST be assumed as shown in
             the following table.
         </span>
     </p>
@@ -2965,7 +2966,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </table>
 
     <p>
-        For example, the following default values should be assumed for forms in the introductory TD example:
+        For example, the following <a>Default Values</a> should be assumed for forms in the introductory TD example:
     </p>
 
     <aside class="example with-default">
@@ -3082,9 +3083,9 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
       <p>
           The number of <a>Protocol Bindings</a> a <a>Thing</a> can implement
-          is not restricted. Other <a>Protocol Bindings</a>, e.g., for CoAP, MQTT, or OPC UA
-          will be standardized in separate documents such as a protocol vocabulary similar to HTTP in RDF [[HTTP-in-RDF10]]
-          or specifications including default value definitions. Such protocols can be simply integrated into the TD by the 
+          is not restricted. Other <a>Protocol Bindings</a> (e.g., for CoAP, MQTT, or OPC UA)
+          are intended to be standardized in separate documents such as a protocol <a>Vocabulary</a> similar to <em>HTTP Vocabulary in RDF 1.0</em> [[HTTP-in-RDF10]]
+          or specifications including <a>Default Value</a> definitions. Such protocols can be simply integrated into the TD by the
           usage of the context extension mechanism (<a href="#content-extension-section"></a>).
       </p>
   </section>
@@ -3599,7 +3600,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </p>
 
     <p>
-        The following JSON Schema for validating TD instances does not require the terms with default values to be present. Thus the terms with default values are optional. (see also <a href="#sec-default-values"></a>)
+        The following JSON Schema for validating TD instances does not require the terms with <a>Default Values</a> to be present. Thus the terms with <a>Default Values</a> are optional. (see also <a href="#sec-default-values"></a>)
 
     <pre class="advisement">
     {td.json-schema.validation}
@@ -3728,7 +3729,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
             <h3>Thing Description JSON-LD Context</h3>
 
             <p>
-                A JSON TD document can be transformed in RDF (to then be uploaded
+                A TD document can be transformed into RDF (to then be uploaded
                 to an RDF store for further analytics) by a standard JSON-LD processor.
                 The following procedure loads the context of the TD, given by the
                 term <code>@context</code>, and generates RDF triples:
@@ -3741,7 +3742,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
             </p>
             
             <p>
-                When applying this procedure to the introductory TD example with all default values,
+                When applying this procedure to the introductory TD example with all <a>Default Values</a>,
                 the following triples are obtained:
             </p>
             
@@ -3863,7 +3864,7 @@ _:b8 &lt;https://www.w3.org/2019/wot-security#in&gt; &quot;header&quot; .</pre>
             </p>
 
             <p>
-                Then, after expanding JSON strings to full IRIs, all map structures of the JSON
+                Then, after expanding JSON strings to full IRIs, all map structures of the
                 TD document must be turned into RDF triples. In a simple case, a
                 triple is produced for every key/value pair in the map. For instance, the
                 very first triple of the example above was produced from <code>"name": "myLampThing"</code>.
@@ -3936,7 +3937,7 @@ _:b8 &lt;https://www.w3.org/2019/wot-security#in&gt; &quot;header&quot; .</pre>
             </p>
 
             <p>
-                Default values require special care when translating the <a>TD Information Model</a>
+                <a>Default Values</a> require special care when translating the <a>TD Information Model</a>
                 into OWL.
             </p>
 

--- a/index.template.html
+++ b/index.template.html
@@ -978,14 +978,17 @@ a[href].internalDFN {
         </p>
 
         <p>
-            In addition, the <a>TD Information Model</a> defines another partial function defined
-            on the <a>Signature</a> of a <a>Class</a>, that takes a <a>Vocabulary Term</a> as
-            input and returns an <a>Object</a>, which is the <dfn>Default Value</dfn> for some
-            assignment. This function allows to relax the constraint defined above on the
-            <a>Assignment Function</a>:
+            In addition, the <a>TD Information Model</a> defines a global function on
+            pairs of <a>Vocabulary Terms</a>. The function takes a <a>Class</a> name and
+            another <a>Vocabulary Term</a> as input and
+            returns an <a>Object</a>. If the returned <a>Object</a> is different from
+            <code>null</code>, it represents the <dfn>Default Value</dfn> for some
+            assignment on the input <a>Vocabulary Term</a> in an instance of the input
+            <a>Class</a>. This function allows to relax the constraint
+            defined above on the <a>Assignment Function</a>:
             an <a>Object</a> is an instance of a <a>Class</a> if it includes all mandatory
             assignments <em>or</em> if <a>Default Value</a> exist for the missing
-            assignments. All <a>Default Values</a> are given in a single table in
+            assignments. All <a>Default Values</a> are given in the table of
             <a href="#sec-default-values"></a>.
         </p>
 
@@ -1098,101 +1101,101 @@ a[href].internalDFN {
       <table class="def">
           <thead>
               <tr>
+                  <th><a>Class</a></th>
                   <th><a>Vocabulary term</a></th>
                   <th>Default value</th>
-                  <th>Class</th>
               </tr>
           </thead>
           <tbody>
               <tr class="rfc2119-default-assertion" id="td-default-contentType">
+                  <td></td>
                   <td>
                       <code>contentType</code>
                   </td>
                   <td><code>application/json</code></td>
-                  <td></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-safe">
+                  <td></td>
                   <td>
                       <code>safe</code>
                   </td>
                   <td><code>false</code></td>
-                  <td></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-idempotent">
+                  <td></td>
                   <td>
                       <code>idempotent</code>
                   </td>
                   <td><code>false</code></td>
-                  <td></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-op-properties">
+                  <td><code>PropertyAffordance</code></td>
                   <td>
                       <code>op</code>
                   </td>
                   <td>Array of strings with values <code>readproperty</code> followed by 
                       <code>writeproperty</code></td>
-                  <td><code>PropertyAffordance</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-op-actions">
+                  <td><code>ActionAffordance</code></td>
                   <td>
                       <code>op</code>
                   </td>
                   <td><code>invokeaction</code></td>
-                  <td><code>ActionAffordance</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-op-events">
+                  <td><code>EventAffordance</code></td>
                   <td>
                       <code>op</code>
                   </td>
                   <td><code>subscribeevent</code></td>
-                  <td><code>EventAffordance</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-in-1">
+                  <td><code>BasicSecurityScheme</code></br>
+                    <code>DigestSecurityScheme</code></br>
+                    <code>BearerSecurityScheme</code></br>
+                    <code>PoPSecurityScheme</code></td>
                   <td>
                       <code>in</code>
                   </td>
                   <td><code>header</code></td>
-                  <td><code>BasicSecurityScheme</code></br>
-                      <code>DigestSecurityScheme</code></br>
-                      <code>BearerSecurityScheme</code></br>
-                      <code>PoPSecurityScheme</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-in-2">
+                  <td><code>APIKeySecurityScheme</code></td>
                   <td>
                       <code>in</code>
                   </td>
                   <td><code>query</code></td>
-                  <td><code>APIKeySecurityScheme</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-qop">
+                  <td><code>DigestSecurityScheme</code></td>
                   <td>
                       <code>qop</code>
                   </td>
                   <td><code>auth</code></td>
-                  <td><code>DigestSecurityScheme</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-alg">
+                  <td><code>BearerSecurityScheme</code></br>
+                    <code>PoPSecurityScheme</code></td>
                   <td>
                       <code>alg</code>
                   </td>
                   <td><code>ES256</code></td>
-                  <td><code>BearerSecurityScheme</code></br>
-                      <code>PoPSecurityScheme</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-format">
+                  <td><code>BearerSecurityScheme</code></br>
+                    <code>PoPSecurityScheme</code></td>
                   <td>
                       <code>format</code>
                   </td>
                   <td><code>jwt</code></td>
-                  <td><code>BearerSecurityScheme</code></br>
-                      <code>PoPSecurityScheme</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-flow">
+                  <td><code>OAuth2SecurityScheme</code></td>
                   <td>
                       <code>flow</code>
                   </td>
                   <td><code>implicit</code></td>
-                  <td><code>OAuth2SecurityScheme</code></td>
               </tr>
           </tbody>
       </table>

--- a/index.template.html
+++ b/index.template.html
@@ -2860,7 +2860,7 @@ given in the Thing Description of the target <a>Thing</a>.
 <span class="rfc2119-assertion" 
       id="server-uri-template">
 URI Templates, base URIs, and href members
-in a WoT Thing Description MUST accurately describe the <a>WoT Interace</a> of the <a>Thing</a>.
+in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of the <a>Thing</a>.
 </span>
 </li>
 </ul>

--- a/index.template.html
+++ b/index.template.html
@@ -1539,7 +1539,7 @@ In summary, this requires the following:
   <p>
   <span class="rfc2119-assertion" id="td-property-names">
     All name-value pairs of an instance of <code>PropertyAffordance</code>,
-    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    where the name is a <a>Vocabulary Term</a> included in (one of) the <a>Signatures</a> of
     <code>PropertyAffordance</code>, <code>InteractionAffordance</code>, or <code>DataSchema</code>,
     MUST be serialized as members of the JSON object that results from
     serializing the <code>PropertyAffordance</code> instance, with the
@@ -1611,7 +1611,7 @@ In summary, this requires the following:
 
   <p><span class="rfc2119-assertion" id="td-action-names">
     All name-value pairs of an instance of <code>ActionAffordance</code>,
-    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    where the name is a <a>Vocabulary Term</a> included in (one of) the <a>Signatures</a> of
     <code>ActionAffordance</code> or <code>InteractionAffordance</code>,
     MUST be serialized as members of the JSON object that results from
     serializing the <code>ActionAffordance</code> instance, with the
@@ -1688,7 +1688,7 @@ In summary, this requires the following:
 
   <p><span class="rfc2119-assertion" id="td-event-names">
     All name-value pairs of an instance of <code>EventAffordance</code>,
-    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    where the name is a <a>Vocabulary Term</a> included in (one of) the <a>Signatures</a> of
     <code>EventAffordance</code> or <code>InteractionAffordance</code>,
     MUST be serialized as members of the JSON object that results from
     serializing the <code>EventAffordance</code> instance, with the
@@ -1973,10 +1973,10 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     All name-value pairs of an instance of one of the <a>Subclasses</a> of
     <code>SecurityScheme</code>,
     where the name is a <a>Vocabulary Term</a> included in the
-    <a>Signatures</a> of that <a>Subclass</a> or <code>SecurityScheme</code>,
-    MUST be serialized as members of the JSON object that results from
-    serializing the <code>SecurityScheme</code> <a>Subclass</a>'s instance, with the
-    <a>Vocabulary Term</a> as name.
+    <a>Signature</a> of that <a>Subclass</a> or in the <a>Signature</a> of
+    <code>SecurityScheme</code>, MUST be serialized as members of the JSON object
+    that results from serializing the <code>SecurityScheme</code> <a>Subclass</a>'s
+    instance, with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
@@ -2273,10 +2273,10 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p><span class="rfc2119-assertion" id="td-data-schema">
     All name-value pairs of an instance of one of the <a>Subclasses</a> of
     <code>DataSchema</code>, where the name is a <a>Vocabulary Term</a> included in the
-    <a>Signatures</a> of that <a>Subclass</a> or <code>DataSchema</code>,
-    MUST be serialized as members of the JSON object that results from
-    serializing the <code>DataSchema</code> <a>Subclass</a>'s instance, with the
-    <a>Vocabulary Term</a> as name.
+    <a>Signature</a> of that <a>Subclass</a> or in the <a>Signature</a> of
+    <code>DataSchema</code>, MUST be serialized as members of the JSON object
+    that results from serializing the <code>DataSchema</code> <a>Subclass</a>'s
+    instance, with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema-objects">

--- a/index.template.html
+++ b/index.template.html
@@ -314,17 +314,17 @@ a[href].internalDFN {
   <p>
   This document describes a formal model and a common representation 
   for a Web of Things (WoT) Thing Description. 
-  A Thing Description describes the metadata and interfaces of Things, 
-  where a Thing is an abstraction of a physical or virtual entity that 
+  A Thing Description describes the metadata and interfaces of <a>Things</a>,
+  where a <a>Thing</a> is an abstraction of a physical or virtual entity that
   provides interactions to and participates in the Web of Things. 
   Thing Descriptions provide a set of interactions based on a small vocabulary 
   that makes it possible both to integrate diverse devices and 
   to allow diverse applications to interoperate. 
   Thing Descriptions, by default, are encoded in a JSON format that also allows
   JSON-LD processing. The latter provides a powerful foundation to represent
-  knowledge about Things in a machine-understandable way.
-  A Thing Description instance can be hosted by the Thing itself or hosted 
-  externally when a Thing has resource restrictions (e.g., limited memory space) 
+  knowledge about <a>Things</a> in a machine-understandable way.
+  A Thing Description instance can be hosted by the <a>Thing</a> itself or hosted
+  externally when a <a>Thing</a> has resource restrictions (e.g., limited memory space)
   or when a Web of Things-compatible legacy device is retrofitted 
   with a Thing Description.
   </p>
@@ -359,19 +359,19 @@ a[href].internalDFN {
   <section id="introduction" class="informative">
   <h1>Introduction</h1>
   <p>
-  The Thing Description (TD) model is a central building block in the W3C Web of
-  Things (WoT) and can be considered as the entry point of a Thing 
+  The WoT Thing Description (TD) is a central building block in the W3C Web of
+  Things (WoT) and can be considered as the entry point of a <a>Thing</a>
   (much like the <i>index.html</i> of a Web site). A TD instance has four main
   components: textual metadata about the <a href="#thing">Thing</a> itself,
   a set of <a href="#interactionaffordance">Interaction Affordances</a>
-  that indicate how the Thing can be used,
+  that indicate how the <a>Thing</a> can be used,
   <a href="#sec-data-schema-vocabulary-definition">schemas</a> for the data
-  exchanged with the Thing for machine-understandability, 
+  exchanged with the <a>Thing</a> for machine-understandability,
   and, finally, <a href="#sec-web-linking-vocabulary-definition">Web links</a> to 
-  express any formal or informal relation to other Things or documents on the Web.
+  express any formal or informal relation to other <a>Things</a> or documents on the Web.
   </p>
   <p>
-  The Interaction Model of W3C WoT defines three types of Interaction Affordances:
+  The <a>Interaction Model</a> of W3C WoT defines three types of <a>Interaction Affordances</a>:
   Properties (<a href="#propertyaffordance"><code>PropertyAffordance</code></a> class)
   can be used for sensing and controlling parameters, such as getting the current value or 
   setting an operation state.
@@ -384,19 +384,19 @@ a[href].internalDFN {
   See [[!wot-architecture] for details.
   </p>
   <p>
-  In general, the TD provides metadata for different Protocol Bindings
+  In general, the TD provides metadata for different <a>Protocol Bindings</a>
   identified by URI schemes [[iana-uri-schemes]] (e.g., <code>http</code>, <code>coap</code>, etc.),
   content types based on media types (e.g., <code>application/json</code>, <code>application/xml</code>, <code>application/cbor</code>, <code>application/exi</code> etc.) [[iana-media-types]],
   and security mechanisms (for authentication,
   authorization, confidentiality, etc.).
   Serialization of TD instances is based on JSON [[rfc8259]], where JSON names refer to terms of
   the TD vocabulary, as defined in this specification document. In addition the JSON serialization of TDs
-  follows the syntax of JSON-LD 1.1 [[json-ld11]] to enable extensions and rich semantic processing.
+  follows the syntax of JSON-LD 1.1 [[?json-ld11]] to enable extensions and rich semantic processing.
   </p>
   <p>
   <a href="#simple-thing-description-sample">Example 1</a> shows a TD instance and
-  illustrates the Interaction Model with Properties, Actions, and Events
-  by describing a lamp Thing with the name <i>MyLampThing</i>. 
+  illustrates the <a>Interaction Model</a> with Properties, Actions, and Events
+  by describing a lamp <a>Thing</a> with the name <i>MyLampThing</i>.
   </p>
 <aside class="example" id="simple-thing-description-sample" title="Thing Description Sample">
     <pre>{
@@ -452,7 +452,7 @@ a[href].internalDFN {
   </p>
   <p>
   The <a href="#eventaffordance">Event affordance</a> enables a mechanism for asynchronous messages
-  to be sent by a Thing.
+  to be sent by a <a>Thing</a>.
   Here, a subscription to be notified upon a possible overheating event 
   of the lamp can be obtained by using HTTP with its long polling
   subprotocol on <code>https://mylamp.example.com/oh</code>.
@@ -469,7 +469,7 @@ a[href].internalDFN {
   Specification of at least one security scheme at the top level is mandatory,
   and gives the default access requirements for every resource.
   However, security schemes can also be specified per-form,
-  with configurations given at the form level overriding configurations given at the Thing level,
+  with configurations given at the form level overriding configurations given at the <code>Thing</code> level,
   allowing for the specification of fine-grained access control.
   It is also possible to use a special <code>nosec</code> security scheme to
   indicate that no access control mechanisms are used.
@@ -488,7 +488,7 @@ a[href].internalDFN {
         prefix <code>saref</code> as referring to the SAREF vocabulary namespace [[smartM2M]].
         The SAREF vocabulary includes terms to describe lighting devices and other home automation
         devices that one can embed in a TD as semantic labels as values for the <code>@type</code>
-        property. In the present example, the Thing is labelled with <code>saref:LightingDevice</code>,
+        property. In the present example, the <a>Thing</a> is labelled with <code>saref:LightingDevice</code>,
         the <code>status</code> property affordance is labelled with <code>saref:OnOffState</code>
         and the <code>toggle</code> action affordance with <code>saref:ToggleCommand</code>.
   </p>
@@ -544,11 +544,11 @@ a[href].internalDFN {
 <p>
         The declaration mechanism inside some
         <code>@context</code> is specified by JSON-LD. A TD instance complies to version 1.1 of
-        this specification [[json-ld11]]. The TD instance can be also processed as an RDF
+        this specification [[?json-ld11]]. The TD instance can be also processed as an RDF
         document (details are given in <a href="#note-jsonld11-processing"></a>).
 </p>
 
-  </section>
+</section>
 
   <section id="terminology"> 
   <h2>Terminology</h2>
@@ -562,8 +562,10 @@ a[href].internalDFN {
   <dfn>Event</dfn>,
   <dfn>Protocol Binding</dfn>,
   <dfn>Servient</dfn>,
+  <dfn>WoT Interface</dfn>,
   <dfn>WoT Runtime</dfn>,
-  etc. is defined in [[WOT-ARCHITECTURE]], Section 2.
+  etc. is defined in <a href="https://w3c.github.io/wot-architecture/#terminology">section 3</a>
+  of the WoT Architecture document [[WOT-ARCHITECTURE]].
   </p>
 
   <p>
@@ -586,12 +588,12 @@ a[href].internalDFN {
     <dd>
         A system that can serialize some internal representation of a TD
         in a given format and deserialize it from that format. If two TDs have different
-        serializations but are semantically equivalent, a TD processor must be able to
+        serializations but are semantically equivalent, a <a>TD Processor</a> must be able to
         construct a canonical (i.e., identical) representation when deserializing them.
         For instance, a TD in which default values were omitted is equivalent to a TD that
-        would include default values. Moreover, a TD processor must also detect semantically
-        inconsistent TDs, for which no representation should exist. A TD processor is
-        typically a sub-system of a WoT runtime.
+        would include default values. Moreover, a <a>TD Processor</a> must also detect semantically
+        inconsistent TDs, for which no representation should exist. A <a>TD Processor</a> is
+        typically a sub-system of a <a>WoT Runtime</a>.
     </dd>
     <dt>
         <dfn id="dfn-td-serialization">TD Serialization</dfn>
@@ -600,14 +602,14 @@ a[href].internalDFN {
     </dt>
     <dd>
         Textual or binary representation of a TD that can be stored and exchanged between
-        servients. A TD serialization follows a given format, provided as a content type
+        <a>Servients</a>. A TD serialization follows a given format, provided as a content type
         when exchanging it. The reference serialization format for TDs is JSON.
     </dd>
     <dt>
         <dfn id="dfn-vocab">Vocabulary</dfn>
     </dt>
     <dd>
-        A collection of vocabulary terms, identified by a namespace IRI.
+        A collection of Vocabulary Terms, identified by a namespace IRI.
     </dd>
     <dt>
         <dfn id="dfn-vocab-term">Term</dfn>
@@ -615,22 +617,23 @@ a[href].internalDFN {
         <dfn id="dfn-vocab-term">Vocabulary Term</dfn>
     </dt>
     <dd>
-        A character string. When a term is part of a vocabulary, it is called
-        a vocabulary term. For the sake of readability, a vocabulary term is
-        always denoted with its local name in this document (i.e. without its
+        A character string. When a Term is part of a Vocabulary, it is called
+        a Vocabulary Term. For the sake of readability, a Vocabulary Term is
+        always denoted with its local name in this document (i.e., without its
         namespace IRI).
     </dd>
   </dl>
 
   <p>
-      These definitions are further developed in Section <a href="#preliminary-definitions"></a>.
+      These definitions are further developed in <a href="#preliminary-definitions"></a>.
   </p>
-  </section>
+</section>
 
-  <section>
+<section>
   <h1>Namespaces</h1>
+
   <p>
-      The TD information model presented in this document has its foundations in
+      The <a>TD Information Model</a> presented in this document has its foundations in
       RDF, with a mapping to JSON. This mapping is provided as a JSON-LD context
       file, available at the following URI:
   </p>
@@ -639,22 +642,27 @@ a[href].internalDFN {
     <code>https://www.w3.org/2019/td/v1</code>
   </p>
 
+  <p>
+    This URI also identifies Thing Description instances of the representation format version
+    specified by this document.
+  </p>
+
   <section>
 
     <h2>Reference Namespaces</h2>
 
     <p>
-        All terms defined in the context are grouped by vocabulary, mirroring the
-        structure of the present document (see
-        <a href="#thing-description-json-ld-context"></a> for more details on the
-        context). Each vocabulary is assigned a year-based namespace URI, as follows:
+        All terms defined in the JSON-LD context are grouped by vocabulary,
+        mirroring the structure of the present document
+        (see <a href="#thing-description-json-ld-context"></a> for more details on the context).
+        Each <a>Vocabulary</a> is assigned a year-based namespace URI as follows:
     </p>
   
     <table class="def">
     <thead>
         <tr>
             <th>Vocabulary</th>
-            <th>Namespace URI</th>
+            <th>Namespace IRI</th>
         </tr>
     </thead>
     <tbody>
@@ -678,18 +686,19 @@ a[href].internalDFN {
     </table>
   
     <p>
-        Vocabularies are independent from each other. They may be reused and
-        extended in other W3C recommendations. For every breaking change in the
-        design of a vocabulary, it will be assigned a new year-based namespace URI.
-        Note that to maintain the general coherence of the TD information model,
+        The <a>Vocabularies</a> are independent from each other.
+        They may be reused and extended in other W3C recommendations.
+        For every breaking change in the design of a vocabulary,
+        it will be assigned a new year-based namespace URI.
+        Note that to maintain the general coherence of the <a>TD Information Model</a>,
         the JSON-LD context itself is versioned, such that every version has its own URI
         (<code>v1</code>, <code>v1.1</code>, <code>v2</code>, ...).
     </p>
 
     <p>
-        Because a vocabulary under some namespace URI can only undergo non-breaking
+        Because a <a>Vocabulary</a> under some namespace IRI can only undergo non-breaking
         changes, its content can be safely cached or embedded in applications. One 
-        advantage of exposing relatively static content under a namespace URI is to
+        advantage of exposing relatively static content under a namespace IRI is to
         optimize payload sizes of messages exchanged between constrained devices. It
         also avoids any privacy leakage resulting from devices accessing publicly
         available vocabularies private networks (see also
@@ -703,15 +712,19 @@ a[href].internalDFN {
     <h2>Alternative Namespaces</h2>
 
     <p>
-        For convenience, generic namespace URIs redirect to the latest year-based
-        URI for each vocabulary. They are defined as follows:
+        For convenience, generic namespace IRIs redirect to the latest year-based IRI for each vocabulary.
+        Their usage is intended for applications with powerful infrastructures,
+        like analytics on large production plants or buildings based on knowledge graphs
+        that can manage different versions of these <a>Vocabularies</a>
+        and can dynamically dereference newer versions.
+        These alternative namespaces are defined as follows:
     </p>
   
     <table class="def">
     <thead>
         <tr>
             <th>Vocabulary</th>
-            <th>Namespace URI</th>
+            <th>Namespace IRI</th>
         </tr>
     </thead>
     <tbody>
@@ -735,11 +748,8 @@ a[href].internalDFN {
     </table>
   
     <p>
-        Embedding generic namespace URIs in applications is however not encouraged,
-        since newer versions of the vocabularies may break functionalities. Their
-        usage should be reserved for applications with powerful infrastructures, like
-        analytics on large production plants or buildings based on knowledge graphs
-        that may include devices referencing different versions of these vocabularies.
+        Embedding these generic namespace IRIs in Thing-to-Thing applications is however not encouraged,
+        since newer versions of the <a>Vocabularies</a> may break functionalities.
     </p>
 
   </section>
@@ -749,16 +759,15 @@ a[href].internalDFN {
   <section id="conformance">
   <p>
   A Thing Description instance complies with this specification if it follows 
-  the normative statements in Section 
+  the normative statements in
   <a href="#sec-vocabulary-definition"></a>
-  and Section 
+  and
   <a href="#sec-td-serialization"></a> 
   regarding Thing Description serialization.
   </p>
   <p>
-  A JSON Schema [[?JSON-SCHEMA-VALIDATION]] is provided in Appendix 
-  <a href="#json-schema-for-validation"></a>
-  to validate Thing Description instances based on JSON serialization.
+  A JSON Schema [[?JSON-SCHEMA-VALIDATION]] to validate Thing Description instances
+  is provided in Appendix <a href="#json-schema-for-validation"></a>.
   </p>
 
   <p>
@@ -782,65 +791,68 @@ a[href].internalDFN {
 
   <section id="sec-vocabulary-definition" class="normative">
     <h1>Information Model</h1>
-    <!-- h1>Vocabulary</h1 -->
-    <p>This section introduces the TD information model. 
-      The TD information model serves as the conceptual basis 
-      for the serialization and processing of Thing Description described 
-      in later sections in this document.<p>
+
+    <p>
+      This section introduces the <a>TD Information Model</a>.
+      The <a>TD Information Model</a> serves as the conceptual basis
+      for the processing of Thing Descriptions and their serialization,
+      which is described separately in <a href="#sec-td-serialization"></a>.
+    <p>
 
       <section>
       <h2>Overview</h2>
     
       <p>
-        The TD information model is built upon the following, independent vocabularies: 
+        The <a>TD Information Model</a> is built upon the following, independent <a>Vocabularies</a>:
         <ul>
             <li>
-                the <em>core</em> TD vocabulary, which reflects the
-                <a href="https://www.w3.org/TR/wot-architecture/#sec-interaction-model">WoT interaction model</a> 
-                including property, action and event affordances [[!WOT-ARCHITECTURE]]
+                the <em>core</em> TD <a>Vocabulary</a>, which reflects the
+                <a>Interaction Model</a> with the <a>Properties</a>, <a>Actions</a>, and <a>Events</a>
+                <a>Interaction Affordances</a> [[!WOT-ARCHITECTURE]]
             </li>
             <li>
-                the <em>Data Schema</em> vocabulary, including (a subset of) the terms defined in 
-                JSON Schema [[?JSON-SCHEMA-VALIDATION]]
+                the <em>Data Schema</em> <a>Vocabulary</a>, including (a subset of)
+                the terms defined by JSON Schema [[?JSON-SCHEMA-VALIDATION]]
             </li>
             <li>
-                the <em>WoT Security</em> vocabulary, defining security mechanisms 
-                and configuration requirements to implement them
+                the <em>WoT Security</em> <a>Vocabulary</a>, identifying security mechanisms
+                and requirements for their configuration
             </li>
             <li>
-                the <em>Web Linking</em> vocabulary, encoding the main principles of RESTful
+                the <em>Web Linking</em> <a>Vocabulary</a>, encoding the main principles of RESTful
                 communication using Web links and forms
             </li>
         </ul>
       </p>
 
       <p>
-          Each of these vocabularies is essentially a set of terms that can
+          Each of these <a>Vocabularies</a> is essentially a set of <a>Terms</a> that can
           be used to build data structures, interpreted as objects in the
           traditional object-oriented sense. Objects are instances of classes
-          and have properties. In the context of WoT, they denote Things and
-          their affordances. A formal definition of objects is given in
-          Section <a href="#preliminary-definitions"></a>. The main elements of
-          the TD information model are then presented in Section
+          and have properties. In the context of W3C WoT, they denote <a>Things</a> and
+          their <a>Interaction Affordances</a>. A formal definition of objects is given in
+          <a href="#preliminary-definitions"></a>. The main elements of
+          the <a>TD Information Model</a> are then presented in
           <a href="#class-definitions"></a>. Certain object properties may be
-          omitted in a <a>TD</a> when default values exist. A list of defaults
-          is given in Section <a href="#sec-default-values"></a>.
+          omitted in a TD when default values exist. A list of defaults
+          is given in <a href="#sec-default-values"></a>.
       </p>
 
       <p>
-          The UML diagram showed next gives an overview of the TD information model.
+          The UML diagram shown next gives an overview of the <a>TD Information Model</a>.
           It represents all classes as tables and the assocations that exist between
           classes, starting from the class <a href="#thing"><code>Thing</code></a>,
           as directed arrows. For the sake of readability, the diagram was split in
-          four parts, one for each of the four base vocabularies.
+          four parts, one for each of the four base <a>Vocabularies</a>.
       </p>
       
       <!--<p><a href="http://visualdataweb.de/webvowl/#iri=https://rawgit.com/w3c/wot-thing-description/TD-JSON-LD-1.1/ontology/td.ttl">Click here for the visualization</a></p>-->
      
 
       <p class="ednote">
-            The following diagrams are automatically generated from the ontology files. The layout will be improved in one of the next TD updates.
-             </p>
+          The following diagrams are automatically generated from the ontology files.
+          The layout will be improved upon publication of Working Drafts.
+      </p>
 
 
     <figure id="td-core-model">
@@ -870,100 +882,112 @@ a[href].internalDFN {
         <h2>Preliminaries</h2>
 
         <p>
+            To provide a model that can be easily processes by both,
+            simple rules on a tree-based document (i.e., raw JSON processing)
+            and rich Semantic Web tooling (i.e., JSON-LD processing),
+            this document defines the following formal preliminaries
+            to construct the <a>TD Information Model</a> accordingly.
+        </p>
+
+        <p>
             All definitions in this section refer to <em>sets</em>, which
             intuitively are collections of elements that can themselves be sets.
             All arbitrarily complex data structures can be defined in terms
-            of sets. In particular, an <dfn>object</dfn> is a data structure
+            of sets. In particular, an <dfn>Object</dfn> is a data structure
             recursively defined as follows:
         </p>
 
         <ul>
             <li>
-                a <a>term</a> which may or not belong to a <a>vocabulary</a>,
-                is an <a>object</a>.
+                a <a>Term</a>, which may or may not belong to a <a>Vocabulary</a>,
+                is an <a>Object</a>.
             </li>
             <li>
-                a set of name-value pairs where the name is a <a>term</a> and the
-                value is another <a>object</a>, is also an <a>object</a>.
+                a set of name-value pairs where the name is a <a>Term</a> and the
+                value is another <a>Object</a>, is also an <a>Object</a>.
             </li>
         </ul>
 
         <p>
-            Though this definition does not prevent <a>object</a>s to include multiple
+            Though this definition does not prevent <a>Objects</a> to include multiple
             name-value pairs with the same name, they are generally not considered
-            in this specification. An <a>object</a> whose elements only have numbers
-            as names is called an <dfn>array</dfn>. Similarly, an <a>object</a> whose
-            elements only have <a>term</a>s that do not belong to any <a>vocabulary</a>
-            as names is called a <dfn>map</dfn>.
+            in this specification. An <a>Object</a> whose elements only have numbers
+            as names is called an <dfn>Array</dfn>. Similarly, an <a>Object</a> whose
+            elements only have <a>Term</a>s (that do not belong to any <a>Vocabulary</a>)
+            as names is called a <dfn>Map</dfn>.
         </p>
 
         <p>
-            Moreover, <a>object</a>s can be instances of some <dfn>class</dfn> (also
-            called <dfn>type</dfn>). A <a>class</a>, which is denoted by a <a>term</a>, is
-            first defined by a set of <a>term</a>s called a <dfn>signature</dfn>. A
-            <a>class</a> whose <a>signature</a> is empty is called a <dfn>simple type</dfn>.
+            Moreover, <a>Object</a>s can be instances of some <dfn>Class</dfn>.
+            A <a>Class</a>, which is denoted by a <a>Vocabulary Term</a>, is
+            first defined by a set of <a>Vocabulary Terms</a> called a <dfn>Signature</dfn>. A
+            <a>Class</a> whose <a>Signature</a> is empty is called a <dfn>Simple Type</dfn>.
         </p>
 
         <p>
-            The <a>signature</a> of a class allows to construct two relations that further
-            define <a>class</a>es: an <dfn>assignment relation</dfn> and a <dfn>type
-            relation</dfn>. The <a>assignment relation</a> of a <a>class</a> takes a
-            <a>term</a> as input and returns either <code>true</code> or <code>false</code>
-            as output. The <a>type relation</a> of a <a>class</a> also takes a <a>term</a>
-            as input and returns another <a>class</a> as output.
+            The <a>Signature</a> of a <a>Class</a> allows to construct two relations that further
+            define <a>Classes</a>: an <dfn>Assignment Relation</dfn> and a <dfn>Type Relation</dfn>.
+            The <a>Assignment Relation</a> of a <a>Class</a> takes a <a>Vocabulary Term</a> as input
+            and returns either <code>true</code> or <code>false</code> as output.
+            The <a>Type Relation</a> of a <a>Class</a> also takes a <a>Vocabulary Term</a>
+            as input and returns another <a>Class</a> as output.
         </p>
 
         <p>
-            On the basis of these two relations, constraints on <a>class</a> instantiation
+            On the basis of these two relations, two constraints on <a>Class</a> instantiation
             can be defined as follows:
             <ul>
                 <li>
-                    an <a>object</a> is an instance of a <a>class</a> if for every <a>term</a>
-                    for which the <a>assignment relation</a> of the <a>class</a> returns
-                    <code>true</code>, it includes a name-value pair with the <a>term</a>
-                    as name. In other words, the <a>assignment relation</a> indicates whether
-                    an assignment for every <a>term</a> in the <a>class</a>'s <a>signature</a>
-                    is mandatory or optional.
+                    an <a>Object</a> is an instance of a <a>Class</a> if for every <a>Term</a>
+                    for which the <a>Assignment Relation</a> of the <a>Class</a> returns
+                    <code>true</code>, it includes a name-value pair with the <a>Vocabulary Term</a>
+                    as name. In other words, the <a>Assignment Relation</a> indicates whether
+                    a <a>Vocabulary Term</a> in the <a>Signature</a> of the <a>Class</a> is mandatory.
+                    <a>Vocabulary Terms</a> that are not mandatory, but are in the <a>Signature</a>
+                    of a <a>Class</a> are optional.
                 </li>
                 <li>
-                    an <a>object</a> is an instance of a <a>class</a> if for every <a>term</a>
-                    of the <a>class</a>'s signature used as name in some name-value pair
-                    of the <a>object</a>, the value of that pair is an instance of the
-                    <a>class</a> returned by the class's <a>type relation</a> for the 
-                    given <a>term</a>.
+                    an <a>Object</a> is an instance of a <a>Class</a>
+                    if for every <a>Vocabulary Term</a>
+                    in the <a>Signature</a> of the <a>Class</a> used as name in some name-value pair
+                    of the <a>Object</a>, the value of that pair is an instance of the
+                    <a>Class</a> returned by the <a>Type Relation</a> of the <a>Class</a> for the
+                    given <a>Vocabulary Term</a>.
                 </li>
             </ul>
         </p>
 
         <p>
-            A <a>class</a> is a <dfn>subclass</dfn> of some other <a>class</a> if every
+            A <a>Class</a> is a <dfn>Subclass</dfn> of some other <a>Class</a> if every
             instance of the former is also an instance of the latter.
         </p>
 
         <p>
-            Given all definitions above, the TD information model is to be understood
-            as a set of <a>class</a> definitions, which include a <a>class</a> name, a
-            <a>signature</a> (elements of which are called property names), an
-            <a>assignment relation</a> and a <a>type relation</a>. These class definitions
-            are provided as tables in Section <a href="#class-definitions"></a>.
+            Given all definitions above, the <a>TD Information Model</a> is to be understood
+            as a set of <a>Class</a> definitions,
+            which include a <a>Class</a> name (a <a>Vocabulary Term</a>),
+            a <a>Signature</a> (a set of <a>Vocabulary Terms</a>),
+            an <a>Assignment Relation</a>,
+            and a <a>Type Relation</a>.
+            These <a>Class</a> definitions are provided as tables in <a href="#class-definitions"></a>.
         </p>
 
         <p>
-            In addition, the TD information model defines another relation for each
-            <a>class</a> that takes a <a>term</a> as input and returns an <a>object</a>,
-            i.e. a <dfn>default value</dfn> for some assignment. This relation allows
-            to relax the constraint defined above on the <a>assignment relation</a>:
-            an <a>object</a> is an instance of a <a>class</a> if it includes all mandatory
-            assignments <em>or</em> if <a>default value</a>s exist for the missing
-            assignments. All default values are given in a single table in Section
+            In addition, the <a>TD Information Model</a> defines another relation for each
+            <a>Class</a> that takes a <a>Vocabulary Term</a> as input and returns an <a>Object</a>,
+            which is the <dfn>Default Value</dfn> for some assignment. This relation allows
+            to relax the constraint defined above on the <a>Assignment Relation</a>:
+            an <a>Object</a> is an instance of a <a>Class</a> if it includes all mandatory
+            assignments <em>or</em> if <a>Default Value</a> exist for the missing
+            assignments. All <a>Default Values</a> are given in a single table in
             <a href="#sec-default-values"></a>.
         </p>
 
         <p>
             The formalization introduced here does not consider the possible relation
-            between objects as abstract data structures and physical world objects
-            like WoT Things. However, care was given to the possibility of re-interpreting
-            all <a>vocabulary terms</a> involved in the TD information model as RDF
+            between <a>Objects</a> as abstract data structures and physical world objects
+            such as <a>Things</a>. However, care was given to the possibility of re-interpreting
+            all <a>Vocabulary Terms</a> involved in the <a>TD Information Model</a> as RDF
             resources, so as to integrate them in a larger model of the physical world
             (an ontology). This aspect is dealt with in Appendix
             <a href="#thing-description-ontology"></a>.
@@ -977,8 +1001,8 @@ a[href].internalDFN {
 
         <p>
             <span class="rfc2119-assertion" id="td-vocabulary">
-                A TD processor MUST be able to detect that a <a>TD</a> does not
-                meet class instantiation constraints on all classes defined in Section
+                A <a>TD Processor</a> MUST be able to detect that a TD does not
+                meet <a>Class</a> instantiation constraints on all <a>Classes</a> defined in
                 <a href="#sec-core-vocabulary-definition"></a>,
                 <a href="#sec-data-schema-vocabulary-definition"></a>,
                 <a href="#sec-security-vocabulary-definition"></a>,
@@ -1004,42 +1028,46 @@ a[href].internalDFN {
       <section id="sec-data-schema-vocabulary-definition">
       <h2>Data Schema Vocabulary Definitions</h2>
       <p>
-        The data schema definition reflecting a very common subset of the terms defined in JSON Schema [[?JSON-SCHEMA-VALIDATION]]. It is noted
-        that data schema definitions within Thing Description instances are not limited to this defined subset and MAY use additional terms you 
-        find in JSON Schema. In that case it is recommended to use context association for that additional terms as described in 
-        <a href="#content-extension-section"></a>, otherwise these terms are semantically ignored (also see <a href="#note-jsonld11-processing"></a>).
+        The data schema definition is reflecting a very common subset of the terms defined by JSON Schema [[?JSON-SCHEMA-VALIDATION]]. It is noted
+        that data schema definitions within Thing Description instances are not limited to this defined subset and MAY use additional terms
+        found in JSON Schema. In that case, it is recommended to use context extension for the additional terms as described in
+        <a href="#content-extension-section"></a>, otherwise these terms are semantically ignored by <a>TD Processors</a>
+        (also see <a href="#note-jsonld11-processing"></a>).
       </p>
 
         {json-schema}
+
       </section>
     
       <section id="sec-security-vocabulary-definition">
       <h2>Security Vocabulary Definitions</h2>
-    
+
       <p>
-      For the core TD vocabulary only well-established security  
-      mechanisms are supported, such as those built into protocols supported by WoT  
-      or already in wide use with those protocols.  
+      This specification provides a selection of well-established security mechanisms
+      that are directly built into protocols eligable as <a>Protocol Bindings</a> for W3C WoT
+      or are widely in use with those protocols.
       The current set of HTTP security schemes is partly based on 
       <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject">OpenAPI 3.0.1</a> (see also [[?OPENAPI]]). 
-      However while the HTTP security schemes, 
-      vocabulary and syntax given in this specification share many similarities 
-      with OpenAPI they are not compatible.  
+      However while the HTTP security schemes, <a>Vocabulary</a>, and syntax
+      given in this specification share many similarities with OpenAPI, they are not compatible.
       </p>
-    
+
         {wot-security}
+
       </section>
-    
+
       <section id="sec-web-linking-vocabulary-definition">
       <h2>Web Linking Vocabulary Definitions</h2>
+
       <p>
         The present model provides a representation for (typed) Web links exposed by
-        a Thing. The web linking definition reflecting a very common subset of the terms defined in 
-        Web Linking [[!RFC8288]]. The defined terms can be used, e.g., to describe the relation to another Thing such 
+        a <a>Thing</a>. The Web Linking definition is reflecting a very common subset of the terms defined in
+        Web Linking [[!RFC8288]]. The defined terms can be used, e.g., to describe the relation to another <a>Thing</a> such
         as a <i>Lamp Thing</i> is controlled by a <i>Switch Thing</i>.
      </p>
 
         {web-linking}
+
       </section>
 
     </section>
@@ -1049,16 +1077,16 @@ a[href].internalDFN {
 
       <p>
           <span class="rfc2119-assertion" id="td-vocabulary-defaults">
-            When assignments in a TD are missing, a TD processor MUST follow
-            the default value assignments expressed in the Table of Section
+            When assignments in a TD are missing, a <a>TD Processor</a> MUST follow
+            the default value assignments expressed in the table of
             <a href="#sec-default-values"></a>.
           </span>
       </p>
       
       <p>
-          The following table gives all <a>default value</a>s defined in the
-          classes of the TD information model. An empty cell in the last column
-          must be interpreted as applying to all classes.
+          The following table gives all <a>Default Values</a> defined in the
+          <a>Classes</a> of the <a>TD Information Model</a>. An empty cell in the last column
+          must be interpreted as applying to all <a>Classes</a>.
       </p>
 
       <table class="def">
@@ -1167,62 +1195,61 @@ a[href].internalDFN {
     </section>
 
   <section id="sec-td-serialization">
-  <h1>Thing Description Serialization</h1>
+  <h1>Thing Description Representation Format</h1>
 
   <p>
-  Thing Description instances are modeled and structured based on Section
+  Thing Description instances are modeled and structured based on
   <a href="#sec-vocabulary-definition"></a>.
+  This section defines a JSON-based representation format for <a>Things</a>,
+  a serialization of the <a>TD Information Model</a>.
+  </p>
 
-</p>
-
-<p>
+  <p>
     <span class="rfc2119-assertion" id="td-processor-serialization">
-        A TD processor MUST be able to serialize TDs in the JSON format and
-        deserialize TDs from that format, according to the rules noted
-        in Sections <a href="#td-basic-types-mapping"></a> and
+        A <a>TD Processor</a> MUST be able to serialize the <a>TD Information Model</a>
+        into the JSON format [[!RFC8259]] and
+        deserialize TD models from that format, according to the rules noted in
+        <a href="#td-basic-types-mapping"></a> and
         <a href="#td-class-serialization"></a>.
     </span>
-</p>
+  </p>
 
-<p>
-  The JSON serialization of TDs is aligned with the syntax of JSON-LD 1.1 [[json-ld11]]
+  <p>
+  The JSON serialization of the <a>TD Information Model</a> is aligned with
+  the syntax of JSON-LD 1.1 [[?json-ld11]]
   in order to streamline semantic evaluation.
-  Hence, TD serializations can be processed either as raw JSON
+  Hence, the TD representation format can be processed either as raw JSON
   or with a JSON-LD 1.1 processor,
   as further detailed in <a href="#note-jsonld11-processing"></a>.
-</p>
-
-
-
+  </p>
 
 <p>
 In order to support interoperable internationalization,
 <span class="rfc2119-assertion" id="td-json-open">TDs MUST be serialized according to the 
-requirements defined in Section 8.1 of RFC8259 [[RFC8259]] for open ecosystems.</span>
+requirements defined in Section 8.1 of RFC8259 [[!RFC8259]] for open ecosystems.</span>
 In summary, this requires the following:
 <ul>
-<li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[RFC3629]].</span</li>
+<li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[!RFC3629]].</span</li>
 <li><span class="rfc2119-assertion" id="td-json-open_no-byte-order">Implementations MUST NOT 
  add a byte order mark (U+FEFF) to the beginning of a networked-transmitted TD.</span></li>
-<li><span class="rfc2119-assertion" id="td-json-open_accept-byte-order">Implementations that parse TDs MAY ignore
+<li><span class="rfc2119-assertion" id="td-json-open_accept-byte-order"><a>TD Processors</a> MAY ignore
  the presence of a byte order mark rather than treating it as an error.</span></li>
 </ul>
 </p>
 
-  <section id="json-serializiation-section">
-  <h2>Basic Representation Format Assumptions</h2>
-   
+<section id="td-basic-types-mapping">
+<h2>Mapping to JSON Types</h2>
+
   <p>
-    As a fundamental basis, every <a>object</a> in a <a>TD</a>
-    is serialized as a JSON object and every name-value pair in the original
-    <a>object</a> is serialized as a member of the JSON object.
+    The <a>TD Information Model</a> is constructed,
+    so that there is an easy mapping between model <a>Objects</a> and JSON types.
+    Every <a>Class</a> instances maps to a JSON object,
+    where each name-value pair of the <a>Class</a> instance
+    is a member of the JSON object.
   </p>
 
-  <section id="td-basic-types-mapping">
-  <h3>Mapping to JSON Types</h3>
-
   <p>
-    Every <a>simple type</a> mentioned in Section
+    Every <a>Simple Type</a> mentioned in
     <a href="#class-definitions"></a> maps to a JSON
     type (string, number, boolean), as per the rules listed below. These
     rules apply to values in name-value pairs:
@@ -1257,33 +1284,35 @@ In summary, this requires the following:
   </ul>
 
   <p>
-    Values that are themselves sets of property-value pairs (i.e. not of a <a>simple
-    type</a>) will be dealt with individually in Section <a href="#td-class-serialization"></a>.
+    Values that are themselves sets of property-value pairs (i.e., not of a <a>Simple
+    Type</a>) will be dealt with individually in <a href="#td-class-serialization"></a>.
+    These include <a>Arrays</a> and <a>Maps</a>.
   </p>
 
-  </section>
+</section>
   
-  <section id="omitting-default-values">
-  <h3>Omitting Default Values</h3>
+<section id="omitting-default-values">
+<h2>Omitting Default Values</h2>
 
   <p>
-  A Thing Description instance serialization may omit <a>vocabulary term</a>s for which
-  default values can be assigned, as listed in the table given in <a href="#sec-default-values"></a>.
+  A Thing Description serialization may omit <a>Vocabulary Term</a>
+  for which <a>Default Values</a> are defined,
+  as listed in the table given in <a href="#sec-default-values"></a>.
   </p>
 
   <p>
   The following example shows the TD instance from
   <a href="#simple-thing-description-sample">Example 1</a>
-  with a checkbox to also include the <a>vocabulary terms</a> with default values (=checkbox checked).
-  These terms can be omitted (=checkbox unchecked) to simplify the TD representation.
-  Note that a Thing Description processor interprets these omitted terms identically
-  as if these terms were explicitly present with the default values.
+  with a checkbox to also include the members with <a>Default Values</a> (=checkbox checked).
+  These members can be omitted (=checkbox unchecked) to simplify the TD serialization.
+  Note that a <a>TD Processor</a> interprets these omitted members identically
+  as if they were explicitly present with a given <a>Default Value</a>.
   </p>
 
   <aside class="example with-default">
     <div class="with-default-control">
       <input type="checkbox"/>
-      <span><i>with default values</i></span>
+      <span><i>with Default Values</i></span>
     </div>
 <pre>{
     "@context": "https://www.w3.org/2019/td/v1",
@@ -1380,37 +1409,37 @@ In summary, this requires the following:
     </aside>
 
     <p>
-    Please note that, depending on the Protocol Binding used,
-    additional protocol-specific <a>vocabulary terms</a> may apply,
-    which also have associated default values and can also be omitted as explained in this subsection.
+    Please note that, depending on the <a>Protocol Binding</a> used,
+    additional protocol-specific <a>Vocabulary Terms</a> may apply.
+    They may also have associated <a>Default Values</a>,
+    and hence can also be omitted as explained in this subsection.
     Further information can be found in <a href="#protocol-bindings"></a>.
     </p>
-    </section>
-
-  </section> <!-- end of section "Basic assumptions" -->
+  </section>
 
 <section id="td-class-serialization">
-  <h2>Information Model Serialization</h2>
+<h2>Information Model Serialization</h2>
 
   <section id="sec-thing-as-a-whole-json">
   <h3>Thing Root Object</h3>
 
   <p>
-    A <a>TD</a> is a data structure rooted at an <a>object</a>
-    of type <code>Thing</code>. In turn, a JSON <a>TD serialization</a>
+    A Thing Description is a data structure rooted at an <a>Object</a>
+    of type <a href="#thing"><code>Thing</code></a>.
+    In turn, a JSON serialization of the Thing Description
     is a JSON object, which is the root of a syntax tree constructed
-    from the abstract TD structure.
+    from the <a>TD Information Model</a>.
   </p>
 
   <p>
   <span class="rfc2119-assertion" id="td-context">
   The root JSON object of a TD serialization MUST include
   a member with the name <code>@context</code> and a value of type
-  string or array that contains
-  <code>https://www.w3.org/2019/td/v1</code> to identify the
-  TD representation format version defined by this document.
+  string or array that contains <code>https://www.w3.org/2019/td/v1</code>.
   </span>
-  For JSON-LD processing [[json-ld11]],
+  In general, this URI is used to identify the
+  TD representation format version defined by this document
+  For JSON-LD processing [[?json-ld11]],
   the <code>@context</code> specifies the Thing Description context file
   and optionally additional term definitions.
   </p>
@@ -1423,9 +1452,9 @@ In summary, this requires the following:
 </pre>
 
   <p><span class="rfc2119-assertion" id="td-context-toplevel">
-    All name-value pairs of an instance of <code>Thing</code> where the name
-    is a <a>term</a> included in the signature of <code>Thing</code> MUST be
-    serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of <code>Thing</code>,
+    where the name is a <a>Vocabulary Term</a> in the <a>Signature</a> of <code>Thing</code>,
+    MUST be serialized as JSON members of the root object.
   </span></p>
 
   <pre class="example">
@@ -1452,16 +1481,23 @@ In summary, this requires the following:
 
   <!-- should this be "the type" or "the elements of"? -->
   <p><span class="rfc2119-assertion" id="td-objects">
-  All values assigned to <code>properties</code>,
-  <code>actions</code>, <code>events</code>, <code>version</code>,
-  and <code>securityDefinitions</code> in an instance of <code>Thing</code>
+  All values assigned to
+  <code>version</code>,
+  <code>securityDefinitions</code>,
+  <code>properties</code>,
+  <code>actions</code>, and
+  <code>events</code>
+  in an instance of <a>Class</a> <code>Thing</code>
   MUST be serialized as JSON objects.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-arrays">
-  All values assigned to <code>forms</code>, <code>links</code>,
-  <code>scopes</code>, and <code>security</code> in an instance of
-  <code>Thing</code> MUST be serialized as JSON arrays.
+  All values assigned to
+  <code>security</code>,
+  <code>links</code>, and
+  <code>forms</code>
+  in an instance of <a>Class</a> <code>Thing</code>
+  MUST be serialized as JSON arrays.
   </span></p>
 
 </section> <!-- end of id="sec-thing-as-a-whole-json"-->
@@ -1470,32 +1506,32 @@ In summary, this requires the following:
 <h3><code>properties</code></h3>
   
   <p>
-  In a <code>Thing</code> instance, the value assigned to <code>properties</code> (at the
-  root level) is a map of instances of <code>PropertyAffordance</code>.
+  The value assigned to <code>properties</code> in a <code>Thing</code> instance
+  is a <a>Map</a> of instances of <code>PropertyAffordance</code>.
   <span class="rfc2119-assertion" id="td-properties">
-  A map of <code>PropertyAffordance</code> instances MUST be serialized as an object
-  with a (unique) JSON name to identify each Property affordance object.
+    A map of <code>PropertyAffordance</code> instances MUST be serialized as an object
+    with a (unique) JSON name to identify each Property affordance object.
   </span></p>
 
   <p>
   <span class="rfc2119-assertion" id="td-property-names">
-    All name-value pairs of an instance of <code>PropertyAffordance</code> where the name
-    is a <a>term</a> included in the signatures of <code>PropertyAffordance</code>,
-    <code>InteractionAffordance</code> and <code>DataSchema</code> MUST be
-    serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of <code>PropertyAffordance</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    <code>PropertyAffordance</code>, <code>InteractionAffordance</code>, or <code>DataSchema</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span>
   See <a href="#data-schema-serialization-json" class="sec-ref"></a> for
-  details on the <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> superclass.
+  details on the <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> <a>Superclass</a>.
   </p>
 
   <p><span class="rfc2119-assertion" id="td-property-arrays">
-  The value assigned to <code>forms</code> in an instance of <code>PropertyAffordance</code>
-  MUST be serialized as a JSON array. Each element in the array must be a JSON
-  object as defined in <a href="#form-serialization-json" class="sec-ref"></a>
+    The value assigned to <code>forms</code> in an instance of <code>PropertyAffordance</code>
+    MUST be serialized as a JSON array
+    containing one or more JSON object serializations as defined in <a href="#form-serialization-json"></a>.
   </span></p>
 
   <p>
-  A snippet for two Property affordances is given below:
+  A snippet for two <a>Property</a> affordances is given below:
   </p>
 
 <aside class="example" id="property-serialization-sample" title="Sample of Property serializations">
@@ -1540,32 +1576,33 @@ In summary, this requires the following:
 
   <p>
     In a <code>Thing</code> instance, the value assigned to <code>actions</code>
-    is a map of instances of <code>ActionAffordance</code>.
+    is a <a>Map</a> of instances of <code>ActionAffordance</code>.
     <span class="rfc2119-assertion" id="td-actions">
     A map of <code>ActionAffordance</code> instances MUST be serialized as an object
     with a (unique) JSON name to identify each Action affordance object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-action-names">
-    All name-value pairs of an instance of <code>ActionAffordance</code> where the name
-    is a <a>term</a> included in the signatures of <code>ActionAffordance</code> and
-    <code>InteractionAffordance</code> MUST be serialized as JSON members with the
-    <a>term</a> as name.
+    All name-value pairs of an instance of <code>ActionAffordance</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    <code>ActionAffordance</code> or <code>InteractionAffordance</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
   <span class="rfc2119-assertion" id="td-action-objects">
     The values assigned to <code>input</code> and <code>output</code> in an instance of
-    <code>ActionAffordance</code> MUST be a JSON object.
+    <code>ActionAffordance</code>
+    MUST be serialized as JSON objects.
   </span>
-  They rely on the the class <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
+  They rely on the the <a>Class</a> <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
   whose serialization is defined in <a href="#data-schema-serialization-json"></a>.
   </p>
 
   <p><span class="rfc2119-assertion" id="td-action-arrays">
     The value assigned to <code>forms</code> in an instance of <code>ActionAffordance</code>
-    MUST be serialized as a JSON array. Each element in the array must be a JSON
-    object as defined in <a href="#form-serialization-json" class="sec-ref"></a>
+    MUST be serialized as a JSON array
+    containing one or more JSON object serializations as defined in <a href="#form-serialization-json"></a>.
   </span></p>
 
   <p>
@@ -1619,26 +1656,27 @@ In summary, this requires the following:
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-event-names">
-    All name-value pairs of an instance of <code>EventAffordance</code> where the name
-    is a <a>term</a> included in the signatures of <code>EventAffordance</code> and
-    <code>InteractionAffordance</code> MUST be serialized as JSON members with the
-    <a>term</a> as name.
+    All name-value pairs of an instance of <code>EventAffordance</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of
+    <code>EventAffordance</code> or <code>InteractionAffordance</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
   <span class="rfc2119-assertion" id="td-event-objects">
-  The values assigned to <code>subscription</code>,
-  <code>data</code>, and <code>cancellation</code>
-  in an instance of <code>EventAffordance</code>
-  MUST be a JSON object.
+    The values assigned to <code>subscription</code>,
+    <code>data</code>, and <code>cancellation</code>
+    in an instance of <code>EventAffordance</code>
+    MUST be serialized as JSON objects.
   </span>
-  They rely on the the class <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
+  They rely on the the <a>Class</a> <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
   whose serialization is defined in <a href="#data-schema-serialization-json"></a>.
   </p>
 
   <p><span class="rfc2119-assertion" id="td-event-arrays">
-  The value assigned to <code>forms</code> in an instance of <code>EventAffordance</code> MUST be a JSON array
-  containing one or more object serializations as defined in <a href="#form-serialization-json"></a>.
+  The value assigned to <code>forms</code> in an instance of <code>EventAffordance</code>
+  MUST be serialized as a JSON array
+  containing one or more JSON object serializations as defined in <a href="#form-serialization-json"></a>.
   </span></p>
 
   <p>
@@ -1673,9 +1711,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 <h3><code>forms</code></h3>
 
   <p><span class="rfc2119-assertion" id="td-forms">
-    All name-value pairs of an instance of <code>Form</code> where the name
-    is a <a>term</a> included in the signatures of <code>Form</code> MUST
-    be serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of <code>Form</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signature</a> of <code>Form</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-form-protocolbindings">
@@ -1717,7 +1755,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p><span class="rfc2119-assertion" id="td-uriVariables-dataschema">
   The serialization of each value in the map assigned to <code>uriVariables</code>
   in an instance of <code>Form</code> MUST
-  rely on the class <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
+  rely on the <a>Class</a> <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>,
   whose serialization is defined in <a href="#data-schema-serialization-json"></a>.
   </span></p>
 
@@ -1761,7 +1799,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 </pre>
 
   <p>
-  In some use cases, the form metadata of the Interaction Affordance not only
+  In some use cases, the form metadata of the <a>Interaction Affordance</a> not only
   describes the request, but also provides metadata for the expected response.
   For instance, an Action <code>takePhoto</code> defines an <code>input</code> schema
   to submit parameter settings of a camera (aperture priority, timer, etc.) using
@@ -1780,7 +1818,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   </span>
   <span class="rfc2119-assertion" id="td-forms-response">
   If present, the response object MUST contain a <code>contentType</code> member as
-  defined in the class definition of
+  defined in the <a>Class</a> definition of
   <a href="#expectedresponse" class="sec-ref"><code>ExpectedResponse</code></a>.
   </span>
   </p>
@@ -1811,14 +1849,14 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 </pre>
 
   <p>
-  When <code>forms</code> is present at the top level, it can be used to describe meta interactions offered by a Thing.
+  When <code>forms</code> is present at the top level, it can be used to describe meta interactions offered by a <a>Thing</a>.
   For example, the operation types "readallproperties" and "writeallproperties" are for meta
-  interactions with a Thing by which Consumers can read and write all properties at once.
+  interactions with a <a>Thing</a> by which <a>Consumers</a> can read and write all properties at once.
   In the example below, a <code>forms</code> member is included in the TD root object
-  and the Consumer can use the submission target
+  and the <a>Consumer</a> can use the submission target
   <code>https://mylamp.example.com/allproperties</code> both to read or write all
   Properties (i.e., <code>on</code>, <code>brightness</code>, and <code>timer</code>)
-  of the Thing in a single protocol transaction.
+  of the <a>Thing</a> in a single protocol transaction.
   </p>
 
 <pre class="example" id="td-forms-readall-example">
@@ -1859,9 +1897,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 <h3><code>links</code></h3>
 
   <p><span class="rfc2119-assertion" id="td-links">
-    All name-value pairs of an instance of <code>Link</code> where the name
-    is a <a>term</a> included in the signatures of <code>Link</code> MUST
-    be serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of <code>Link</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signature</a> of <code>Link</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>A TD snippet of a link object in the <code>links</code> array is given below:</p>
@@ -1885,24 +1923,25 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
     In a <code>Thing</code> instance, the value assigned to
-    <code>securityDefinitions</code> is a map of instances of
+    <code>securityDefinitions</code> is a <a>Map</a> of instances of
     <code>SecurityScheme</code>.
     <span class="rfc2119-assertion" id="td-security">
-    A map of <code>SecurityScheme</code> instances MUST be serialized as an object
+    A <a>Map</a> of <code>SecurityScheme</code> instances MUST be serialized as JSON object
     with a (unique) JSON name to identify each Security configuration object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-security-schemes">
-    All name-value pairs of an instance of one of the <a>subclass</a>es of
-    <code>SecurityScheme</code> where the name is a <a>term</a> included in the
-    signatures of that <a>subclass</a> and <code>SecurityScheme</code> MUST
-    be serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of one of the <a>Subclasses</a> of
+    <code>SecurityScheme</code>,
+    where the name is a <a>Vocabulary Term</a> included in the
+    <a>Signatures</a> of that <a>Subclass</a> or <code>SecurityScheme</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>
   The following TD snippet shows a simple security configuration specifying
   basic username/password authentication in the header.
-  The value given for <code>in</code> is actually the default value (<code>header</code>)
+  The value given for <code>in</code> is actually the <a>Default Value</a> (<code>header</code>)
   and could be omitted.
   First, a named security configuration must be given
   in the <code>securityDefinitions</code> map.
@@ -1924,11 +1963,11 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   Here is a more complex example: a TD snippet showing digest authentication
-  on a proxy combined with bearer token authentication on the endpoint.
+  on a proxy combined with bearer token authentication on the <a>Thing</a>.
   Here the default value of <code>in</code> in the <code>digest</code> scheme,
   <code>header</code>, is omitted, but still applies.
   Note that the corresponding private security configuration
-  such as username/password and tokens must be configured in the Consumer
+  such as username/password and tokens must be configured in the <a>Consumer</a>
   to interact successfully.
   </p>
 
@@ -1957,7 +1996,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   At least one security definition MUST be activated through the
   <code>security</code> array at the Thing level (i.e., in the TD root object).
   </span>
-  This configuration can be seen as the default security mechanism required to interact with the Thing.
+  This configuration can be seen as the default security mechanism required to interact with the <a>Thing</a>.
   <span class="rfc2119-assertion" id="td-security-overrides">
   Security definitions MAY also be activated at the form level by including a
   <code>security</code> member in form objects,
@@ -1968,7 +2007,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p>
   The <code>nosec</code> security scheme is provided for the case that 
   no security is needed.
-  The minimal security configuration for a Thing is activation
+  The minimal security configuration for a <a>Thing</a> is activation
   of the <code>nosec</code> security scheme 
   at the Thing level, as shown in the following example:
   </p>
@@ -1991,7 +2030,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   To give a more complex example, 
-  suppose we have a Thing where all Interaction Affordances
+  suppose we have a <a>Thing</a> where all <a>Interaction Affordances</a>
   require basic authentication except for one, for which
   no authentication is required.
   For the <code>status</code> Property and the <code>toggle</code> Action,
@@ -2040,7 +2079,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   Security configurations can also can be specified for different forms
-  within the same Interaction Affordance. This may be required for devices that support
+  within the same <a>Interaction Affordance</a>. This may be required for devices that support
   multiple protocols, for example HTTP and CoAP [[?RFC7252]], which support different
   security mechanisms.  This is also useful when alternative authentication
   mechanisms are allowed.  Here is a TD snippet demonstrating three possible
@@ -2051,7 +2090,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   provides a way to combine security mechanisms in an "OR" fashion.
   In contrast, putting multiple security configurations in the same
   <code>security</code> member combines them in an "AND" fashion, 
-  since in that case they would all need to be satisfied to allow activation of the Interaction Affordance.
+  since in that case they would all need to be satisfied to allow activation of the <a>Interaction Affordance</a>.
   Note that activating one (default) configuration at the Thing level is still mandatory.
   </p>
 
@@ -2087,9 +2126,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   As another more complex example, OAuth2 makes use of scopes. 
   These are identifiers that 
   may appear in tokens and must match with corresponding identifiers in a resource to allow 
-  access to that resource (or Interaction Affordance in the case of W3C WoT).
+  access to that resource (or <a>Interaction Affordance</a> in the case of W3C WoT).
   For example, in the following, the <code>status</code> Property can be
-  read by Consumers using bearer tokens containing the scope <code>limited</code>,
+  read by <a>Consumers</a> using bearer tokens containing the scope <code>limited</code>,
   but the <code>configure</code> Action can only be invoked
   with a token containing the <code>special</code> scope.
   Scopes are not identical to roles, but are often associated with them;
@@ -2142,9 +2181,9 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 <h3><code>version</code></h3>
 
   <p><span class="rfc2119-assertion" id="td-version">
-    All name-value pairs of an instance of <code>VersionInfo</code> where the
-    name is a <a>term</a> included in the signatures of <code>VersionInfo</code>
-    MUST be serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of <code>VersionInfo</code>,
+    where the name is a <a>Vocabulary Term</a> included in the <a>Signature</a> of <code>VersionInfo</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p>The recommended version identification pattern value is to rely on the semantic versioning policy [[?SemVer]].</p>
@@ -2161,7 +2200,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   <span class="rfc2119-assertion" id="td-version-container">
-  The <code>version</code> map MAY be used to provide additional application-
+  The <code>version</code> <a>Map</a> MAY be used to provide additional application-
   and/or device-specific version information based on terms from non-TD vocabularies.
   </span>
   See <a href="#content-extension-section"></a> for how to include additional namespaces.
@@ -2174,44 +2213,44 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   The data schemas of WoT Thing Description defined through the
-  <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> class
+  <a href="#dataschema" class="sec-ref"><code>DataSchema</code></a> <a>Class</a>
   are based on a subset of the JSON Schema terms [[?JSON-SCHEMA-VALIDATION]].
   Thus, serializations of the TD data schemas can be fed directly into JSON Schema
-  validator implementations to validate the data exchanged with Things.
+  validator implementations to validate the data exchanged with <a>Things</a>.
   </p>
 
   <p>
-  Data schema serialization applies to <a href="#property-serialization-json">Property objects</a>,
+  Data schema serialization applies to <code>PropertyAffordance</code> instances,
   the values assigned to <code>input</code> and <code>output</code> in
-  <a href="#action-serialization-json">Action objects</a>,
+  <code>ActionAffordance</code> instances,
   the values assigned to <code>subscription</code>, <code>data</code>, and <code>cancellation</code> in
-  <a href="#event-serialization-json">Event objects</a>,
-  and the value assigned to <code>uriVariables</code> in Interaction Affordance objects in general
+  <code>EventAffordance</code> instances,
+  and the value assigned to <code>uriVariables</code> in instances of <a>Subclasses</a> of <code>InteractionAffordance<code>
   (when a <a href="#form-serialization-json">form object</a> uses a URI Template).
   </p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema">
-    All name-value pairs of an instance of one of the <a>subclass</a>es of
-    <code>DataSchema</code> where the name is a <a>term</a> included in the
-    signatures of that <a>subclass</a> and <code>DataSchema</code> MUST
-    be serialized as JSON members with the <a>term</a> as name.
+    All name-value pairs of an instance of one of the <a>Subclasses</a> of
+    <code>DataSchema</code>, where the name is a <a>Vocabulary Term</a> included in the
+    <a>Signatures</a> of that <a>Subclass</a> or <code>DataSchema</code>,
+    MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema-objects">
   The value assigned to <code>properties</code> in an instance of
-  <code>ObjectSchema</code> MUST be a JSON object.
+  <code>ObjectSchema</code> MUST be serialized as a JSON object.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema-arrays">
   The values assigned to <code>enum</code>,
   <code>required</code>,
   and <code>oneOf</code> in an instance of <code>DataSchema</code>
-  MUST be a JSON array.
+  MUST be serialized as a JSON array.
   </span></p>
 
   <p><span class="rfc2119-assertion" id="td-data-schema-objects-arrays">
   The value assigned to <code>items</code> in an instance of
-  <code>ArraySchema</code> MUST be a JSON object or a JSON array containing JSON objects.
+  <code>ArraySchema</code> MUST be serialized as a JSON object or a JSON array containing JSON objects.
   </span></p>
 
   <p>
@@ -2257,7 +2296,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   The terms <code>readOnly</code> and <code>writeOnly</code> can be used signal
   which data items are exchanged in read interactions (i.e., when reading a Property)
   and which in write interactions (i.e., when writing a Property).
-  This can be used as workaround when Properties of an unconventional Thing
+  This can be used as workaround when Properties of an unconventional <a>Thing</a>
   exhibit different data for reading and writing, which can be the case when
   augmenting an existing device or service with a Thing Description.
   </p>
@@ -2314,7 +2353,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   <p>
   The vocabulary terms <code>title</code> and <code>description</code> are 
   used to provide human-readable texts for titles (e.g., a display
-  text for UI) and additional information useful for Consumers of TDs.
+  text for UI) and additional information useful for <a>Consumers</a> of TDs.
   When a default language is specified by assigned a value to <code>@language</code>
   in the <code>@context</code> of a <a href="#sec-thing-as-a-whole-json">Thing object</a>,
   that default language is associated with the string values assigned to
@@ -2362,7 +2401,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   enable human-readable texts in multiple languages using language tags defined in [[!BCP47]].
   <span class="rfc2119-assertion" id="td-multi-languages">
   If present, the values assigned to <code>titles</code> and <code>descriptions</code>
-  in any <a>object</a> in a <a>TD</a> instance
+  in any <a>Object</a> in a TD model
   MUST be serialized as JSON objects.
   The names of their members MUST be language tags as defined in [[!BCP47]]
   (e.g., "en", "de", "ja", "zh-Hans", "zh-Hant")
@@ -2485,11 +2524,11 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     instances with additional (e.g., domain-specific) semantics.
     In addition, it can also be used to specify some configurations
     and behaviors of the underlying communication protocols announced in the
-    Protocol Bindings serialized in <code>forms</code>.
+    <a>Protocol Bindings</a> serialized in <code>forms</code>.
     </p>
     <p>
     For this extension the Thing Description uses the <code>@context</code>
-    mechanism known from JSON-LD [[!json-ld11]].
+    mechanism known from JSON-LD [[?json-ld11]].
     <span class="rfc2119-assertion" id="td-additional-contexts">
     When a Thing Description uses multiple contexts,
     the <code>@context</code> member of the TD root object MUST be an array
@@ -2515,25 +2554,26 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
     <p>
     The context extension allows to add additional vocabulary to a Thing Description instance.
-    If the included namespaces are based on class definitions
+    If the included namespaces are based on <a>Class</a> definitions
     such as those provided by the RDF Schema or OWL,
     they can be used to annotate elements of the TD semantically
-    by associating the affiliation to a class.
+    by associating the <a>Object</a> to a <a>Class</a>.
     <span class="rfc2119-assertion" id="td-jsonld-keywords">
-    Thing Description instances MAY contain the JSON-LD [[json-ld11]] keyword
+    Thing Description instances MAY contain the JSON name
     <code>@type</code> for members that provide semantic annotations.
     </span>
+    <code>@type</code> is a JSON-LD keyword [[?json-ld11]] used to set the type of a node.
     <span class="rfc2119-assertion" id="td-at-type">
-    The <code>@type</code> member MUST be of type string
-    or array of strings for multiple annotations.
+    The value of the <code>@type</code> member MUST be a JSON string
+    or JSON array of strings for multiple annotations.
     </span>
     </p>
 
     <p>
     Additional vocabulary also allows to include additional <a>vocabulary terms</a>
-    within any class of the Information Model, which are serialized as additional
+    within any <a>Class</a> of the Information Model, which are serialized as additional
     JSON members in the corresponding objects.
-    Examples are additional version metadata for the Thing
+    Examples are additional version metadata for the <a>Thing</a>
     or units of measure for data items.
     </p>
 
@@ -2579,17 +2619,17 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
   <p>
   With the context extension in the Thing Description,
-  the communication metadata can be supplemented or new Protocol Bindings added
+  the communication metadata can be supplemented or new <a>Protocol Bindings</a> added
   through additional <a>vocabulary terms</a> serialized into a form object
   (see also <a href="#protocol-bindings"></a>).
   </p>
     
   <p>
-  The following TD example uses a fictional CoAP Protocol Binding,
-  as no such Protocol Binding is available at the time of writing of this specification.
+  The following TD example uses a fictional CoAP <a>Protocol Binding</a>,
+  as no such <a>Protocol Binding</a> is available at the time of writing of this specification.
   It assumes that there is a CoAP RDF vocabulary similar to [[HTTP-in-RDF10]]
   that is accessable via the namespace <code>http://www.example.org/coap-binding#</code>.
-  The supplemented <code>cov:methodName</code> member instructs the Consumer
+  The supplemented <code>cov:methodName</code> member instructs the <a>Consumer</a>
   which CoAP method has to be applied
   (e.g., <code>GET</code> for the CoAP Method Code 0.01,
   <code>POST</code> for the CoAP Method Code 0.02,
@@ -2640,8 +2680,8 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   For this example, we will use a fictional ACE security scheme
   based on [[?draft-ietf-ace-oauth-authz]] and that is, for this example,
   defined by the namespace at <code>http://www.example.org/ace-security#</code>.
-  Note that such addiational security schemes must be subclasses of the
-  class <a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>.
+  Note that such addiational security schemes must be <a>Subclasses</a> of the
+  <a>Class</a> <a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>.
   </p>
 
 <pre class="example">
@@ -2735,20 +2775,18 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 <h3>Security Configurations</h3>
  <p>
  To enable secure interoperation, 
- security configurations must accurately reflect the requirements of the Thing:
+ security configurations must accurately reflect the requirements of the <a>Thing</a>:
 <ul>
 <li>
  <span class="rfc2119-assertion" id="td-security-binding">
- If a Thing requires a specific access mechanism for a resource, that 
- mechanism MUST be specified in the Thing Description's security scheme configuration 
- for that resource. 
+ If a <a>Thing</a> requires a specific access mechanism for an interaction, that
+ mechanism MUST be specified in the security configuration of the Thing Description.
  </span>  
 </li>
 <li>
  <span class="rfc2119-assertion" id="td-security-no-extras">
- If a Thing does not require a specific access mechanism for a resource, that 
- mechanism MUST NOT be specified in the Thing Description's security scheme configuration 
- for that resource. 
+ If a <a>Thing</a> does not require a specific access mechanism for an interaction, that
+ mechanism MUST NOT be specified in the security configuration of the Thing Description.
  </span>  
 </li>
 </ul>
@@ -2763,18 +2801,18 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 <section id="behavior-data">
 <h3>Data Schemas</h3>
 <p>The data schemas provided in the TD should accurately represent the 
-data payloads returned and accepted by the described Thing
-in the interactions specified in the TD.  In general, Consumers should
+data payloads returned and accepted by the described <a>Thing</a>
+in the interactions specified in the TD.  In general, <a>Consumers</a> should
 follow the data schemas strictly, not generating anything not given
 in the WoT Thing Description, but should accept additional data from
-the Thing not given explicitly in the WoT Thing Decription.  In general, Things are <em>described</em> by WoT Thing Descriptions,
-but Consumers are <em>constrained</em> to follow WoT Thing Descriptions when
-interacting with Things.
+the <a>Thing</a> not given explicitly in the WoT Thing Decription.  In general, <a>Things</a> are <em>described</em> by WoT Thing Descriptions,
+but <a>Consumers</a> are <em>constrained</em> to follow WoT Thing Descriptions when
+interacting with <a>Things</a>.
 <ul>
 <li>
 <span class="rfc2119-assertion" 
       id="client-data-schema">
-A WoT Thing acting as a Consumer when interacting with another target Thing 
+A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another target <a>Thing</a>
 described in a WoT Thing Description MUST generate data  
 organized according to the data schemas given in the corresponding
 interactions.
@@ -2790,7 +2828,7 @@ data returned and accepted by each interaction.
 <li>
 <span class="rfc2119-assertion" 
       id="server-data-schema-extras">
-A Thing MAY return additional data from an interaction  
+A <a>Thing</a> MAY return additional data from an interaction
 even when such data is 
 not described in the data schemas given in its WoT Thing Description.
 </span>
@@ -2798,31 +2836,31 @@ not described in the data schemas given in its WoT Thing Description.
 <li>
 <span class="rfc2119-assertion" 
       id="client-data-schema-accept-extras">
-A WoT Thing acting as a Consumer when interacting with another Thing MUST accept without
+A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another <a>Thing</a> MUST accept without
 error any additional data  
-not described in the data schemas given in the target Thing's WoT Thing Description.
+not described in the data schemas given in the Thing Description of the target <a>Thing</a>.
 </span>
 </li>
 <li>
 <span class="rfc2119-assertion" 
       id="client-data-schema-no-extras">
-A WoT Thing acting as a Consumer when interacting with another Thing MUST NOT generate data  
-not described in the data schemas given in that Thing's WoT Thing Description.
+A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another <a>Thing</a> MUST NOT generate data
+not described in the data schemas given in the Thing Description of that <a>Thing</a>.
 </span>
 </li>
 <li>
 <span class="rfc2119-assertion" 
       id="client-uri-template">
-A WoT Thing acting as a Consumer when interacting with another Thing MUST generate URIs 
+A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another <a>Thing</a> MUST generate URIs
 according to the URI Templates, base URIs, and form href parameters
-given in the target Thing's WoT Thing Description.
+given in the Thing Description of the target <a>Thing</a>.
 </span>
 </li>
 <li>
 <span class="rfc2119-assertion" 
       id="server-uri-template">
 URI Templates, base URIs, and href members
-in a WoT Thing Description MUST accurately describe the WoT Interace of the Thing.
+in a WoT Thing Description MUST accurately describe the <a>WoT Interace</a> of the <a>Thing</a>.
 </span>
 </li>
 </ul>
@@ -2832,32 +2870,32 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
 <section>
   <h3>Protocol Bindings</h3>
 
-  <p>A Protocol Binding is the mapping from an Interaction Affordance to concrete messages of a 
-      specific protocol such as HTTP [[!RFC7231]], CoAP [[!RFC7252]], or MQTT [[!MQTT]]. Protocol Bindings of 
-      Interaction Affordances are serialized as <code>forms</code> as defined in <a href="#form-serialization-json"></a>.
+  <p>A <a>Protocol Binding</a> is the mapping from an <a>Interaction Affordance</a> to concrete messages of a
+      specific protocol such as HTTP [[!RFC7231]], CoAP [[!RFC7252]], or MQTT [[!MQTT]]. <a>Protocol Bindings</a> of
+      <a>Interaction Affordances</a> are serialized as <code>forms</code> as defined in <a href="#form-serialization-json"></a>.
     </p>
 
   <p>
     Every form in a WoT Thing Description must have a submission target,
     given by the <code>href</code> member. The URI scheme of this
-    submission target indicates what Protocol Binding the Thing implements
+    submission target indicates what <a>Protocol Binding</a> the <a>Thing</a> implements
     [[WoT-Architecture]].
     For instance, if the target starts with <code>http</code> or
-    <code>https</code>, a Consumer can then infer the Thing implements the
-    HTTP Protocol Binding and it should expect HTTP-specific terms in the
+    <code>https</code>, a <a>Consumer</a> can then infer the <a>Thing</a> implements the
+    HTTP <a>Protocol Binding</a> and it should expect HTTP-specific terms in the
     form instance (see next section, <a href="#http-binding-assertions"></a>).
     <ul>
         <li>
             <span class="rfc2119-assertion" id="bindings-requirements-scheme">
                 Every form in a WoT Thing Description MUST follow the requirements
-                of the Protocol Binding indicated by the URI scheme of its
+                of the <a>Protocol Binding</a> indicated by the URI scheme of its
                 <code>href</code> member.
             </span>
         </li>
         <li>
             <span class="rfc2119-assertion" id="bindings-server-accept">
                 Every form in a WoT Thing Description MUST accurately describe requests
-                (including request headers, if present) accepted by the Thing in an
+                (including request headers, if present) accepted by the <a>Thing</a> in an
                 interaction.
             </span>
         </li>
@@ -2868,21 +2906,21 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     <h4>HTTP Protocol Binding</h4>
 
     <p>
-        Per default the Thing Description supports the HTTP Protocol Binding and
+        Per default the Thing Description supports the HTTP <a>Protocol Binding</a> and
         includes the HTTP RDF vocabulary set definitions from [[HTTP-in-RDF10]] and can be 
         directly used within TD instances by the usage of the prefix <code>htv</code>, which 
         points to <code>http://www.w3.org/2011/http#</code>. 
     </p>
     <p>
-        To interact with a Thing that implements the HTTP Protocol Binding, a Consumer
+        To interact with a <a>Thing</a> that implements the HTTP <a>Protocol Binding</a>, a <a>Consumer</a>
         needs to know what HTTP method to use when submitting a form. In the general case,
         a Thing Description can explicitly include a term indicating the method, i.e.,
         <code>htv:methodName</code>. For the
-        sake of conciseness, the HTTP Protocol Binding defines default values for each operation type, 
-        which also aims at convergence of the methods expected by Things (e.g., GET to read, PUT to write).
+        sake of conciseness, the HTTP <a>Protocol Binding</a> defines default values for each operation type,
+        which also aims at convergence of the methods expected by <a>Things</a> (e.g., GET to read, PUT to write).
         <span class="rfc2119-assertion" id="td-default-http-method">
             When no method is indicated in a form representing an HTTP
-            Protocol Binding, a default value MUST be assumed as shown in
+            <a>Protocol Binding</a>, a default value MUST be assumed as shown in
             the following table.
         </span>
     </p>
@@ -3043,8 +3081,8 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       <h4>Other Protocol Bindings</h4>
 
       <p>
-          The number of Protocol Bindings a Thing can implement
-          is not restricted. Other Protocol Bindings, e.g., for CoAP, MQTT, or OPC UA
+          The number of <a>Protocol Bindings</a> a <a>Thing</a> can implement
+          is not restricted. Other <a>Protocol Bindings</a>, e.g., for CoAP, MQTT, or OPC UA
           will be standardized in separate documents such as a protocol vocabulary similar to HTTP in RDF [[HTTP-in-RDF10]]
           or specifications including default value definitions. Such protocols can be simply integrated into the TD by the 
           usage of the context extension mechanism (<a href="#content-extension-section"></a>).
@@ -3081,7 +3119,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
   <section id="sec-security-consideration-context">
   <h5>Context Dereferencing Privacy Risk</h5>
       <p>Deferencing the vocabulary files given in the <code>@context</code>
-          member of any JSON-LD [[json-ld11]] document can be a privacy risk.
+          member of any JSON-LD [[?json-ld11]] document can be a privacy risk.
           In the case of the WoT, an attacker can observe the network
           traffic produced by such deferences and can use the metadata
           of the dereference, such as the destination IP address,
@@ -3114,14 +3152,14 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       <dl><dt>Mitigation:</dt><dd>
           All identifiers should be mutable,
           and there should be a mechanism to update the <code>id</code>
-          of a Thing.
+          of a <a>Thing</a>.
           Specifically,
-          the <code>id</code> of a Thing should not be fixed in hardware.
+          the <code>id</code> of a <a>Thing</a> should not be fixed in hardware.
           This does, however, conflict with the Linked Data ideal that
           identifiers are fixed URIs.  In many circumstances it
           will be acceptable to only allow updates to identifiers if
-          a Thing is reinitialized.  In this case as a software entity the
-          old Thing ceases to exist and a new Thing is created.
+          a <a>Thing</a> is reinitialized.  In this case as a software entity the
+          old <a>Thing</a> ceases to exist and a new <a>Thing</a> is created.
           This can be sufficient to break a tracking chain when, for
           example, a device is sold to a new owner.
           Alternatively, if more frequent changes are desired during 
@@ -3145,7 +3183,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       </p>
       <dl><dt>Mitigation:</dt><dd>
           Only authorized users should be provided access
-          to the Thing Description for a Thing.
+          to the Thing Description for a <a>Thing</a>.
           If the TD is only distributed to authorized users 
           through secure and confidential channels, for
           example through a directory service that requires authentication,
@@ -3161,7 +3199,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       <dl><dt>Mitigation:</dt><dd>
           Obtain Thing Descriptions only through
           mutually authenticated channels.
-          This ensures that the Consumer and the server are both sure of the 
+          This ensures that the <a>Consumer</a> and the server are both sure of the
           identity of the other party to the communication.
           This is also necessary in order to deliver TDs only to authorized users.
       </dd></dl>
@@ -3202,13 +3240,13 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
           As an example application of this principle,
           consider how to obtain user consent.  
           Consent for usage of personally identifiable data
-          generated by a Thing is often obtained when a Thing is paired with system
+          generated by a <a>Thing</a> is often obtained when a <a>Thing</a> is paired with system
           consuming the data,
           which is frequently also when the Thing Description
           is registered with a local directory or the system consuming the 
           Thing Description in order to access the device.
-          In this case consent for using data from a Thing can be combined with
-          consent for accessing the Thing's Thing Description.
+          In this case, consent for using data from a <a>Thing</a> can be combined with
+          consent for accessing the Thing Description of the <a>Thing</a>.
           As a second example, if we consider a TD to contain personally
           identifiable information, then it should not be retained indefinitely
           or used for purposes other than those for which consent was given.
@@ -3237,7 +3275,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
         <p>
           <span class="rfc2119-assertion" id="iana-security-execution">
             Since WoT Thing Description is intended to be a pure data exchange format for
-            Thing metadata, the serialization SHOULD NOT be passed through a
+            <a>Thing</a> metadata, the serialization SHOULD NOT be passed through a
             code execution mechanism such as JavaScript's <code>eval()</code>
             function to be parsed.
           </span>
@@ -3250,7 +3288,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
           which typically follows links to remote contexts (i.e., TD context
           extensions, see <a href="#content-extension-section"></a>)
           automatically, resulting in the transfer of files
-          without the explicit request of the Consumer for each one. If remote
+          without the explicit request of the <a>Consumer</a> for each one. If remote
           contexts are served by third parties, it may allow them to gather
           usage patterns or similar information leading to privacy concerns.
           <span class="rfc2119-assertion" id="iana-security-remote">
@@ -3267,10 +3305,10 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
           Context Extensions (see <a href="#content-extension-section"></a>)
           that are loaded from the Web over non-secure connections,
           such as HTTP, run the risk of being altered by an attacker such that
-          they may modify the TD Information Model in a way that could
+          they may modify the <a>TD Information Model</a> in a way that could
           compromise security.
           <span class="rfc2119-assertion" id="iana-security-alter">
-          For this reason, Consumer again
+          For this reason, <a>Consumer</a> again
           SHOULD vet and cache remote contexts before allowing the system
           to use it.
           </span>
@@ -3282,7 +3320,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
           a JSON-LD 1.1 processor and, in the worst case, the resulting data
           might consume all of the recipient's resources.
           <span class="rfc2119-assertion" id="iana-security-expansion">
-          Consumers SHOULD treat any TD metadata with due skepticism.
+          <a>Consumers</a> SHOULD treat any TD metadata with due skepticism.
           </span>
         </p>
       </dd>
@@ -3298,7 +3336,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
       <dt>Applications that use this media type:</dt>
       <dd>
         All participating entities in the W3C Web of Things, that is,
-        Things, Consumers, and Intermediaries as defined in the
+        <a>Things</a>, <a>Consumers</a>, and Intermediaries as defined in the
         <a href="https://w3c.github.io/wot-architecture">Web of Things (WoT) Architecture</a>.</dd>
       <dt>Fragment identifier considerations:</dt>
       <dd>See <a href="https://tools.ietf.org/html/rfc6839#section-3.1">RFC&nbsp;6839, section 3.1</a>.</dd>
@@ -3354,7 +3392,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     <section id="myLampThing-example-serialization">
     <h3>MyLampThing Example with CoAP Protocol Binding</h3>
   
-    <p>Feature list of the Thing:</p>
+    <p>Feature list of the <a>Thing</a>:</p>
   
     <ul>
         <li>Name: MyLampThing</li>
@@ -3363,8 +3401,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
         <li>Security: PSKSecurityScheme</li>
         <li>Protocol Binding: CoAP [[?RFC7252]] over TLS</li>
         <li>Serialization: default (JSON)</li>
-        <li>Comment: Also see Section <a href="#adding-protocol-bindings">Adding Protocol Bindings</a>. </li>
-  
+        <li>Comment: Also see <a href="#adding-protocol-bindings"></a>.</li>
     </ul>
   
   <pre class="example" title="MyLampThing with CoAP Protocol Binding">
@@ -3417,7 +3454,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     <section id="myLampThing-example-serialization">
     <h3>MyLightSensor Example with MQTT Protocol Binding</h3>
   
-    <p>Feature list of the Thing:</p>
+    <p>Feature list of the <a>Thing</a>:</p>
   
     <ul>
         <li>Name: MyLightSensor</li>
@@ -3456,25 +3493,25 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     <section id="webhook-example-serialization">
       <h3>Webhook Event Example</h3>
     
-      <p>Feature list of the Thing:</p>
+      <p>Feature list of the <a>Thing</a>:</p>
     
       <ul>
           <li>Name: WebhookThing</li>
-          <li>Context extension: use HTTP Protocol Binding supplements (htv prefix already included in TD context)</li>
+          <li>Context extension: use HTTP <a>Protocol Binding</a> supplements (htv prefix already included in TD context)</li>
           <li>Offered affordances: 1 Event</li>
           <li>Security: none</li>
           <li>Protocol Binding: HTTP</li>
           <li>Serializiation: default (JSON) </li>
           <li>Comment: <i>WebhookThing</i> provides an Event affordance <code>temperature</code>
-              which periodically pushes the latest temperature value to the Consumer using a Webhook mechanism,
-              where the Thing sends POST requests to a callback URI provided by the Consumer.
+              which periodically pushes the latest temperature value to the <a>Consumer</a> using a Webhook mechanism,
+              where the <a>Thing</a> sends POST requests to a callback URI provided by the <a>Consumer</a>.
               To describe this, the <code>subscription</code> member defines a write-only parameter <code>callbackURL</code>,
               which must be submitted through the <code>subscribeevent</code> form.
               The read-only parameter <code>subscriptionID</code> is returned by the subscription.
               The <i>WebhookThing</i> will then periodically POST to this callback URI with a payload defined by <code>data</code>.
-              To unsubscribe, the Consumer has to submit the <code>unsubscribeevent</code> form,
+              To unsubscribe, the <a>Consumer</a> has to submit the <code>unsubscribeevent</code> form,
               which makes use of a URI Template.
-              The <code>uriVariables</code> member informs the Consumer to include the <code>subscriptionID</code> string.
+              The <code>uriVariables</code> member informs the <a>Consumer</a> to include the <code>subscriptionID</code> string.
               This can be further automated by using a context extension to include proper semantic annotations.
               Alternatively, one can imagine unsubscribing using the <code>concellation</code> member similarly to <code>subscription</code>
               and combine this with a <code>unsubscribeevent</code> form that describes a POST request with payload to unsubscribe.
@@ -3553,7 +3590,7 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     </p>
     <p class="note">The Thing Description defined by this document allows for 
         adding external vocabularies by using <code>@context</code> mechanism 
-        known from JSON-LD [[json-ld11]], and the terms in those external vocabularies can be 
+        known from JSON-LD [[?json-ld11]], and the terms in those external vocabularies can be
         used in addition to the terms defined in Section <a href="#sec-vocabulary-definition">Information Model</a>. 
         For this reason, the below JSON schema is intentionally non-strict in that 
         regard. You can replace the value of <code>additionalProperties</code> schema 
@@ -3574,18 +3611,18 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
   <h1>Thing Templates</h1>
       
     <p>
-    A <em>Thing Template</em> is a description for a <em>class</em> of devices or things.
-    It describes the properties, actions, events and common metadata that are shared for an entire group of things,
-    to enable the common handling of thousands of devices by a cloud server, which is not practical on a per-thing basis.
+    A <em>Thing Template</em> is a description for a <em>class</em> of <a>Things</a>.
+    It describes the properties, actions, events and common metadata that are shared for an entire group of <a>Things</a>,
+    to enable the common handling of thousands of devices by a cloud server, which is not practical on a per-<a>Thing</a> basis.
     The Thing Template uses the same core vocabulary and information model from section 5.
     </p>
     <p>
     The Thing Template enables:
     <ul>
-    <li> management of multiple things by a cloud service. </li>
-    <li> simulation of devices/things that have not yet been developed.</li>
-    <li> common applications across devices from different manufacturers that share a common thing model.</li>
-    <li> combining multiple models into a thing.
+    <li> management of multiple <a>Things</a> by a cloud service. </li>
+    <li> simulation of devices/<a>Things</a> that have not yet been developed.</li>
+    <li> common applications across devices from different manufacturers that share a common <a>Thing</a> model.</li>
+    <li> combining multiple models into a <a>Thing</a>.
     </ul>
     </p>
     <p>
@@ -3593,19 +3630,19 @@ in a WoT Thing Description MUST accurately describe the WoT Interace of the Thin
     (properties, actions and events), however it does not contain device-specific
     information, such as a serial number, GPS location, security information or concrete protocol endpoints.
     </p><p>
-    Since a Thing Template does not contain a Protocol Binding to specific endpoints and 
+    Since a Thing Template does not contain a <a>Protocol Binding</a> to specific endpoints and
     does not define a specific security mechanism, the <em>forms</em> and <em>securityDefinitions</em> and 
     <em>security</em> keys must not be present.
     </p><p>
-     The same Thing Template can be implemented by things from multiple vendors,
-    a thing can implement multiple thing templates, define additional metadata
+     The same Thing Template can be implemented by <a>Things</a> from multiple vendors,
+    a <a>Thing</a> can implement multiple Thing Templates, define additional metadata
     (vendor, location, security) and define bindings to concrete protocols.
-    To avoid conflicts between properties, actions and events from different thing templates
-    that are combined into a common thing, all thse identifiers must be unique within a thing.
+    To avoid conflicts between properties, actions and events from different Thing Templates
+    that are combined into a common <a>Thing</a>, all thse identifiers must be unique within a <a>Thing</a>.
     </p><p>
     A common Thing Template for a class of devices enables writing applications across vendors and
     creates a more attractive market for application developers.
-    A concrete Thing Description can implement multiple <em>Thing Templates</em> and
+    A concrete Thing Description can implement multiple Thing Templates and
     thus can aggregate function blocks into a combined device.
     </p><p>
     The business models of cloud vendors are typically built on managing thousands of identical devices.
@@ -3878,7 +3915,7 @@ _:b8 &lt;https://www.w3.org/2019/wot-security#in&gt; &quot;header&quot; .</pre>
 
             <p class="ednote">
                 The last two JSON-LD features (property-based data indexing and indexing without a
-                predicate) are still experimental; they have not been published in any Editor's
+                predicate) are still experimental; they have not been published in any Editors'
                 Draft yet.
             </p>
     
@@ -3893,13 +3930,13 @@ _:b8 &lt;https://www.w3.org/2019/wot-security#in&gt; &quot;header&quot; .</pre>
             <h3>Thing Description Ontology</h3>
 
             <p>
-                TD classes and properties have RDF foundations, in the form of a Web
+                TD <a>Classes</a> and name-value pairs (properties) have RDF foundations, in the form of a Web
                 ontology in the Web Ontology Language [[owl2-overview]]. Some assertions of
                 this document are also expressed as OWL axioms.
             </p>
 
             <p>
-                Default values require special care when translating the TD information model
+                Default values require special care when translating the <a>TD Information Model</a>
                 into OWL.
             </p>
 
@@ -3919,57 +3956,57 @@ _:b8 &lt;https://www.w3.org/2019/wot-security#in&gt; &quot;header&quot; .</pre>
     <li>General</li>
     <ul>
     <li>Added <a href="#multilanguage">multi-language</a> support for human-readable metadata (<code>descriptions</code> and <code>titles</code> <a>vocabulary terms</a>).</li>
-    <li>Renamed the <code>InteractionPattern</code> class to <a href="#interactionaffordance"><code>InteractionAffordance</code></a>.</li>
+    <li>Renamed the <code>InteractionPattern</code> <a>Class</a> to <a href="#interactionaffordance"><code>InteractionAffordance</code></a>.</li>
     <li>Added a <a href="#behavior">section</a> to describe behavioral constraints of a WoT system.</li>
     <li>Added a <a href="#sec-security-consideration">section</a> with security and privacy considerations.</li>
     <li>Added a <a href="#iana-section">section</a> with IANA considerations to register media type and CoAP Content Format.</li>
-    <li>Added an <a href="#thing-templates">appendix section</a> describing the concept of Thing Templates for describing classes of Things.</li>
+    <li>Added an <a href="#thing-templates">appendix section</a> describing the concept of Thing Templates for describing classes of <a>Things</a>.</li>
     <li>Added an <a href="#note-jsonld11-processing">appendix section</a> explaining the RDF representation of Thing Descriptions; it replaces the former subsection "Implementation Notes".</li>
     <li>Moved the full examples of Thing Description instances to the <a href="#example-serialization">appendix</a>.</li>
     </ul>
 
     <li>Thing</li>
     <ul>
-    <li>Added mandatory <code>@context</code> and optional <code>@type</code> <a>vocabulary terms</a> to the <a href="#thing">Thing</a> class.</li>
-    <li>Added optional <code>created</code> and <code>modified</code> <a>vocabulary terms</a> to the <a href="#thing">Thing</a> class to provide information as to when the TD instance was created or last modified, resp.</li>
-    <li>Added optional <code>version</code> <a>vocabulary term</a> to the <a href="#thing">Thing</a> class to provide version information.</li>
+    <li>Added mandatory <code>@context</code> and optional <code>@type</code> <a>vocabulary terms</a> to the <a href="#thing">Thing</a> <a>Class</a>.</li>
+    <li>Added optional <code>created</code> and <code>modified</code> <a>vocabulary terms</a> to the <a href="#thing">Thing</a> <a>Class</a> to provide information as to when the TD instance was created or last modified, resp.</li>
+    <li>Added optional <code>version</code> <a>vocabulary term</a> to the <a href="#thing">Thing</a> <a>Class</a> to provide version information.</li>
     <li>Added support for <a href="#meta-interactions-of-thing">meta interactions</a> through the operation types <code>readallproperties</code>, <code>writeallproperties</code>, <code>readmultipleproperties</code>, and <code>writemultipleproperties</code>.</li>
     </ul>
 
     <li>InteractionAffordance</li>
     <ul>
-    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#interactionaffordance">InteractionAffordance</a> class to make semantic annotations part of the Information Model.</li>
-    <li>Added optional <code>uriVariables</code> <a>vocabulary terms</a> to <a href="#interactionaffordance">InteractionAffordance</a> class to describe URI Template variables.</li>
-    <li>Added optional <code>safe</code> and <code>idempotent</code> <a>vocabulary terms</a> to the <a href="#actionaffordance">ActionAffordance</a> class to provide information about the safeness and idempotency of the Action.</li>
-    <li>Added optional <code>subscription</code> and <code>cancellation</code> <a>vocabulary terms</a> to the <a href="#eventaffordance">EventAffordance</a> class to describe data that needs to be passed upon subscription and cancellation, resp.</li>
-    <li>Renamed <code>label</code> to <code>title</code> in the <a href="#interactionaffordance">InteractionAffordance</a> class to be consistent with JSON Schema.</li>
-    <li>Removed <code>security</code> and <code>scopes</code> <a>vocabulary terms</a> from the <a href="#interactionaffordance">InteractionAffordance</a> class to simplify mechanism.</li>
-    <li>Removed the <code>writable</code> <a>vocabulary term</a> from the <a href="#propertyaffordance">PropertyAffordance</a> class and made Property affordances both readable and writable by default; this can be overridden using the <code>op</code> <a>vocabulary term</a> of the <a href="#form">Form</a> class.</li>
+    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#interactionaffordance">InteractionAffordance</a> <a>Class</a> to make semantic annotations part of the Information Model.</li>
+    <li>Added optional <code>uriVariables</code> <a>vocabulary terms</a> to <a href="#interactionaffordance">InteractionAffordance</a> <a>Class</a> to describe URI Template variables.</li>
+    <li>Added optional <code>safe</code> and <code>idempotent</code> <a>vocabulary terms</a> to the <a href="#actionaffordance">ActionAffordance</a> <a>Class</a> to provide information about the safeness and idempotency of the Action.</li>
+    <li>Added optional <code>subscription</code> and <code>cancellation</code> <a>vocabulary terms</a> to the <a href="#eventaffordance">EventAffordance</a> <a>Class</a> to describe data that needs to be passed upon subscription and cancellation, resp.</li>
+    <li>Renamed <code>label</code> to <code>title</code> in the <a href="#interactionaffordance">InteractionAffordance</a> <a>Class</a> to be consistent with JSON Schema.</li>
+    <li>Removed <code>security</code> and <code>scopes</code> <a>vocabulary terms</a> from the <a href="#interactionaffordance">InteractionAffordance</a> <a>Class</a> to simplify mechanism.</li>
+    <li>Removed the <code>writable</code> <a>vocabulary term</a> from the <a href="#propertyaffordance">PropertyAffordance</a> <a>Class</a> and made Property affordances both readable and writable by default; this can be overridden using the <code>op</code> <a>vocabulary term</a> of the <a href="#form">Form</a> <a>Class</a>.</li>
     </ul>
 
     <li>Link and Form</li>
     <ul>
-    <li>Renamed <code>mediaType</code> to <code>type</code> in the <a href="#link">Link</a> class to align with RFC 8288.</li>
-    <li>Added optional <code>response</code> <a>vocabulary term</a> to the <a href="#form">Form</a> class to describe possible response messages.</li>
-    <li>Renamed <code>mediaType</code> to <code>contentType</code> in the <a href="#form">Form</a> class to reflect that request might need to set also media type parameters.</li>
-    <li>Renamed <code>rel</code> to <code>op</code> in the <a href="#form">Form</a> class to resolve perceived conflicts with link relations.</li>
+    <li>Renamed <code>mediaType</code> to <code>type</code> in the <a href="#link">Link</a> <a>Class</a> to align with RFC 8288.</li>
+    <li>Added optional <code>response</code> <a>vocabulary term</a> to the <a href="#form">Form</a> <a>Class</a> to describe possible response messages.</li>
+    <li>Renamed <code>mediaType</code> to <code>contentType</code> in the <a href="#form">Form</a> <a>Class</a> to reflect that request might need to set also media type parameters.</li>
+    <li>Renamed <code>rel</code> to <code>op</code> in the <a href="#form">Form</a> <a>Class</a> to resolve perceived conflicts with link relations.</li>
     <li>Added <code>unobserveproperty</code> to the enumerated values for the <code>op</code> <a>vocabulary term</a>.</li>
     </ul>
 
     <li>DataSchema</li>
     <ul>
-    <li>Added missing <a href="#nullschema">NullSchema</a> class.</li>
-    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> class to make semantic annotations part of the Information Model.</li>
-    <li>Added optional <code>unit</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> class to provide unit metadata.</li>
-    <li>Added optional <code>oneOf</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> class to allow for alternative schemas.</li>
-    <li>Added optional <code>format</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> class to allow for pattern validation.</li>
+    <li>Added missing <a href="#nullschema">NullSchema</a> <a>Class</a>.</li>
+    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> <a>Class</a> to make semantic annotations part of the Information Model.</li>
+    <li>Added optional <code>unit</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> <a>Class</a> to provide unit metadata.</li>
+    <li>Added optional <code>oneOf</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> <a>Class</a> to allow for alternative schemas.</li>
+    <li>Added optional <code>format</code> <a>vocabulary term</a> to the <a href="#dataschema">DataSchema</a> <a>Class</a> to allow for pattern validation.</li>
     </ul>
 
     <li>Security Scheme</li>
     <ul>
-    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#securityscheme">SecurityScheme</a> class to make semantic annotations part of the Information Model.</li>
-    <li>Added <code>securityDefinitions</code> <a>vocabulary term</a> to the <a href="#thing">Thing</a> class to declare security definitions.</li>
-    <li>Redefined <code>security</code> <a>vocabulary term</a> in the <a href="#thing">Thing</a> and <a href="#form">Form</a> classes to be used to activate declared security definitions.</li>
+    <li>Added optional <code>@type</code> <a>vocabulary term</a> to the <a href="#securityscheme">SecurityScheme</a> <a>Class</a> to make semantic annotations part of the Information Model.</li>
+    <li>Added <code>securityDefinitions</code> <a>vocabulary term</a> to the <a href="#thing">Thing</a> <a>Class</a> to declare security definitions.</li>
+    <li>Redefined <code>security</code> <a>vocabulary term</a> in the <a href="#thing">Thing</a> and <a href="#form">Form</a> <a>Classes</a> to be used to activate declared security definitions.</li>
     <li>Clarified that the top-level <a href="#security-serialization-json"><code>securityDefinitions</code> and <code>security</code></a> configuration is mandatory.</li>
     <li>Removed all <code>Url</code> postfixes from security scheme <a>vocabulary terms</a>.</li>
     </ul>

--- a/index.template.html
+++ b/index.template.html
@@ -915,7 +915,9 @@ a[href].internalDFN {
             in this specification. An <a>Object</a> whose elements only have numbers
             as names is called an <dfn>Array</dfn>. Similarly, an <a>Object</a> whose
             elements only have <a>Term</a>s (that do not belong to any <a>Vocabulary</a>)
-            as names is called a <dfn>Map</dfn>.
+            as names is called a <dfn>Map</dfn>. All names appearing in some name-value pair
+            in a <a>Map</a> are assumed to be <em>unique</em> within the scope of the
+            <a>Map</a>.
         </p>
 
         <p>
@@ -926,23 +928,24 @@ a[href].internalDFN {
         </p>
 
         <p>
-            The <a>Signature</a> of a <a>Class</a> allows to construct two relations that further
-            define <a>Classes</a>: an <dfn>Assignment Relation</dfn> and a <dfn>Type Relation</dfn>.
-            The <a>Assignment Relation</a> of a <a>Class</a> takes a <a>Vocabulary Term</a> as input
+            The <a>Signature</a> of a <a>Class</a> allows to construct two functions that further
+            define <a>Classes</a>: an <dfn>Assignment Function</dfn> and a <dfn>Type Function</dfn>.
+            The <a>Assignment Function</a> of a <a>Class</a> takes a <a>Vocabulary Term</a> as input
             and returns either <code>true</code> or <code>false</code> as output.
-            The <a>Type Relation</a> of a <a>Class</a> also takes a <a>Vocabulary Term</a>
-            as input and returns another <a>Class</a> as output.
+            The <a>Type Function</a> of a <a>Class</a> also takes a <a>Vocabulary Term</a>
+            as input and returns another <a>Class</a> as output. These functions are <em>partial</em>:
+            their domain is limited to the <a>Signature</a> of the <a>Class</a> being defined.
         </p>
 
         <p>
-            On the basis of these two relations, two constraints on <a>Class</a> instantiation
+            On the basis of these two functions, two constraints on <a>Class</a> instantiation
             can be defined as follows:
             <ul>
                 <li>
                     an <a>Object</a> is an instance of a <a>Class</a> if for every <a>Term</a>
-                    for which the <a>Assignment Relation</a> of the <a>Class</a> returns
+                    for which the <a>Assignment Function</a> of the <a>Class</a> returns
                     <code>true</code>, it includes a name-value pair with the <a>Vocabulary Term</a>
-                    as name. In other words, the <a>Assignment Relation</a> indicates whether
+                    as name. In other words, the <a>Assignment Function</a> indicates whether
                     a <a>Vocabulary Term</a> in the <a>Signature</a> of the <a>Class</a> is mandatory.
                     <a>Vocabulary Terms</a> that are not mandatory, but are in the <a>Signature</a>
                     of a <a>Class</a> are optional.
@@ -952,7 +955,7 @@ a[href].internalDFN {
                     if for every <a>Vocabulary Term</a>
                     in the <a>Signature</a> of the <a>Class</a> used as name in some name-value pair
                     of the <a>Object</a>, the value of that pair is an instance of the
-                    <a>Class</a> returned by the <a>Type Relation</a> of the <a>Class</a> for the
+                    <a>Class</a> returned by the <a>Type Function</a> of the <a>Class</a> for the
                     given <a>Vocabulary Term</a>.
                 </li>
             </ul>
@@ -968,16 +971,18 @@ a[href].internalDFN {
             as a set of <a>Class</a> definitions,
             which include a <a>Class</a> name (a <a>Vocabulary Term</a>),
             a <a>Signature</a> (a set of <a>Vocabulary Terms</a>),
-            an <a>Assignment Relation</a>,
-            and a <a>Type Relation</a>.
+            an <a>Assignment Function</a>,
+            and a <a>Type Function</a>.
             These <a>Class</a> definitions are provided as tables in <a href="#class-definitions"></a>.
+            By convention, <a>Simple Types</a> are denoted by names starting with lowercase.
         </p>
 
         <p>
-            In addition, the <a>TD Information Model</a> defines another relation for each
-            <a>Class</a> that takes a <a>Vocabulary Term</a> as input and returns an <a>Object</a>,
-            which is the <dfn>Default Value</dfn> for some assignment. This relation allows
-            to relax the constraint defined above on the <a>Assignment Relation</a>:
+            In addition, the <a>TD Information Model</a> defines another partial function defined
+            on the <a>Signature</a> of a <a>Class</a>, that takes a <a>Vocabulary Term</a> as
+            input and returns an <a>Object</a>, which is the <dfn>Default Value</dfn> for some
+            assignment. This function allows to relax the constraint defined above on the
+            <a>Assignment Function</a>:
             an <a>Object</a> is an instance of a <a>Class</a> if it includes all mandatory
             assignments <em>or</em> if <a>Default Value</a> exist for the missing
             assignments. All <a>Default Values</a> are given in a single table in
@@ -1251,7 +1256,9 @@ In summary, this requires the following:
 
   <p>
     Every <a>Simple Type</a> mentioned in
-    <a href="#class-definitions"></a> maps to a JSON
+    <a href="#class-definitions"></a> (<code>string</code>, <code>anyURI</code>,
+    <code>dateTime</code>, <code>integer</code>, <code>unsignedInt</code>,
+    <code>double</code>, <code>boolean</code>) maps to a JSON 
     type (string, number, boolean), as per the rules listed below. These
     rules apply to values in name-value pairs:
   </p>
@@ -1275,7 +1282,7 @@ In summary, this requires the following:
     XSD built-in dateTime datatype
   </a>, itself inspired by the ISO standard for dates and times [[ISO8601]].</li>
   <li><span class="rfc2119-assertion" id="td-integer-type">
-        Values that are of type <code>integer</code>
+        Values that are of type <code>integer</code> or <code>unsignedInt</code>
         MUST be serialized as JSON numbers without a fraction or exponent part.
   </span></li>
   <li><span class="rfc2119-assertion" id="td-number-type">

--- a/index.template.html
+++ b/index.template.html
@@ -1282,6 +1282,10 @@ In summary, this requires the following:
         Values that are of type <code>double</code>
         MUST be serialized as JSON number.
   </span></li>
+  <li><span class="rfc2119-assertion" id="td-boolean-type">
+        Values that are of type <code>boolean</code>
+        MUST be serialized as JSON boolean.
+  </span></li>
   </ul>
 
   <p>
@@ -1494,12 +1498,21 @@ In summary, this requires the following:
 
   <p><span class="rfc2119-assertion" id="td-arrays">
   All values assigned to
-  <code>security</code>,
   <code>links</code>, and
   <code>forms</code>
   in an instance of <a>Class</a> <code>Thing</code>
-  MUST be serialized as JSON arrays.
+  MUST be serialized as JSON arrays containing JSON objects
+  as defined in <a href="#form-serialization-json"></a>
+  and <a href="#links-serialization-json"></a>, respectively.
   </span></p>
+
+  <p>
+      <span class="rfc2119-assertion" id="td-security-activation">
+          The value assigned to <code>security</code> in an instance
+          of <a>Class</a> <code>Thing</code> MUST be serialized as
+          a JSON string or as a JSON array whose elements are JSON strings.
+      </span>
+  </p>
 
 </section> <!-- end of id="sec-thing-as-a-whole-json"-->
 


### PR DESCRIPTION
I implemented many editorial clean-ups. I marked defined terms consistently (might still have missed some).

I checked @vcharpenay 's updates to the TD Information Model definition and resulting changes to the serialization.
* A resulting glitch is now that there are no assertions on how to serialize specific class instances. The general instruction to serialize them as JSON objects is not an assertion. This is particularly bad for the serializations of (model) assigned Map and Array values.
* Assertions with "where the name is a <a>Vocabulary Term</a> included in the <a>Signatures</a> of ..." require an OR, not AND -- please verify
* Superclass is not defined, but used once
* "Every Simple Type mentioned in Section § 5.3 Class Definitions maps to a JSON type" -- unfortunately there is no list of the Simple Types

We need to check for a consistent usage of
* WoT Thing Description -- this should be only for referring to the building block or document
* Thing Description
* Thing Description instance
* TD
* TD instance
* TD Document -- this should be used primarily to refer to the JSON-based serializations
* TD Serialization -- this secondary
* TD model -- makes it clear we are in this self-defined Object world
* TD format
* TD representation format -- good to refer to the specified representation format
* ... more variations