### PR TITLE
Update validation schema

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -1056,8 +1056,7 @@
         },
         "anyUri": {
             "type": "string",
-            "$comment": "Until iri-reference is supported by ajv, it will stay as uri-reference in playground",
-            "format": "uri-reference"
+            "format": "iri-reference"
         }
     },
     "type": "object",

--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -1,14 +1,22 @@
 {
     "title": "WoT TD Schema - 29 March 2019",
     "description": "JSON Schema for validating TD instances against the TD model. TD instances can be with or without terms that have default values",
-    "$schema ": "http://json-schema.org/draft-06/schema#",
+    "$schema ": "http://json-schema.org/draft-07/schema#",
     "definitions": {
+        "thing-context-w3c-uri": {
+            "type": "string",
+            "enum": [
+                "https://www.w3.org/2019/td/v1"
+            ]
+        },
         "thing-context": {
-            "oneOf": [{
+            "oneOf": [
+                {
                     "type": "array",
                     "items": {
-                        "anyOf": [{
-                                "$ref": "#/definitions/url"
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/anyUri"
                             },
                             {
                                 "type": "object"
@@ -16,18 +24,17 @@
                         ]
                     },
                     "contains": {
-                        "type": "string",
-                        "pattern": "^https?://(www\\.)?w3\\.org/2019/td/v1$"
+                        "$ref": "#/definitions/thing-context-w3c-uri"
                     }
                 },
                 {
-                    "type": "string",
-                    "pattern": "^https?://(www\\.)?w3\\.org/2019/td/v1$"
+                    "$ref": "#/definitions/thing-context-w3c-uri"
                 }
             ]
         },
         "type_declaration": {
-            "oneOf": [{
+            "oneOf": [
+                {
                     "type": "string"
                 },
                 {
@@ -109,7 +116,8 @@
                     ]
                 },
                 "items": {
-                    "oneOf": [{
+                    "oneOf": [
+                        {
                             "$ref": "#/definitions/dataSchema"
                         },
                         {
@@ -259,10 +267,11 @@
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/definitions/url"
+                    "$ref": "#/definitions/anyUri"
                 },
                 "op": {
-                    "oneOf": [{
+                    "oneOf": [
+                        {
                             "type": "string",
                             "enum": [
                                 "readproperty",
@@ -326,10 +335,11 @@
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/definitions/url"
+                    "$ref": "#/definitions/anyUri"
                 },
                 "op": {
-                    "oneOf": [{
+                    "oneOf": [
+                        {
                             "type": "string",
                             "enum": [
                                 "invokeaction"
@@ -387,10 +397,11 @@
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/definitions/url"
+                    "$ref": "#/definitions/anyUri"
                 },
                 "op": {
-                    "oneOf": [{
+                    "oneOf": [
+                        {
                             "type": "string",
                             "enum": [
                                 "subscribeevent",
@@ -450,10 +461,11 @@
             "type": "object",
             "properties": {
                 "href": {
-                    "$ref": "#/definitions/url"
+                    "$ref": "#/definitions/anyUri"
                 },
                 "op": {
-                    "oneOf": [{
+                    "oneOf": [
+                        {
                             "type": "string",
                             "enum": [
                                 "readallproperties",
@@ -580,7 +592,8 @@
                     ]
                 },
                 "items": {
-                    "oneOf": [{
+                    "oneOf": [
+                        {
                             "$ref": "#/definitions/dataSchema"
                         },
                         {
@@ -622,10 +635,10 @@
             "type": "object",
             "properties": {
                 "anchor": {
-                    "$ref": "#/definitions/url"
+                    "$ref": "#/definitions/anyUri"
                 },
                 "href": {
-                    "$ref": "#/definitions/url"
+                    "$ref": "#/definitions/anyUri"
                 },
                 "rel": {
                     "type": "string"
@@ -640,7 +653,8 @@
             "additionalProperties": true
         },
         "securityScheme": {
-            "oneOf": [{
+            "oneOf": [
+                {
                     "type": "object",
                     "properties": {
                         "@type": {
@@ -653,7 +667,7 @@
                             "$ref": "#/definitions/descriptions"
                         },
                         "proxy": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scheme": {
                             "type": "string",
@@ -679,7 +693,7 @@
                             "$ref": "#/definitions/descriptions"
                         },
                         "proxy": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scheme": {
                             "type": "string",
@@ -689,7 +703,12 @@
                         },
                         "in": {
                             "type": "string",
-                            "enum": ["header", "query", "body", "cookie"]
+                            "enum": [
+                                "header",
+                                "query",
+                                "body",
+                                "cookie"
+                            ]
                         },
                         "name": {
                             "type": "string"
@@ -712,7 +731,7 @@
                             "$ref": "#/definitions/descriptions"
                         },
                         "proxy": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scheme": {
                             "type": "string",
@@ -741,7 +760,7 @@
                             "$ref": "#/definitions/descriptions"
                         },
                         "proxy": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scheme": {
                             "type": "string",
@@ -751,11 +770,19 @@
                         },
                         "qop": {
                             "type": "string",
-                            "enum": ["auth", "auth-int"]
+                            "enum": [
+                                "auth",
+                                "auth-int"
+                            ]
                         },
                         "in": {
                             "type": "string",
-                            "enum": ["header", "query", "body", "cookie"]
+                            "enum": [
+                                "header",
+                                "query",
+                                "body",
+                                "cookie"
+                            ]
                         },
                         "name": {
                             "type": "string"
@@ -778,7 +805,7 @@
                             "$ref": "#/definitions/descriptions"
                         },
                         "proxy": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scheme": {
                             "type": "string",
@@ -787,19 +814,32 @@
                             ]
                         },
                         "authorization": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "alg": {
                             "type": "string",
-                            "enum": ["MD5", "ES256", "ES512-256"]
+                            "enum": [
+                                "MD5",
+                                "ES256",
+                                "ES512-256"
+                            ]
                         },
                         "format": {
                             "type": "string",
-                            "enum": ["jwt", "jwe", "jws"]
+                            "enum": [
+                                "jwt",
+                                "jwe",
+                                "jws"
+                            ]
                         },
                         "in": {
                             "type": "string",
-                            "enum": ["header", "query", "body", "cookie"]
+                            "enum": [
+                                "header",
+                                "query",
+                                "body",
+                                "cookie"
+                            ]
                         },
                         "name": {
                             "type": "string"
@@ -822,7 +862,7 @@
                             "$ref": "#/definitions/descriptions"
                         },
                         "proxy": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scheme": {
                             "type": "string",
@@ -851,7 +891,7 @@
                             "$ref": "#/definitions/descriptions"
                         },
                         "proxy": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scheme": {
                             "type": "string",
@@ -880,7 +920,7 @@
                             "$ref": "#/definitions/descriptions"
                         },
                         "proxy": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scheme": {
                             "type": "string",
@@ -889,13 +929,13 @@
                             ]
                         },
                         "authorization": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "token": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "refresh": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scopes": {
                             "type": "array",
@@ -905,7 +945,12 @@
                         },
                         "flow": {
                             "type": "string",
-                            "enum": ["implicit", "password", "client", "code"]
+                            "enum": [
+                                "implicit",
+                                "password",
+                                "client",
+                                "code"
+                            ]
                         }
                     },
                     "required": [
@@ -925,7 +970,7 @@
                             "$ref": "#/definitions/descriptions"
                         },
                         "proxy": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scheme": {
                             "type": "string",
@@ -935,7 +980,12 @@
                         },
                         "in": {
                             "type": "string",
-                            "enum": ["header", "query", "body", "cookie"]
+                            "enum": [
+                                "header",
+                                "query",
+                                "body",
+                                "cookie"
+                            ]
                         },
                         "name": {
                             "type": "string"
@@ -958,7 +1008,7 @@
                             "$ref": "#/definitions/descriptions"
                         },
                         "proxy": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "scheme": {
                             "type": "string",
@@ -967,19 +1017,32 @@
                             ]
                         },
                         "authorization": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/definitions/anyUri"
                         },
                         "format": {
                             "type": "string",
-                            "enum": ["jwt", "jwe", "jws"]
+                            "enum": [
+                                "jwt",
+                                "jwe",
+                                "jws"
+                            ]
                         },
                         "alg": {
                             "type": "string",
-                            "enum": ["MD5", "ES256", "ES512-256"]
+                            "enum": [
+                                "MD5",
+                                "ES256",
+                                "ES512-256"
+                            ]
                         },
                         "in": {
                             "type": "string",
-                            "enum": ["header", "query", "body", "cookie"]
+                            "enum": [
+                                "header",
+                                "query",
+                                "body",
+                                "cookie"
+                            ]
                         },
                         "name": {
                             "type": "string"
@@ -991,8 +1054,9 @@
                 }
             ]
         },
-        "url": {
+        "anyUri": {
             "type": "string",
+            "$comment": "Until iri-reference is supported by ajv, it will stay as uri-reference in playground",
             "format": "uri-reference"
         }
     },
@@ -1054,7 +1118,7 @@
             }
         },
         "base": {
-            "$ref": "#/definitions/url"
+            "$ref": "#/definitions/anyUri"
         },
         "securityDefinitions": {
             "type": "object",


### PR DESCRIPTION
* I have constrained the schema to accept only the `@context` (or namespace) of the discussion in #628 
* We now use iri instead of uri (this was a bug noticed by @jmcanterafonseca )
* I have used the proposal in the PR #603 by @jmcanterafonseca to reference the context url instead of repeating it