### PR TITLE
[Testing] add new extra asserts

### DIFF
--- a/testing/inputs/extra-asserts.html
+++ b/testing/inputs/extra-asserts.html
@@ -334,6 +334,39 @@ The type of the members securityDefinitions MUST be serialized as a JSON object.
 <li><span class="rfc2119-assertion" id="td-objects_version">
 The type of the members version MUST be serialized as a JSON object.
 </span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_invokeaction">
+Type: string or Array of string (invokeaction).
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_observeproperty">
+Type: string or Array of string (observeproperty).
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_readproperty">
+Type: string or Array of string (readproperty).
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_subscribeevent">
+Type: string or Array of string (subscribeevent).
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_unobserveproperty">
+Type: string or Array of string (unobserveproperty).
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_unsubscribeevent">
+Type: string or Array of string (unsubscribeevent).
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_writeproperty">
+Type: string or Array of string (writeproperty).
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_readallproperties">
+Type: string or Array of string (readallproperties).
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_writeallproperties">
+Type: string or Array of string (writeallproperties).
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_readmultipleproperties">
+Type: string or Array of string (readmultipleproperties).
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-op--Form_writemultipleproperties">
+Type: string or Array of string (writemultipleproperties).
+</span></li>
 <li><span class="rfc2119-assertion" id="td-properties_existence">
 Properties offered by a Thing MUST be collected in the JSON-object based properties member.
 </span></li>

--- a/testing/inputs/extra-asserts.html
+++ b/testing/inputs/extra-asserts.html
@@ -476,7 +476,7 @@ If title and titles are defined at the same time at the JSON level, title MAY be
 <!--
 <li><span class="rfc2119-assertion" id="td-vocab-description_security">
 A description that provides additional (human-readable) information based on a default language MAY be included
-within a SecurityScheme.
+within a SecurityScheme. 
 </span></li>
 -->
 <li><span class="rfc2119-assertion" id="td-vocab-scheme--SecurityScheme_apikey">
@@ -508,6 +508,27 @@ scheme: Identification of security mechanism being configured MAY be set to <cod
 </span></li>
 <li><span class="rfc2119-assertion" id="td-vocab-scheme--SecurityScheme_public">
 scheme: Identification of security mechanism being configured MAY be set to <code>"public"</code>.
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-type--DataSchema_array">
+type: Assignment of JSON-based data types compatible with JSON Schema (array).>.
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-type--DataSchema_boolean">
+type: Assignment of JSON-based data types compatible with JSON Schema (boolean).>.
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-type--DataSchema_integer">
+type: Assignment of JSON-based data types compatible with JSON Schema (integer).>.
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-type--DataSchema_null">
+type: Assignment of JSON-based data types compatible with JSON Schema (null).>.
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-type--DataSchema_number">
+type: Assignment of JSON-based data types compatible with JSON Schema (number).>.
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-type--DataSchema_object">
+type: Assignment of JSON-based data types compatible with JSON Schema (object).>.
+</span></li>
+<li><span class="rfc2119-assertion" id="td-vocab-type--DataSchema_string">
+type: Assignment of JSON-based data types compatible with JSON Schema (string).>.
 </span></li>
 </ul>
 </body>


### PR DESCRIPTION
I have added new child assertions to the extra-asserts.html that fixes td-vocab-type--DataSchema master assertion having 0 implementations