### PR TITLE
String-meta requirement is not an assertion in TD (Issue #738)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2131,10 +2131,8 @@ In summary, this requires the following:
     can either be estimated using heuristics such as the first-strong rule or inferred from language information.
     In TD documents the default language is defined by a value assigned to <code>@language</code> in the <code>@context</code>,
     and this, along with a script subtag if necessary, can be used to determine a base text direction.
-    <span class="rfc2119-assertion" id="td-context-default-language-direction-independence">
-      However, when interpreting human-readable text,
-      each human-readable string value MUST be processed independently.
-    </span>
+    However, according to Strings on the Web [[?string-meta]], when interpreting human-readable text,
+    each human-readable string value is processed independently.
     In other words, a <a>TD Processor</a> cannot carry forward changes in direction from one string to another,
     or infer direction for one string from another one elsewhere in the TD.
   </p>

--- a/index.template.html
+++ b/index.template.html
@@ -1704,10 +1704,8 @@ In summary, this requires the following:
     can either be estimated using heuristics such as the first-strong rule or inferred from language information.
     In TD documents the default language is defined by a value assigned to <code>@language</code> in the <code>@context</code>,
     and this, along with a script subtag if necessary, can be used to determine a base text direction.
-    <span class="rfc2119-assertion" id="td-context-default-language-direction-independence">
-      However, when interpreting human-readable text,
-      each human-readable string value MUST be processed independently.
-    </span>
+    However, according to Strings on the Web [[?string-meta]], when interpreting human-readable text,
+    each human-readable string value is processed independently.
     In other words, a <a>TD Processor</a> cannot carry forward changes in direction from one string to another,
     or infer direction for one string from another one elsewhere in the TD.
   </p>


### PR DESCRIPTION
td-context-default-language-direction-independence assertion belongs to string-meta.