### PR TITLE
Clarify TD Processor (#772)

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,12 +792,14 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
     </dt>
     <dd>
         A system that can serialize some internal representation of a <a>Thing Description</a>
-        in a given format and deserialize it from that format. A <a>TD Processor</a> must detect
+        in a given format and/or deserialize it from that format. A <a>TD Processor</a> must detect
         semantically inconsistent <a>Thing Descriptions</a>, that is, <a>Thing Descriptions</a>
         that cannot satisfy constraints on the <a>Instance Relation</a> of the <code>Thing</code>
         class. For that purpose, a <a>TD Processor</a> may compute canonical forms of <a>Thing
         Descriptions</a> in which all possible <a>Default Values</a> are assigned. A <a>TD Processor</a>
         is typically a sub-system of a <a>WoT Runtime</a>.
+        Implementations of a TD Processor may be a TD producer only (able to serialize to TD Documents)
+        or a TD consumer only (able to deserialize from TD Documents).
     </dd>
     <dt>
         <dfn id="dfn-td-serialization">TD Serialization</dfn>
@@ -1172,8 +1174,8 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
         <p>
             <span class="rfc2119-assertion" id="td-processor">
-                A <a>TD Processor</a> MUST be able to detect that a TD does not
-                meet <a>Class</a> instantiation constraints on all <a>Classes</a> defined in
+                A <a>TD Processor</a> MUST satisfy the
+                <a>Class</a> instantiation constraints on all <a>Classes</a> defined in
                 <a href="#sec-core-vocabulary-definition"></a>,
                 <a href="#sec-data-schema-vocabulary-definition"></a>,
                 <a href="#sec-security-vocabulary-definition"></a>,
@@ -1782,7 +1784,7 @@ IANA HTTP content coding registry</a>.
   <p>
     <span class="rfc2119-assertion" id="td-processor-serialization">
         A <a>TD Processor</a> MUST be able to serialize <a>Thing Descriptions</a>
-        into the JSON format [[!RFC8259]] and deserialize <a>Thing Descriptions</a>
+        into the JSON format [[!RFC8259]] and/or deserialize <a>Thing Descriptions</a>
         from that format, according to the rules noted in
         <a href="#td-basic-types-mapping"></a> and
         <a href="#td-class-serialization"></a>.

--- a/index.template.html
+++ b/index.template.html
@@ -684,12 +684,14 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
     </dt>
     <dd>
         A system that can serialize some internal representation of a <a>Thing Description</a>
-        in a given format and deserialize it from that format. A <a>TD Processor</a> must detect
+        in a given format and/or deserialize it from that format. A <a>TD Processor</a> must detect
         semantically inconsistent <a>Thing Descriptions</a>, that is, <a>Thing Descriptions</a>
         that cannot satisfy constraints on the <a>Instance Relation</a> of the <code>Thing</code>
         class. For that purpose, a <a>TD Processor</a> may compute canonical forms of <a>Thing
         Descriptions</a> in which all possible <a>Default Values</a> are assigned. A <a>TD Processor</a>
         is typically a sub-system of a <a>WoT Runtime</a>.
+        Implementations of a TD Processor may be a TD producer only (able to serialize to TD Documents)
+        or a TD consumer only (able to deserialize from TD Documents).
     </dd>
     <dt>
         <dfn id="dfn-td-serialization">TD Serialization</dfn>
@@ -1064,8 +1066,8 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
         <p>
             <span class="rfc2119-assertion" id="td-processor">
-                A <a>TD Processor</a> MUST be able to detect that a TD does not
-                meet <a>Class</a> instantiation constraints on all <a>Classes</a> defined in
+                A <a>TD Processor</a> MUST satisfy the
+                <a>Class</a> instantiation constraints on all <a>Classes</a> defined in
                 <a href="#sec-core-vocabulary-definition"></a>,
                 <a href="#sec-data-schema-vocabulary-definition"></a>,
                 <a href="#sec-security-vocabulary-definition"></a>,
@@ -1355,7 +1357,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
   <p>
     <span class="rfc2119-assertion" id="td-processor-serialization">
         A <a>TD Processor</a> MUST be able to serialize <a>Thing Descriptions</a>
-        into the JSON format [[!RFC8259]] and deserialize <a>Thing Descriptions</a>
+        into the JSON format [[!RFC8259]] and/or deserialize <a>Thing Descriptions</a>
         from that format, according to the rules noted in
         <a href="#td-basic-types-mapping"></a> and
         <a href="#td-class-serialization"></a>.


### PR DESCRIPTION
Clarified that TD Processor can be producer or consumer only, hence serialize **and/or** deserialize.
Simplified assertion text on class instantiation constraints.