### PR TITLE
Default value table + reponse term handling in Forms

### DIFF
--- a/index.html
+++ b/index.html
@@ -1641,7 +1641,8 @@ operations types SHOULD NOT be arbitrarily set by servients
 </p>
 <p>
 In some use cases such as for an <code>ActionAffordance</code> there is a different expectations of content types for the <code>input</code> 
-and <code>output</code>. In such a case the <code>response</code> term from the <a href="#expectedresponse"></a> class can be enabled to decleare different content types for requests and 
+and <code>output</code>. In such a case the <code>response</code> term that is typed with the <a href="#expectedresponse"></a> class can be enabled to 
+decleare different content types for requests and 
 responses.
 <span class="rfc2119-assertion" id="td-expectedResponse-contentType">
 The term <code>response</code> MUST be mandatory in a TD document if the response content type differs 
@@ -1661,11 +1662,6 @@ IANA HTTP content coding registry</a>.
 <tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link"><td><code>anchor</code></td><td>By default, the context, or anchor, of a link conveyed in the Link header field is the URL of the representation it is associated with, as defined in RFC7231, Section 3.1.4.1, and is serialized as a URI.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr></tbody></table></section>
 <section><h3><code>ExpectedResponse</code></h3><p>Communication metadata for response messages (e.g., contentType of the response).</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type [[IANA-MEDIA-TYPES]] (e.g., 'application/json) and (optional) parameters (e.g., 'charset=utf-8').</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
 
-<<<<<<< HEAD
-
-
-=======
->>>>>>> ba93c1c8c385328f8857d6cc419adb48265b50e8
       </section>
 
     </section>
@@ -1683,111 +1679,110 @@ IANA HTTP content coding registry</a>.
       
       <p>
           The following table gives all <a>Default Values</a> defined in the
-          <a>Classes</a> of the <a>TD Information Model</a>. An empty cell in the last column
-          must be interpreted as applying to all <a>Classes</a>.
+          <a>Classes</a> of the <a>TD Information Model</a>. 
       </p>
 
       <table class="def">
-          <thead>
-              <tr>
-                  <th><a>Class</a></th>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Default value</th>
-              </tr>
-          </thead>
-          <tbody>
-              <tr class="rfc2119-default-assertion" id="td-default-contentType">
-                  <td></td>
-                  <td>
-                      <code>contentType</code>
-                  </td>
-                  <td><code>application/json</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-safe">
-                  <td></td>
-                  <td>
-                      <code>safe</code>
-                  </td>
-                  <td><code>false</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-idempotent">
-                  <td></td>
-                  <td>
-                      <code>idempotent</code>
-                  </td>
-                  <td><code>false</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-op-properties">
-                  <td><code>PropertyAffordance</code></td>
-                  <td>
-                      <code>op</code>
-                  </td>
-                  <td>Array of strings with values <code>readproperty</code> followed by 
-                      <code>writeproperty</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-op-actions">
-                  <td><code>ActionAffordance</code></td>
-                  <td>
-                      <code>op</code>
-                  </td>
-                  <td><code>invokeaction</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-op-events">
-                  <td><code>EventAffordance</code></td>
-                  <td>
-                      <code>op</code>
-                  </td>
-                  <td><code>subscribeevent</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-in-1">
-                  <td><code>BasicSecurityScheme</code></br>
-                    <code>DigestSecurityScheme</code></br>
-                    <code>BearerSecurityScheme</code></br>
-                    <code>PoPSecurityScheme</code></td>
-                  <td>
-                      <code>in</code>
-                  </td>
-                  <td><code>header</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-in-2">
-                  <td><code>APIKeySecurityScheme</code></td>
-                  <td>
-                      <code>in</code>
-                  </td>
-                  <td><code>query</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-qop">
-                  <td><code>DigestSecurityScheme</code></td>
-                  <td>
-                      <code>qop</code>
-                  </td>
-                  <td><code>auth</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-alg">
-                  <td><code>BearerSecurityScheme</code></br>
-                    <code>PoPSecurityScheme</code></td>
-                  <td>
-                      <code>alg</code>
-                  </td>
-                  <td><code>ES256</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-format">
-                  <td><code>BearerSecurityScheme</code></br>
-                    <code>PoPSecurityScheme</code></td>
-                  <td>
-                      <code>format</code>
-                  </td>
-                  <td><code>jwt</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-flow">
-                  <td><code>OAuth2SecurityScheme</code></td>
-                  <td>
-                      <code>flow</code>
-                  </td>
-                  <td><code>implicit</code></td>
-              </tr>
-          </tbody>
-      </table>
+        <thead>
+            <tr>
+                <th><a>Class</a></th>
+                <th><a>Vocabulary term</a></th>
+                <th>Default value</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="rfc2119-default-assertion" id="td-default-contentType">
+                <td><code>Forms</code></td>
+                <td>
+                    <code>contentType</code>
+                </td>
+                <td><code>application/json</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-safe">
+                <td><code>ActionAffordance</code></td>
+                <td>
+                    <code>safe</code>
+                </td>
+                <td><code>false</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-idempotent">
+                <td><code>ActionAffordance</code></td>
+                <td>
+                    <code>idempotent</code>
+                </td>
+                <td><code>false</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-op-properties">
+                <td><code>PropertyAffordance</code></td>
+                <td>
+                    <code>op</code>
+                </td>
+                <td>Array of strings with values <code>readproperty</code> followed by 
+                    <code>writeproperty</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-op-actions">
+                <td><code>ActionAffordance</code></td>
+                <td>
+                    <code>op</code>
+                </td>
+                <td><code>invokeaction</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-op-events">
+                <td><code>EventAffordance</code></td>
+                <td>
+                    <code>op</code>
+                </td>
+                <td><code>subscribeevent</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-in-1">
+                <td><code>BasicSecurityScheme</code></br>
+                  <code>DigestSecurityScheme</code></br>
+                  <code>BearerSecurityScheme</code></br>
+                  <code>PoPSecurityScheme</code></td>
+                <td>
+                    <code>in</code>
+                </td>
+                <td><code>header</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-in-2">
+                <td><code>APIKeySecurityScheme</code></td>
+                <td>
+                    <code>in</code>
+                </td>
+                <td><code>query</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-qop">
+                <td><code>DigestSecurityScheme</code></td>
+                <td>
+                    <code>qop</code>
+                </td>
+                <td><code>auth</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-alg">
+                <td><code>BearerSecurityScheme</code></br>
+                  <code>PoPSecurityScheme</code></td>
+                <td>
+                    <code>alg</code>
+                </td>
+                <td><code>ES256</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-format">
+                <td><code>BearerSecurityScheme</code></br>
+                  <code>PoPSecurityScheme</code></td>
+                <td>
+                    <code>format</code>
+                </td>
+                <td><code>jwt</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-flow">
+                <td><code>OAuth2SecurityScheme</code></td>
+                <td>
+                    <code>flow</code>
+                </td>
+                <td><code>implicit</code></td>
+            </tr>
+        </tbody>
+    </table>
     </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1649,21 +1649,21 @@ IANA HTTP content coding registry</a>.
                       <code>contentType</code>
                   </td>
                   <td><code>application/json</code></td>
-                  <td></td>
+                  <td><code>Forms</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-safe">
                   <td>
                       <code>safe</code>
                   </td>
                   <td><code>false</code></td>
-                  <td></td>
+                  <td><code>ActionAffordance</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-idempotent">
                   <td>
                       <code>idempotent</code>
                   </td>
                   <td><code>false</code></td>
-                  <td></td>
+                  <td><code>ActionAffordance</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-op-properties">
                   <td>

--- a/index.html
+++ b/index.html
@@ -1603,6 +1603,16 @@ well-known types necessary to implement the WoT interaction model described in
 operations types SHOULD NOT be arbitrarily set by servients
 </span>.
 </p>
+<p>
+In some use cases such as for an <code>ActionAffordance</code> there is a different expectations of content types for the <code>input</code> 
+and <code>output</code>. In such a case the <code>response</code> term from the <a href="#expectedresponse"></a> class can be enabled to decleare different content types for requests and 
+responses.
+<span class="rfc2119-assertion" id="td-expectedResponse-contentType">
+The term <code>response</code> MUST be mandatory in a TD document if the response content type differs 
+from the <code>Form</code> content type.
+</span>
+</p>
+
 
 <p>Possible values for the <code>contentCoding</code> property can be found e.g. in
 the <a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
@@ -1614,6 +1624,9 @@ IANA HTTP content coding registry</a>.
 <tr class="rfc2119-table-assertion" id="td-vocab-rel--Link"><td><code>rel</code></td><td>A link relation type identifies the semantics of a link.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link"><td><code>anchor</code></td><td>By default, the context, or anchor, of a link conveyed in the Link header field is the URL of the representation it is associated with, as defined in RFC7231, Section 3.1.4.1, and is serialized as a URI.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr></tbody></table></section>
 <section><h3><code>ExpectedResponse</code></h3><p>Communication metadata for response messages (e.g., contentType of the response).</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type [[IANA-MEDIA-TYPES]] (e.g., 'application/json) and (optional) parameters (e.g., 'charset=utf-8').</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+
+
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1640,13 +1640,11 @@ operations types SHOULD NOT be arbitrarily set by servients
 </span>.
 </p>
 <p>
-In some use cases such as for an <code>ActionAffordance</code> there is a different expectations of content types for the <code>input</code> 
-and <code>output</code>. In such a case the <code>response</code> term that is typed with the <a href="#expectedresponse"></a> class can be enabled to 
-decleare different content types for requests and 
-responses.
+In some use cases such as for an <code>ActionAffordance</code> there is a different expectation about the content type for the <code>input</code> 
+and <code>output</code>. In such a case, the optional <code>response</code> name-value pair can describe the content type of the expected response.
 <span class="rfc2119-assertion" id="td-expectedResponse-contentType">
-The term <code>response</code> MUST be mandatory in a TD document if the response content type differs 
-from the <code>Form</code> content type.
+If the content type of the expected response does not equal its <a>Default Value</a> and differs from the content type of the form,
+the <code>Form</code> instance MUST include a name-value pair with the name <code>response</code>.
 </span>
 </p>
 
@@ -1679,20 +1677,22 @@ IANA HTTP content coding registry</a>.
       
       <p>
           The following table gives all <a>Default Values</a> defined in the
-          <a>Classes</a> of the <a>TD Information Model</a>. 
+          <a>Context</a> of the <a>TD Information Model</a>. 
       </p>
 
       <table class="def">
         <thead>
             <tr>
-                <th><a>Class</a></th>
+                <th><a>Context</a></th>
                 <th><a>Vocabulary term</a></th>
                 <th>Default value</th>
             </tr>
         </thead>
         <tbody>
             <tr class="rfc2119-default-assertion" id="td-default-contentType">
-                <td><code>Forms</code></td>
+                <td><code>Form</code><br>
+                    <code>ExpectedResponse</code>
+                </td>
                 <td>
                     <code>contentType</code>
                 </td>

--- a/index.template.html
+++ b/index.template.html
@@ -1078,11 +1078,6 @@ a[href].internalDFN {
 
         {web-linking}
 
-<<<<<<< HEAD
-
-
-=======
->>>>>>> ba93c1c8c385328f8857d6cc419adb48265b50e8
       </section>
 
     </section>
@@ -1100,107 +1095,110 @@ a[href].internalDFN {
       
       <p>
           The following table gives all <a>Default Values</a> defined in the
-          <a>Classes</a> of the <a>TD Information Model</a>. An empty cell in the last column
-          must be interpreted as applying to all <a>Classes</a>.
+          <a>Classes</a> of the <a>TD Information Model</a>. 
       </p>
 
       <table class="def">
-          <thead>
-              <tr>
-                  <th><a>Class</a></th>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Default value</th>
-              </tr>
-          </thead>
-          <tbody>
-              <tr class="rfc2119-default-assertion" id="td-default-contentType">
-                  <td></td>
-                  <td>
-                      <code>contentType</code>
-                  </td>
-                  <td><code>application/json</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-safe">
-                  <td></td>
-                  <td>
-                      <code>safe</code>
-                  </td>
-                  <td><code>false</code></td>
-                      <code>idempotent</code>
-                  </td>
-                  <td><code>false</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-op-properties">
-                  <td><code>PropertyAffordance</code></td>
-                  <td>
-                      <code>op</code>
-                  </td>
-                  <td>Array of strings with values <code>readproperty</code> followed by 
-                      <code>writeproperty</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-op-actions">
-                  <td><code>ActionAffordance</code></td>
-                  <td>
-                      <code>op</code>
-                  </td>
-                  <td><code>invokeaction</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-op-events">
-                  <td><code>EventAffordance</code></td>
-                  <td>
-                      <code>op</code>
-                  </td>
-                  <td><code>subscribeevent</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-in-1">
-                  <td><code>BasicSecurityScheme</code></br>
-                    <code>DigestSecurityScheme</code></br>
-                    <code>BearerSecurityScheme</code></br>
-                    <code>PoPSecurityScheme</code></td>
-                  <td>
-                      <code>in</code>
-                  </td>
-                  <td><code>header</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-in-2">
-                  <td><code>APIKeySecurityScheme</code></td>
-                  <td>
-                      <code>in</code>
-                  </td>
-                  <td><code>query</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-qop">
-                  <td><code>DigestSecurityScheme</code></td>
-                  <td>
-                      <code>qop</code>
-                  </td>
-                  <td><code>auth</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-alg">
-                  <td><code>BearerSecurityScheme</code></br>
-                    <code>PoPSecurityScheme</code></td>
-                  <td>
-                      <code>alg</code>
-                  </td>
-                  <td><code>ES256</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-format">
-                  <td><code>BearerSecurityScheme</code></br>
-                    <code>PoPSecurityScheme</code></td>
-                  <td>
-                      <code>format</code>
-                  </td>
-                  <td><code>jwt</code></td>
-              </tr>
-              <tr class="rfc2119-default-assertion" id="td-default-flow">
-                  <td><code>OAuth2SecurityScheme</code></td>
-                  <td>
-                      <code>flow</code>
-                  </td>
-                  <td><code>implicit</code></td>
-              </tr>
-          </tbody>
-      </table>
+        <thead>
+            <tr>
+                <th><a>Class</a></th>
+                <th><a>Vocabulary term</a></th>
+                <th>Default value</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="rfc2119-default-assertion" id="td-default-contentType">
+                <td><code>Forms</code></td>
+                <td>
+                    <code>contentType</code>
+                </td>
+                <td><code>application/json</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-safe">
+                <td><code>ActionAffordance</code></td>
+                <td>
+                    <code>safe</code>
+                </td>
+                <td><code>false</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-idempotent">
+                <td><code>ActionAffordance</code></td>
+                <td>
+                    <code>idempotent</code>
+                </td>
+                <td><code>false</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-op-properties">
+                <td><code>PropertyAffordance</code></td>
+                <td>
+                    <code>op</code>
+                </td>
+                <td>Array of strings with values <code>readproperty</code> followed by 
+                    <code>writeproperty</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-op-actions">
+                <td><code>ActionAffordance</code></td>
+                <td>
+                    <code>op</code>
+                </td>
+                <td><code>invokeaction</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-op-events">
+                <td><code>EventAffordance</code></td>
+                <td>
+                    <code>op</code>
+                </td>
+                <td><code>subscribeevent</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-in-1">
+                <td><code>BasicSecurityScheme</code></br>
+                  <code>DigestSecurityScheme</code></br>
+                  <code>BearerSecurityScheme</code></br>
+                  <code>PoPSecurityScheme</code></td>
+                <td>
+                    <code>in</code>
+                </td>
+                <td><code>header</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-in-2">
+                <td><code>APIKeySecurityScheme</code></td>
+                <td>
+                    <code>in</code>
+                </td>
+                <td><code>query</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-qop">
+                <td><code>DigestSecurityScheme</code></td>
+                <td>
+                    <code>qop</code>
+                </td>
+                <td><code>auth</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-alg">
+                <td><code>BearerSecurityScheme</code></br>
+                  <code>PoPSecurityScheme</code></td>
+                <td>
+                    <code>alg</code>
+                </td>
+                <td><code>ES256</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-format">
+                <td><code>BearerSecurityScheme</code></br>
+                  <code>PoPSecurityScheme</code></td>
+                <td>
+                    <code>format</code>
+                </td>
+                <td><code>jwt</code></td>
+            </tr>
+            <tr class="rfc2119-default-assertion" id="td-default-flow">
+                <td><code>OAuth2SecurityScheme</code></td>
+                <td>
+                    <code>flow</code>
+                </td>
+                <td><code>implicit</code></td>
+            </tr>
+        </tbody>
+    </table>
     </section>
 
     </section>

--- a/index.template.html
+++ b/index.template.html
@@ -1095,20 +1095,22 @@ a[href].internalDFN {
       
       <p>
           The following table gives all <a>Default Values</a> defined in the
-          <a>Classes</a> of the <a>TD Information Model</a>. 
+          <a>Context</a> of the <a>TD Information Model</a>. 
       </p>
 
       <table class="def">
         <thead>
             <tr>
-                <th><a>Class</a></th>
+                <th><a>Context</a></th>
                 <th><a>Vocabulary term</a></th>
                 <th>Default value</th>
             </tr>
         </thead>
         <tbody>
             <tr class="rfc2119-default-assertion" id="td-default-contentType">
-                <td><code>Forms</code></td>
+                <td><code>Form</code><br>
+                    <code>ExpectedResponse</code>
+                </td>
                 <td>
                     <code>contentType</code>
                 </td>

--- a/index.template.html
+++ b/index.template.html
@@ -1076,21 +1076,21 @@ a[href].internalDFN {
                       <code>contentType</code>
                   </td>
                   <td><code>application/json</code></td>
-                  <td></td>
+                  <td><code>Forms</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-safe">
                   <td>
                       <code>safe</code>
                   </td>
                   <td><code>false</code></td>
-                  <td></td>
+                  <td><code>ActionAffordance</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-idempotent">
                   <td>
                       <code>idempotent</code>
                   </td>
                   <td><code>false</code></td>
-                  <td></td>
+                  <td><code>ActionAffordance</code></td>
               </tr>
               <tr class="rfc2119-default-assertion" id="td-default-op-properties">
                   <td>

--- a/index.template.html
+++ b/index.template.html
@@ -1041,6 +1041,9 @@ a[href].internalDFN {
      </p>
 
         {web-linking}
+
+
+
       </section>
 
     </section>

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -316,13 +316,11 @@ operations types SHOULD NOT be arbitrarily set by servients
 </span>.
 </p>
 <p>
-In some use cases such as for an <code>ActionAffordance</code> there is a different expectations of content types for the <code>input</code> 
-and <code>output</code>. In such a case the <code>response</code> term that is typed with the <a href="#expectedresponse"></a> class can be enabled to 
-decleare different content types for requests and 
-responses.
+In some use cases such as for an <code>ActionAffordance</code> there is a different expectation about the content type for the <code>input</code> 
+and <code>output</code>. In such a case, the optional <code>response</code> name-value pair can describe the content type of the expected response.
 <span class="rfc2119-assertion" id="td-expectedResponse-contentType">
-The term <code>response</code> MUST be mandatory in a TD document if the response content type differs 
-from the <code>Form</code> content type.
+If the content type of the expected response does not equal its <a>Default Value</a> and differs from the content type of the form,
+the <code>Form</code> instance MUST include a name-value pair with the name <code>response</code>.
 </span>
 </p>
 

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -315,6 +315,17 @@ well-known types necessary to implement the WoT interaction model described in
 operations types SHOULD NOT be arbitrarily set by servients
 </span>.
 </p>
+<p>
+In some use cases such as for an <code>ActionAffordance</code> there is a different expectations of content types for the <code>input</code> 
+and <code>output</code>. In such a case the <code>response</code> term that is typed with the <a href="#expectedresponse"></a> class can be enabled to 
+decleare different content types for requests and 
+responses.
+<span class="rfc2119-assertion" id="td-expectedResponse-contentType">
+The term <code>response</code> MUST be mandatory in a TD document if the response content type differs 
+from the <code>Form</code> content type.
+</span>
+</p>
+
 """^^rdf:HTML ;
     sh:description
 """


### PR DESCRIPTION
[The default value table](https://w3c.github.io/wot-thing-description/#sec-default-values) provides an empty cells for contentType, safe and idempotent. This PR assign the corresponding class + explains that the response term has to be used when the response content type differ from the form content type.