### PR TITLE
A requirement (Can ignore BOM) is not an assertion of TD (Issue #721)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1807,9 +1807,10 @@ In summary, this requires the following:
 <li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[!RFC3629]].</span</li>
 <li><span class="rfc2119-assertion" id="td-json-open_no-byte-order">Implementations MUST NOT 
   add a byte order mark (U+FEFF) to the beginning of a TD document.</span></li>
-<li><span class="rfc2119-assertion" id="td-json-open_accept-byte-order"><a>TD Processors</a> MAY ignore
-  the presence of a byte order mark rather than treating it as an error.</span></li>
 </ul>
+</p>
+<p>
+In addition, <a>TD Processors</a> may ignore the presence of a byte order mark rather than treating it as an error.
 </p>
 
 <section id="td-basic-types-mapping">

--- a/index.template.html
+++ b/index.template.html
@@ -1380,9 +1380,10 @@ In summary, this requires the following:
 <li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[!RFC3629]].</span</li>
 <li><span class="rfc2119-assertion" id="td-json-open_no-byte-order">Implementations MUST NOT 
   add a byte order mark (U+FEFF) to the beginning of a TD document.</span></li>
-<li><span class="rfc2119-assertion" id="td-json-open_accept-byte-order"><a>TD Processors</a> MAY ignore
-  the presence of a byte order mark rather than treating it as an error.</span></li>
 </ul>
+</p>
+<p>
+In addition, <a>TD Processors</a> may ignore the presence of a byte order mark rather than treating it as an error.
 </p>
 
 <section id="td-basic-types-mapping">


### PR DESCRIPTION
The assertion does not belong to TD specification.
This is an assertion in RFC 8259.