### PR TITLE
Annotate at-risk features with searchable text

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <script class='remove'>
           var respecConfig = {
               specStatus:     "CR"
-            , crEnd: "2019-06-18"
+            , crEnd: "2019-06-13"
             , previousMaturity: "WD"
             , previousPublishDate: "2018-10-21"
             , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report.html"
@@ -420,10 +420,10 @@ a[href].internalDFN {
   The Working Group seeks implementation feedback, having set the
   requirement of at least two implementations of each feature as the
   exit criteria for the Candidate Recommendation phase. 
-  <font color="red">The group aims
-  to obtain reports from one producer and one consumer for each
-  feature if possible.</font> 
-  For details, see the draft 
+  The group aims
+  to obtain reports from one TD producer and one TD consumer for each
+  feature if applicable.
+  For details, including definitions of implementation, TD producer, and TD consumer, see the draft 
   <a href="https://w3c.github.io/wot-thing-description/testing/report.html">implementation
   report</a>.
   </p>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
     <script class='remove'>
           var respecConfig = {
               specStatus:     "CR"
+            , crEnd: "2019-06-19"
+            , previousMaturity: "WD"
+            , previousPublishDate: "2018-10-21"
+            , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report.html"
             , processVersion: 2017
             , shortName:      "wot-thing-description"
             , copyrightStart: 2017
@@ -415,9 +419,11 @@ a[href].internalDFN {
   <p>
   The Working Group seeks implementation feedback, having set the
   requirement of at least two implementations of each feature as the
-  exit criteria for the Candidate Recommendation phase. <font color="red">The group aims
+  exit criteria for the Candidate Recommendation phase. 
+  <font color="red">The group aims
   to obtain reports from one producer and one consumer for each
-  feature if possible.</font> For details, see the draft 
+  feature if possible.</font> 
+  For details, see the draft 
   <a href="https://w3c.github.io/wot-thing-description/testing/report.html">implementation
   report</a>.
   </p>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <script class='remove'>
           var respecConfig = {
               specStatus:     "CR"
-            , crEnd: "2019-06-19"
+            , crEnd: "2019-06-18"
             , previousMaturity: "WD"
             , previousPublishDate: "2018-10-21"
             , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report.html"

--- a/index.html
+++ b/index.html
@@ -390,29 +390,34 @@ a[href].internalDFN {
   insufficient implementation experience (reports).
   </p>
   <ul>
-  <li>Whole features described in <a href="#apikeysecurityscheme"></a>, <a href="#certsecurityscheme"></a>, 
+  <li>Whole sections related to the security schemes described in <a href="#apikeysecurityscheme"></a>, <a href="#certsecurityscheme"></a>, 
       <a href="#psksecurityscheme"></a>, <a href="#publicsecurityscheme"></a>, <a href="#popsecurityscheme"></a> 
       and <a href="#oauth2securityscheme"></a>.
   </li>
   <li>Vocabulary terms <code>proxy</code> in <a href="#securityscheme"></a>, 
       <code>qop</code> in <a href="#digestsecurityscheme"></a>
-      and <code>scopes</code> term in <a href="#form"></a>, 
+      and <code>scopes</code> term in <a href="#form"></a>. 
   </li>
+  <li>All default values related to the above in <a href="#sec-default-values"></a>.</li>
   </ul>
   <p>
-  <span class="at-risk">Text and table entries highlighted with a yellow background
-  indicates an assertion associated with an at-risk feature for which
+  <span class="at-risk">Text or table entries highlighted with a yellow background
+  indicate an at-risk feature for which
   insufficient implementation experience currently exists.</span>
-  When an entire section is at-risk the words
-  "<span class="at-risk">This section is at risk.</span>"
+  In each such case the annotation
+  "This feature is at risk" is attached.
+  When an entire section is at risk the annotation
+  "<span class="at-risk">This section is at risk</span>"
   will be placed at the start of the section and highlighted with a yellow background.</span>
+  When an entire section is at risk individual items within that section
+  are not highlighted or annotated.
   </p>
   <p>
   The Working Group seeks implementation feedback, having set the
   requirement of at least two implementations of each feature as the
   exit criteria for the Candidate Recommendation phase. <font color="red">The group aims
   to obtain reports from one producer and one consumer for each
-  feature if possible.</font>. For details, see draft 
+  feature if possible.</font> For details, see the draft 
   <a href="https://w3c.github.io/wot-thing-description/testing/report.html">implementation
   report</a>.
   </p>
@@ -1337,7 +1342,7 @@ such a validation SHOULD succeed.
         <section><h3><code>SecurityScheme</code></h3><p>Metadata describing the configuration of a security mechanism.  <span class="rfc2119-assertion" id="td-security-scheme-name">The value assigned to the name <code>scheme</code> MUST be defined within a <a>Vocabulary</a> included in the <a>Thing Description</a>, either in the standard <a>Vocabulary</a> defined in <a href="#sec-vocabulary-definition"></a> or in a <a>TD Context Extension</a>.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme"><td><code>scheme</code></td><td>Identification of the security mechanism being configured.</td><td>mandatory</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g. <code>nosec</code>, <code>basic</code>, <code>cert</code>, <code>digest</code>, <code>bearer</code>, <code>pop</code>, <code>psk</code>, <code>public</code>, <code>oauth2</code>, or <code>apikey</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable) information based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable) information in different languages.</td><td>optional</td><td><a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme"><td><code>proxy</code></td><td>URI of the proxy server this security configuration provides access to.  If not given, the corresponding security configuration is for the endpoint.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr></tbody></table><p>The class <code>SecurityScheme</code> has the following subclasses:</p><ul><li><a href="#publicsecurityscheme"><code>PublicSecurityScheme</code></a></li>
+<tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme"><td><code>proxy</code></td><td>URI of the proxy server this security configuration provides access to.  If not given, the corresponding security configuration is for the endpoint.  <br/>This feature is at risk.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr></tbody></table><p>The class <code>SecurityScheme</code> has the following subclasses:</p><ul><li><a href="#publicsecurityscheme"><code>PublicSecurityScheme</code></a></li>
 <li><a href="#popsecurityscheme"><code>PoPSecurityScheme</code></a></li>
 <li><a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a></li>
 <li><a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a></li>
@@ -1351,7 +1356,7 @@ such a validation SHOULD succeed.
 <section><h3><code>NoSecurityScheme</code></h3><p>A security configuration corresponding to identified by the <a>Vocabulary Term</a> <code>nosec</code> (i.e., <code>"scheme": "nosec"</code>), indicating there is no authentication or other mechanism required to access the resource.</p></section>
 <section><h3><code>BasicSecurityScheme</code></h3><p>Basic authentication security configuration identified by the <a>Vocabulary Term</a> <code>basic</code> (i.e., <code>"scheme": "basic"</code>), using an unencrypted username and password.  This scheme should be used with some other security mechanism providing confidentiality, for example, TLS.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme"><td><code>in</code></td><td>Specifies the location of security authentication information.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, or <code>cookie</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme"><td><code>name</code></td><td>Name for query, header, or cookie parameters.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>DigestSecurityScheme</code></h3><p>Digest authentication security configuration identified by the <a>Vocabulary Term</a> <code>digest</code> (i.e., <code>"scheme": "digest"</code>). This scheme is similar to basic authentication but with added features to avoid man-in-the-middle attacks.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme"><td><code>qop</code></td><td>Quality of protection.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>auth</code>, or <code>auth-int</code>)</td></tr>
+<section><h3><code>DigestSecurityScheme</code></h3><p>Digest authentication security configuration identified by the <a>Vocabulary Term</a> <code>digest</code> (i.e., <code>"scheme": "digest"</code>). This scheme is similar to basic authentication but with added features to avoid man-in-the-middle attacks.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme"><td><code>qop</code></td><td>Quality of protection.  <br/>This feature is at risk.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>auth</code>, or <code>auth-int</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme"><td><code>in</code></td><td>Specifies the location of security authentication information.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, or <code>cookie</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme"><td><code>name</code></td><td>Name for query, header, or cookie parameters.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
 <section><h3><code>APIKeySecurityScheme</code></h3><p><span class="at-risk">This section is at risk.</span></p><p>API key authentication security configuration identified by the <a>Vocabulary Term</a> <code>apikey</code> (i.e., <code>"scheme": "apikey"</code>).  This is for the case where the access token is opaque and is not using a standard token format.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme"><td><code>in</code></td><td>Specifies the location of security authentication information.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, or <code>cookie</code>)</td></tr>
@@ -1372,7 +1377,7 @@ such a validation SHOULD succeed.
 <section><h3><code>OAuth2SecurityScheme</code></h3><p><span class="at-risk">This section is at risk.</span></p><p>OAuth2 authentication security configuration for systems conformant with [[!RFC6749]] and [[!RFC8252]], identified by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e., <code>"scheme": "oauth2"</code>).  <span class="rfc2119-assertion" id="td-security-oauth2-implicit-flow">For the <code>implicit</code> flow <code>authorization</code> MUST be included.</span>  <span class="rfc2119-assertion" id="td-security-oauth2-password-client-flow">For the <code>password</code> and <code>client</code> flows <code>token</code> MUST be included.</span>  <span class="rfc2119-assertion" id="td-security-oauth2-code-flow">For the <code>code</code> flow both <code>authorization</code> and <code>token</code> MUST be included.</span>  If no <code>scopes</code> are defined in the <code>SecurityScheme</code> then they are considered to be empty.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme"><td><code>token</code></td><td>URI of the token server.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme"><td><code>refresh</code></td><td>URI of the refresh server.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an <code>OAuth2SecurityScheme</code> active on that form.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an <code>OAuth2SecurityScheme</code> active on that form.  <br/>This feature is at risk.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme"><td><code>flow</code></td><td>Authorization flow.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>implicit</code>, <code>password</code>, <code>client</code>, or <code>code</code>)</td></tr></tbody></table></section>
 
       </section>
@@ -1406,7 +1411,7 @@ op can be assigned one or more interaction verb(s) each representing a semantic 
      
 For example, for HTTP and Events, it indicates which of several available mechanisms should be used for asynchronous notifications such as long polling, websub (also see https://www.w3.org/TR/websub/), or server sent events (also see https://www.w3.org/TR/eventsource/). Please note that there is no restriction on the sub-protocol selection and other mechanisms can also be announced by this subprotocol term.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g. <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-security--Form"><td><code>security</code></td><td>Set of security definition names, chosen from those defined in securityDefinitions.  These must all be satisfied for access to resources.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an <code>OAuth2SecurityScheme</code> active on that form.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an <code>OAuth2SecurityScheme</code> active on that form.  <br/>This feature is at risk.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-response--Form"><td><code>response</code></td><td>This optional term can be used if, e.g., the output communication metadata differ from input metdata (e.g., output contentType differ from the
      input contentType). The response name contains metadata that is only valid for the reponse messages.</td><td>optional</td><td><a href="#expectedresponse"><code>ExpectedResponse</code></a></td></tr></tbody></table>
 <p>The list of possible operation types of a form is fixed. As of this version of the specification, it only includes the
@@ -1581,6 +1586,7 @@ IANA HTTP content coding registry</a>.
             <tr class="rfc2119-default-assertion" id="td-default-in-pop">
                 <td>
                   <code>PoPSecurityScheme</code>
+                  <br/>This feature is at risk.
                 </td>
                 <td>
                     <code>in</code>
@@ -1589,7 +1595,10 @@ IANA HTTP content coding registry</a>.
                 <td></td>
             </tr>
             <tr class="rfc2119-default-assertion" id="td-default-in-apikey">
-                <td><code>APIKeySecurityScheme</code></td>
+                <td>
+                  <code>APIKeySecurityScheme</code>
+                  <br/>This feature is at risk.
+                </td>
                 <td>
                     <code>in</code>
                 </td>
@@ -1597,7 +1606,10 @@ IANA HTTP content coding registry</a>.
                 <td></td>
             </tr>
             <tr class="rfc2119-default-assertion" id="td-default-qop">
-                <td><code>DigestSecurityScheme</code></td>
+                <td>
+                  <code>DigestSecurityScheme</code>
+                  <br/>This feature is at risk.
+                </td>
                 <td>
                     <code>qop</code>
                 </td>
@@ -1606,7 +1618,7 @@ IANA HTTP content coding registry</a>.
             </tr>
             <tr class="rfc2119-default-assertion" id="td-default-alg">
                 <td>
-                  <code>BearerSecurityScheme</code></br>
+                  <code>BearerSecurityScheme</code>
                 </td>
                 <td>
                     <code>alg</code>
@@ -1617,6 +1629,7 @@ IANA HTTP content coding registry</a>.
             <tr class="rfc2119-default-assertion" id="td-default-alg-pop">
                 <td>
                   <code>PoPSecurityScheme</code>
+                  <br/>This feature is at risk.
                 </td>
                 <td>
                     <code>alg</code>
@@ -1626,7 +1639,7 @@ IANA HTTP content coding registry</a>.
             </tr>
             <tr class="rfc2119-default-assertion" id="td-default-format">
                 <td>
-                  <code>BearerSecurityScheme</code></br>
+                  <code>BearerSecurityScheme</code>
                 </td>
                 <td>
                     <code>format</code>
@@ -1637,6 +1650,7 @@ IANA HTTP content coding registry</a>.
             <tr class="rfc2119-default-assertion" id="td-default-format-pop">
                 <td>
                   <code>PoPSecurityScheme</code>
+                  <br/>This feature is at risk.
                 </td>
                 <td>
                     <code>format</code>
@@ -1645,7 +1659,10 @@ IANA HTTP content coding registry</a>.
                 <td></td>
             </tr>
             <tr class="rfc2119-default-assertion" id="td-default-flow">
-                <td><code>OAuth2SecurityScheme</code></td>
+                <td>
+                    <code>OAuth2SecurityScheme</code>
+                    <br/>This feature is at risk.
+                </td>
                 <td>
                     <code>flow</code>
                 </td>

--- a/index.template.html
+++ b/index.template.html
@@ -7,6 +7,10 @@
     <script class='remove'>
           var respecConfig = {
               specStatus:     "CR"
+            , crEnd: "2019-06-19"
+            , previousMaturity: "WD"
+            , previousPublishDate: "2018-10-21"
+            , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report.html"
             , processVersion: 2017
             , shortName:      "wot-thing-description"
             , copyrightStart: 2017
@@ -388,9 +392,11 @@ a[href].internalDFN {
   <p>
   The Working Group seeks implementation feedback, having set the
   requirement of at least two implementations of each feature as the
-  exit criteria for the Candidate Recommendation phase. <font color="red">The group aims
+  exit criteria for the Candidate Recommendation phase. 
+  <font color="red">The group aims
   to obtain reports from one producer and one consumer for each
-  feature if possible.</font> For details, see the draft 
+  feature if possible.</font> 
+  For details, see the draft 
   <a href="https://w3c.github.io/wot-thing-description/testing/report.html">implementation
   report</a>.
   </p>

--- a/index.template.html
+++ b/index.template.html
@@ -363,29 +363,34 @@ a[href].internalDFN {
   insufficient implementation experience (reports).
   </p>
   <ul>
-  <li>Whole features described in <a href="#apikeysecurityscheme"></a>, <a href="#certsecurityscheme"></a>, 
+  <li>Whole sections related to the security schemes described in <a href="#apikeysecurityscheme"></a>, <a href="#certsecurityscheme"></a>, 
       <a href="#psksecurityscheme"></a>, <a href="#publicsecurityscheme"></a>, <a href="#popsecurityscheme"></a> 
       and <a href="#oauth2securityscheme"></a>.
   </li>
   <li>Vocabulary terms <code>proxy</code> in <a href="#securityscheme"></a>, 
       <code>qop</code> in <a href="#digestsecurityscheme"></a>
-      and <code>scopes</code> term in <a href="#form"></a>, 
+      and <code>scopes</code> term in <a href="#form"></a>. 
   </li>
+  <li>All default values related to the above in <a href="#sec-default-values"></a>.</li>
   </ul>
   <p>
-  <span class="at-risk">Text and table entries highlighted with a yellow background
-  indicates an assertion associated with an at-risk feature for which
+  <span class="at-risk">Text or table entries highlighted with a yellow background
+  indicate an at-risk feature for which
   insufficient implementation experience currently exists.</span>
-  When an entire section is at-risk the words
-  "<span class="at-risk">This section is at risk.</span>"
+  In each such case the annotation
+  "This feature is at risk" is attached.
+  When an entire section is at risk the annotation
+  "<span class="at-risk">This section is at risk</span>"
   will be placed at the start of the section and highlighted with a yellow background.</span>
+  When an entire section is at risk individual items within that section
+  are not highlighted or annotated.
   </p>
   <p>
   The Working Group seeks implementation feedback, having set the
   requirement of at least two implementations of each feature as the
   exit criteria for the Candidate Recommendation phase. <font color="red">The group aims
   to obtain reports from one producer and one consumer for each
-  feature if possible.</font>. For details, see draft 
+  feature if possible.</font> For details, see the draft 
   <a href="https://w3c.github.io/wot-thing-description/testing/report.html">implementation
   report</a>.
   </p>
@@ -1235,6 +1240,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             <tr class="rfc2119-default-assertion" id="td-default-in-pop">
                 <td>
                   <code>PoPSecurityScheme</code>
+                  <br/>This feature is at risk.
                 </td>
                 <td>
                     <code>in</code>
@@ -1243,7 +1249,10 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                 <td></td>
             </tr>
             <tr class="rfc2119-default-assertion" id="td-default-in-apikey">
-                <td><code>APIKeySecurityScheme</code></td>
+                <td>
+                  <code>APIKeySecurityScheme</code>
+                  <br/>This feature is at risk.
+                </td>
                 <td>
                     <code>in</code>
                 </td>
@@ -1251,7 +1260,10 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                 <td></td>
             </tr>
             <tr class="rfc2119-default-assertion" id="td-default-qop">
-                <td><code>DigestSecurityScheme</code></td>
+                <td>
+                  <code>DigestSecurityScheme</code>
+                  <br/>This feature is at risk.
+                </td>
                 <td>
                     <code>qop</code>
                 </td>
@@ -1260,7 +1272,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             </tr>
             <tr class="rfc2119-default-assertion" id="td-default-alg">
                 <td>
-                  <code>BearerSecurityScheme</code></br>
+                  <code>BearerSecurityScheme</code>
                 </td>
                 <td>
                     <code>alg</code>
@@ -1271,6 +1283,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             <tr class="rfc2119-default-assertion" id="td-default-alg-pop">
                 <td>
                   <code>PoPSecurityScheme</code>
+                  <br/>This feature is at risk.
                 </td>
                 <td>
                     <code>alg</code>
@@ -1280,7 +1293,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             </tr>
             <tr class="rfc2119-default-assertion" id="td-default-format">
                 <td>
-                  <code>BearerSecurityScheme</code></br>
+                  <code>BearerSecurityScheme</code>
                 </td>
                 <td>
                     <code>format</code>
@@ -1291,6 +1304,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             <tr class="rfc2119-default-assertion" id="td-default-format-pop">
                 <td>
                   <code>PoPSecurityScheme</code>
+                  <br/>This feature is at risk.
                 </td>
                 <td>
                     <code>format</code>
@@ -1299,7 +1313,10 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                 <td></td>
             </tr>
             <tr class="rfc2119-default-assertion" id="td-default-flow">
-                <td><code>OAuth2SecurityScheme</code></td>
+                <td>
+                    <code>OAuth2SecurityScheme</code>
+                    <br/>This feature is at risk.
+                </td>
                 <td>
                     <code>flow</code>
                 </td>

--- a/index.template.html
+++ b/index.template.html
@@ -7,7 +7,7 @@
     <script class='remove'>
           var respecConfig = {
               specStatus:     "CR"
-            , crEnd: "2019-06-19"
+            , crEnd: "2019-06-18"
             , previousMaturity: "WD"
             , previousPublishDate: "2018-10-21"
             , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report.html"

--- a/index.template.html
+++ b/index.template.html
@@ -7,7 +7,7 @@
     <script class='remove'>
           var respecConfig = {
               specStatus:     "CR"
-            , crEnd: "2019-06-18"
+            , crEnd: "2019-06-13"
             , previousMaturity: "WD"
             , previousPublishDate: "2018-10-21"
             , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report.html"
@@ -393,10 +393,10 @@ a[href].internalDFN {
   The Working Group seeks implementation feedback, having set the
   requirement of at least two implementations of each feature as the
   exit criteria for the Candidate Recommendation phase. 
-  <font color="red">The group aims
-  to obtain reports from one producer and one consumer for each
-  feature if possible.</font> 
-  For details, see the draft 
+  The group aims
+  to obtain reports from one TD producer and one TD consumer for each
+  feature if applicable.
+  For details, including definitions of implementation, TD producer, and TD consumer, see the draft 
   <a href="https://w3c.github.io/wot-thing-description/testing/report.html">implementation
   report</a>.
   </p>

--- a/ontology/wot-security.ttl
+++ b/ontology/wot-security.ttl
@@ -114,7 +114,7 @@
                                              
                                              rdfs:label "proxy" ;
                                              
-                                             rdfs:comment "URI of the proxy server this security configuration provides access to.  If not given, the corresponding security configuration is for the endpoint."@en .
+                                             rdfs:comment "URI of the proxy server this security configuration provides access to.  If not given, the corresponding security configuration is for the endpoint.  <br/>This feature is at risk."@en .
 
 
 
@@ -124,7 +124,7 @@
                                         
                                         rdfs:label "qop" ;
                                         
-                                        rdfs:comment "Quality of protection." .
+                                        rdfs:comment "Quality of protection.  <br/>This feature is at risk." .
 
 
 
@@ -154,7 +154,7 @@
                                            
                                            rdfs:label "scopes" ;
                                            
-                                           rdfs:comment "Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an <code>OAuth2SecurityScheme</code> active on that form."@en .
+                                           rdfs:comment "Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an <code>OAuth2SecurityScheme</code> active on that form.  <br/>This feature is at risk."@en .
 
 
 ###  https://www.w3.org/2019/wot/security#token

--- a/testing/report.html
+++ b/testing/report.html
@@ -1519,12 +1519,13 @@ MUST be serialized as a JSON array.
 	<td class="missing">0</td>
 	<td class="missing">0</td>
 	<td class="missing">0</td></tr>
-<tr id="td-context-default-language-direction-default" class="baseassertion">
-	<td class="baseassertion"><a target="spec" href="#td-context-default-language-direction-default">td-context-default-language-direction-default</a></td>
+<tr id="td-context-default-language-direction-heuristic" class="baseassertion">
+	<td class="baseassertion"><a target="spec" href="#td-context-default-language-direction-heuristic">td-context-default-language-direction-heuristic</a></td>
 	<td class="baseassertion"></td>
 	<td class="baseassertion">
             If no language tag is given,
-            the base direction SHOULD be assumed to be LTR (left-to-right).
+            the base direction SHOULD be inferred through 
+            first-strong heuristics or detection algorithms such as the CLDR Likely Subtags [[?LDML]].
         </td>
 	<td class="baseassertion">N</td>
 	<td class="baseassertion"></td>
@@ -1537,8 +1538,8 @@ MUST be serialized as a JSON array.
 	<td class="baseassertion"><a target="spec" href="#td-context-default-language-direction-independence">td-context-default-language-direction-independence</a></td>
 	<td class="baseassertion"></td>
 	<td class="baseassertion">
-      Each human-readable string value MUST be processed independently, using the base
-      direction defined for that string.
+      However, when interpreting human-readable text,
+      each human-readable string value MUST be processed independently.
     </td>
 	<td class="baseassertion">Y</td>
 	<td class="baseassertion"></td>
@@ -1552,9 +1553,9 @@ MUST be serialized as a JSON array.
 	<td class="baseassertion"></td>
 	<td class="baseassertion">
         Outside of MultiLanguage Maps,
-        the base direction MUST be inferred from the language tag of the default language.
+        the base direction MAY be inferred from the language tag of the default language.
     </td>
-	<td class="baseassertion">Y</td>
+	<td class="baseassertion">N</td>
 	<td class="baseassertion"></td>
 	<td class="baseassertion"></td>
 	<td class="missing">0</td>
@@ -1582,9 +1583,9 @@ MUST be serialized as a JSON array.
 	<td class="baseassertion">
         Inside of MultiLanguage Maps,
         the base direction of each value of the name-value pairs 
-        MUST be inferred from the language tag given in the corresponding name.
+        MAY be inferred from the language tag given in the corresponding name.
     </td>
-	<td class="baseassertion">Y</td>
+	<td class="baseassertion">N</td>
 	<td class="baseassertion"></td>
 	<td class="baseassertion"></td>
 	<td class="missing">0</td>
@@ -2241,20 +2242,32 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="extraassertion">0</td>
 	<td class="extraassertion">5</td>
 	<td class="extraassertion">14</td></tr>
+<tr id="td-datetime-recommended-type" class="baseassertion">
+	<td class="baseassertion"><a target="spec" href="#td-datetime-recommended-type">td-datetime-recommended-type</a></td>
+	<td class="baseassertion"></td>
+	<td class="baseassertion">
+        Values that are of type dateTime
+        SHOULD use the literal Z 
+        representing the UTC time zone instead 
+        of an offset.
+    </td>
+	<td class="baseassertion">N</td>
+	<td class="baseassertion"></td>
+	<td class="baseassertion"></td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td></tr>
 <tr id="td-datetime-type" class="baseassertion">
 	<td class="baseassertion"><a target="spec" href="#td-datetime-type">td-datetime-type</a></td>
 	<td class="baseassertion">Syntax</td>
 
 	<td class="baseassertion">
         Values that are of type dateTime
-        SHOULD be serialized as JSON strings and have the lexical
-        form YYYY-MM-DDThh:mm:ssZ,
-        where YYYY, MM and DD
-        respectively encode a year, a month and a day (i.e. a date) and where
-        hh, mm and ss
-        respectively encode hours, minutes and seconds (i.e. a time).
-  </td>
-	<td class="baseassertion">N</td>
+        MUST be serialized as JSON strings  following the &quot;date-time&quot; format
+        specified by [[RFC3339]].
+    </td>
+	<td class="baseassertion">Y</td>
 	<td class="baseassertion"></td>
 	<td class="baseassertion"></td>
 	<td class="missing">0</td>
@@ -2265,8 +2278,9 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="defassertion"><a target="spec" href="#td-default-alg">td-default-alg</a></td>
 	<td class="defassertion">Default</td>
 
-	<td class="defassertion">The value associated with member &quot;BearerSecurityScheme
-                  PoPSecurityScheme&quot; if not given MUST be assumed to have the default value &quot;
+	<td class="defassertion">The value associated with member &quot;
+                  BearerSecurityScheme
+                &quot; if not given MUST be assumed to have the default value &quot;
                     alg
                 &quot;.</td>
 	<td class="defassertion">Y</td>
@@ -2280,6 +2294,26 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="defassertion">0</td>
 	<td class="defassertion">5</td>
 	<td class="defassertion">6</td></tr>
+<tr id="td-default-alg-pop" class="defassertion">
+	<td class="defassertion"><a target="spec" href="#td-default-alg-pop">td-default-alg-pop</a></td>
+	<td class="defassertion"></td>
+	<td class="atrisk">The value associated with member &quot;
+                  PoPSecurityScheme
+                  This feature is at risk.
+                &quot; if not given MUST be assumed to have the default value &quot;
+                    alg
+                &quot;.</td>
+	<td class="defassertion">Y</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#td-serialization-default-values">td-serialization-default-values</a><br>
+	</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#ES256">ES256</a><br>
+	</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td></tr>
 <tr id="td-default-contentType" class="defassertion">
 	<td class="defassertion"><a target="spec" href="#td-default-contentType">td-default-contentType</a></td>
 	<td class="defassertion">Default</td>
@@ -2303,7 +2337,10 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="defassertion"><a target="spec" href="#td-default-flow">td-default-flow</a></td>
 	<td class="defassertion">Default</td>
 
-	<td class="atrisk">The value associated with member &quot;OAuth2SecurityScheme&quot; if not given MUST be assumed to have the default value &quot;
+	<td class="atrisk">The value associated with member &quot;
+                    OAuth2SecurityScheme
+                    This feature is at risk.
+                &quot; if not given MUST be assumed to have the default value &quot;
                     flow
                 &quot;.</td>
 	<td class="defassertion">Y</td>
@@ -2321,8 +2358,9 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="defassertion"><a target="spec" href="#td-default-format">td-default-format</a></td>
 	<td class="defassertion">Default</td>
 
-	<td class="defassertion">The value associated with member &quot;BearerSecurityScheme
-                  PoPSecurityScheme&quot; if not given MUST be assumed to have the default value &quot;
+	<td class="defassertion">The value associated with member &quot;
+                  BearerSecurityScheme
+                &quot; if not given MUST be assumed to have the default value &quot;
                     format
                 &quot;.</td>
 	<td class="defassertion">Y</td>
@@ -2336,6 +2374,26 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="defassertion">0</td>
 	<td class="defassertion">4</td>
 	<td class="defassertion">6</td></tr>
+<tr id="td-default-format-pop" class="defassertion">
+	<td class="defassertion"><a target="spec" href="#td-default-format-pop">td-default-format-pop</a></td>
+	<td class="defassertion"></td>
+	<td class="atrisk">The value associated with member &quot;
+                  PoPSecurityScheme
+                  This feature is at risk.
+                &quot; if not given MUST be assumed to have the default value &quot;
+                    format
+                &quot;.</td>
+	<td class="defassertion">Y</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#td-serialization-default-values">td-serialization-default-values</a><br>
+	</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#jwt">jwt</a><br>
+	</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td></tr>
 <tr id="td-default-http-method" class="baseassertion">
 	<td class="baseassertion"><a target="spec" href="#td-default-http-method">td-default-http-method</a></td>
 	<td class="baseassertion"></td>
@@ -2417,50 +2475,39 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="missing">0</td>
 	<td class="missing">0</td>
 	<td class="missing">0</td></tr>
-<tr id="td-default-idempotent" class="defassertion">
-	<td class="defassertion"><a target="spec" href="#td-default-idempotent">td-default-idempotent</a></td>
-	<td class="defassertion">Default</td>
-
+<tr id="td-default-idempotent-1" class="defassertion">
+	<td class="defassertion"><a target="spec" href="#td-default-idempotent-1">td-default-idempotent-1</a></td>
+	<td class="defassertion"></td>
+	<td class="defassertion">The value associated with member &quot;DataSchema&quot; if not given MUST be assumed to have the default value &quot;
+                    writeOnly
+                &quot;.</td>
+	<td class="defassertion">Y</td>
+	<td class="defassertion"></td>
+	<td class="defassertion"></td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td></tr>
+<tr id="td-default-idempotent-2" class="defassertion">
+	<td class="defassertion"><a target="spec" href="#td-default-idempotent-2">td-default-idempotent-2</a></td>
+	<td class="defassertion"></td>
 	<td class="defassertion">The value associated with member &quot;ActionAffordance&quot; if not given MUST be assumed to have the default value &quot;
                     idempotent
                 &quot;.</td>
 	<td class="defassertion">Y</td>
-	<td class="defassertion">
-		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#td-serializiation-default-values">td-serializiation-default-values</a><br>
-	</td>
-	<td class="defassertion">
-		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#Action">Action</a><br>
-	</td>
-	<td class="defassertion">5</td>
-	<td class="defassertion">0</td>
-	<td class="defassertion">8</td>
-	<td class="defassertion">13</td></tr>
-<tr id="td-default-in-1" class="defassertion">
-	<td class="defassertion"><a target="spec" href="#td-default-in-1">td-default-in-1</a></td>
-	<td class="defassertion">Default</td>
-
-	<td class="defassertion">The value associated with member &quot;BasicSecurityScheme
-                  DigestSecurityScheme
-                  BearerSecurityScheme
-                  PoPSecurityScheme&quot; if not given MUST be assumed to have the default value &quot;
-                    in
-                &quot;.</td>
-	<td class="defassertion">Y</td>
-	<td class="defassertion">
-		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#td-serialization-default-values">td-serialization-default-values</a><br>
-	</td>
-	<td class="defassertion">
-		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#header">header</a><br>
-	</td>
-	<td class="defassertion">6</td>
-	<td class="defassertion">0</td>
-	<td class="defassertion">0</td>
-	<td class="defassertion">6</td></tr>
-<tr id="td-default-in-2" class="defassertion">
-	<td class="defassertion"><a target="spec" href="#td-default-in-2">td-default-in-2</a></td>
-	<td class="defassertion">Default</td>
-
-	<td class="defassertion">The value associated with member &quot;APIKeySecurityScheme&quot; if not given MUST be assumed to have the default value &quot;
+	<td class="defassertion"></td>
+	<td class="defassertion"></td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td></tr>
+<tr id="td-default-in-apikey" class="defassertion">
+	<td class="defassertion"><a target="spec" href="#td-default-in-apikey">td-default-in-apikey</a></td>
+	<td class="defassertion"></td>
+	<td class="atrisk">The value associated with member &quot;
+                  APIKeySecurityScheme
+                  This feature is at risk.
+                &quot; if not given MUST be assumed to have the default value &quot;
                     in
                 &quot;.</td>
 	<td class="defassertion">Y</td>
@@ -2470,10 +2517,87 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="defassertion">
 		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#query">query</a><br>
 	</td>
-	<td class="defassertion">2</td>
-	<td class="defassertion">0</td>
-	<td class="defassertion">4</td>
-	<td class="defassertion">6</td></tr>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td></tr>
+<tr id="td-default-in-basic" class="defassertion">
+	<td class="defassertion"><a target="spec" href="#td-default-in-basic">td-default-in-basic</a></td>
+	<td class="defassertion"></td>
+	<td class="defassertion">The value associated with member &quot;
+                  BasicSecurityScheme
+                &quot; if not given MUST be assumed to have the default value &quot;
+                    in
+                &quot;.</td>
+	<td class="defassertion">Y</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#td-serialization-default-values">td-serialization-default-values</a><br>
+	</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#header">header</a><br>
+	</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td></tr>
+<tr id="td-default-in-bearer" class="defassertion">
+	<td class="defassertion"><a target="spec" href="#td-default-in-bearer">td-default-in-bearer</a></td>
+	<td class="defassertion"></td>
+	<td class="defassertion">The value associated with member &quot;
+                  BearerSecurityScheme
+                &quot; if not given MUST be assumed to have the default value &quot;
+                    in
+                &quot;.</td>
+	<td class="defassertion">Y</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#td-serialization-default-values">td-serialization-default-values</a><br>
+	</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#header">header</a><br>
+	</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td></tr>
+<tr id="td-default-in-digest" class="defassertion">
+	<td class="defassertion"><a target="spec" href="#td-default-in-digest">td-default-in-digest</a></td>
+	<td class="defassertion"></td>
+	<td class="defassertion">The value associated with member &quot;
+                  DigestSecurityScheme
+                &quot; if not given MUST be assumed to have the default value &quot;
+                    in
+                &quot;.</td>
+	<td class="defassertion">Y</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#td-serialization-default-values">td-serialization-default-values</a><br>
+	</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#header">header</a><br>
+	</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td></tr>
+<tr id="td-default-in-pop" class="defassertion">
+	<td class="defassertion"><a target="spec" href="#td-default-in-pop">td-default-in-pop</a></td>
+	<td class="defassertion"></td>
+	<td class="atrisk">The value associated with member &quot;
+                  PoPSecurityScheme
+                  This feature is at risk.
+                &quot; if not given MUST be assumed to have the default value &quot;
+                    in
+                &quot;.</td>
+	<td class="defassertion">Y</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#td-serialization-default-values">td-serialization-default-values</a><br>
+	</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#header">header</a><br>
+	</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td>
+	<td class="missing">0</td></tr>
 <tr id="td-default-op-actions" class="defassertion">
 	<td class="defassertion"><a target="spec" href="#td-default-op-actions">td-default-op-actions</a></td>
 	<td class="defassertion">Default</td>
@@ -2524,12 +2648,12 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="defassertion">
 		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#Array">Array</a><br>
 		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#of">of</a><br>
-		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#strings">strings</a><br>
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#string">string</a><br>
 		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#with">with</a><br>
-		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#values">values</a><br>
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#the">the</a><br>
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#elements">elements</a><br>
 		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#readproperty">readproperty</a><br>
-		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#followed">followed</a><br>
-		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#by">by</a><br>
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#and">and</a><br>
 		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#writeproperty">writeproperty</a><br>
 	</td>
 	<td class="missing">0</td>
@@ -2540,7 +2664,10 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="defassertion"><a target="spec" href="#td-default-qop">td-default-qop</a></td>
 	<td class="defassertion">Default</td>
 
-	<td class="atrisk">The value associated with member &quot;DigestSecurityScheme&quot; if not given MUST be assumed to have the default value &quot;
+	<td class="atrisk">The value associated with member &quot;
+                  DigestSecurityScheme
+                  This feature is at risk.
+                &quot; if not given MUST be assumed to have the default value &quot;
                     qop
                 &quot;.</td>
 	<td class="defassertion">Y</td>
@@ -2554,6 +2681,25 @@ vocabulary term as defined in the class DataSchema for integers MUST be serializ
 	<td class="defassertion">0</td>
 	<td class="defassertion">5</td>
 	<td class="defassertion">6</td></tr>
+<tr id="td-default-readOnly" class="defassertion">
+	<td class="defassertion"><a target="spec" href="#td-default-readOnly">td-default-readOnly</a></td>
+	<td class="defassertion">Default</td>
+
+	<td class="defassertion">The value associated with member &quot;DataSchema&quot; if not given MUST be assumed to have the default value &quot;
+                    readOnly
+                &quot;.</td>
+	<td class="defassertion">Y</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#td-serializiation-default-values">td-serializiation-default-values</a><br>
+	</td>
+	<td class="defassertion">
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#Property">Property</a><br>
+		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#DataSchema">DataSchema</a><br>
+	</td>
+	<td class="defassertion">7</td>
+	<td class="defassertion">0</td>
+	<td class="defassertion">6</td>
+	<td class="defassertion">13</td></tr>
 <tr id="td-default-safe" class="defassertion">
 	<td class="defassertion"><a target="spec" href="#td-default-safe">td-default-safe</a></td>
 	<td class="defassertion">Default</td>
@@ -3508,7 +3654,7 @@ unobserveproperty or an  Array containing a combination of these terms.
 
 	<td class="baseassertion">
     When the forms Array of a Thing instance contains Form instances,
-    each value assigned to their op name-value pair
+    the string values assigned to the name op, either directly or within an Array, 
     MUST be one of the following opteration types:
     readallproperties, writeallproperties, 
     readmultipleproperties, or writemultipleproperties.
@@ -4262,20 +4408,6 @@ MUST be serialized as a JSON name within a Property object.
 	<td class="failed">1</td>
 	<td class="baseassertion">14</td>
 	<td class="baseassertion">15</td></tr>
-<tr id="td-semantic-version" class="baseassertion">
-	<td class="baseassertion"><a target="spec" href="#td-semantic-version">td-semantic-version</a></td>
-	<td class="baseassertion"></td>
-	<td class="baseassertion">
-    The version SHOULD be identified with a value based on the semantic versioning pattern,
-    where a sequence of three numbers separated by dots indicates the major version, minor version, and patch version, respectively.
-  </td>
-	<td class="baseassertion">N</td>
-	<td class="baseassertion"></td>
-	<td class="baseassertion"></td>
-	<td class="missing">0</td>
-	<td class="missing">0</td>
-	<td class="missing">0</td>
-	<td class="missing">0</td></tr>
 <tr id="td-string-type" class="baseassertion">
 	<td class="baseassertion"><a target="spec" href="#td-string-type">td-string-type</a></td>
 	<td class="baseassertion">Syntax</td>
@@ -4418,23 +4550,6 @@ If title and titles are defined at the same time at the JSON level, title MAY be
     MUST be serialized as JSON members with the Vocabulary Term as name.
   </td>
 	<td class="baseassertion">Y</td>
-	<td class="baseassertion"></td>
-	<td class="baseassertion">
-		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#Thing">Thing</a><br>
-	</td>
-	<td class="baseassertion">5</td>
-	<td class="baseassertion">0</td>
-	<td class="baseassertion">9</td>
-	<td class="baseassertion">14</td></tr>
-<tr id="td-version-container" class="baseassertion">
-	<td class="baseassertion"><a target="spec" href="#td-version-container">td-version-container</a></td>
-	<td class="baseassertion">Syntax</td>
-
-	<td class="baseassertion">
-  The version Map MAY be used to provide additional application-
-  and/or device-specific version information based on terms from non-TD vocabularies.
-  </td>
-	<td class="baseassertion">N</td>
 	<td class="baseassertion"></td>
 	<td class="baseassertion">
 		<a href="file:///home/mmccool/Dev/wot-thing-description/testing/report.html#Thing">Thing</a><br>
@@ -5708,7 +5823,7 @@ Type: Map of PropertyAffordance.</td>
 	<td class="tabassertion"><a target="spec" href="#td-vocab-proxy--SecurityScheme">td-vocab-proxy--SecurityScheme</a></td>
 	<td class="tabassertion">Vocabulary</td>
 
-	<td class="atrisk">proxy: URI of the proxy server this security configuration provides access to.  If not given, the corresponding security configuration is for the endpoint.
+	<td class="atrisk">proxy: URI of the proxy server this security configuration provides access to.  If not given, the corresponding security configuration is for the endpoint.  This feature is at risk.
 MAY be included.
 Type: anyURI.</td>
 	<td class="tabassertion">N</td>
@@ -5726,7 +5841,7 @@ Type: anyURI.</td>
 	<td class="tabassertion"><a target="spec" href="#td-vocab-qop--DigestSecurityScheme">td-vocab-qop--DigestSecurityScheme</a></td>
 	<td class="tabassertion">Vocabulary</td>
 
-	<td class="atrisk">qop: Quality of protection.
+	<td class="atrisk">qop: Quality of protection.  This feature is at risk.
 MAY be included.
 Type: string (one of auth, or auth-int).</td>
 	<td class="tabassertion">N</td>
@@ -6051,7 +6166,7 @@ scheme: Identification of security mechanism being configured MAY be set to &quo
 	<td class="tabassertion"><a target="spec" href="#td-vocab-scopes--Form">td-vocab-scopes--Form</a></td>
 	<td class="tabassertion">Vocabulary</td>
 
-	<td class="atrisk">scopes: Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an OAuth2SecurityScheme active on that form.
+	<td class="atrisk">scopes: Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an OAuth2SecurityScheme active on that form.  This feature is at risk.
 MAY be included.
 Type: string or Array of string.</td>
 	<td class="tabassertion">N</td>
@@ -6069,7 +6184,7 @@ Type: string or Array of string.</td>
 	<td class="tabassertion"><a target="spec" href="#td-vocab-scopes--OAuth2SecurityScheme">td-vocab-scopes--OAuth2SecurityScheme</a></td>
 	<td class="tabassertion">Vocabulary</td>
 
-	<td class="tabassertion">scopes: Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an OAuth2SecurityScheme active on that form.
+	<td class="tabassertion">scopes: Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an OAuth2SecurityScheme active on that form.  This feature is at risk.
 MAY be included.
 Type: string or Array of string.</td>
 	<td class="tabassertion">N</td>


### PR DESCRIPTION
- As requested, annotate at-risk features with searchable text.  "This feature is at risk" has been added to all table entries that were marked as at risk.
- Default values associated with other features at risk are also at risk but are in a different section.  I added a reference to the default value section to the SOTD section but did not list the specific default values (this would be redundant, as they are associated with the other features at risk listed immediately above).
- Cleanup in the SOTD section to mention the above annotation and some grammar fixes.  Changes to talk about "features" and "sections" where appropriate rather than "Text or table entries".

We actually don't have any assertions at risk so this COULD be simplified further to just talk about table entries.   But I decided to leave it alone.  For the time being I also left the "possible" wording alone for the producers/consumers statement although I think "appropriate" would be a better word here.

There were also some ReSpec issues having to do with metadata mandatory for CR.   This PR also adds the following to the preamble:
```
            , crEnd: "2019-06-18"
            , previousMaturity: "WD"
            , previousPublishDate: "2018-10-21"
            , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report.html"
```
Of these, `crEnd` is particularly important: it is the day just before the date (2019-06-19) by which we will have to make a resolution to proceed to PR.   Implementors have until this crEnd to complete their implementation and file their implementation report data.
