### PR TITLE
Remove Appendix D (see resolution)

### DIFF
--- a/index.html
+++ b/index.html
@@ -704,10 +704,11 @@ a[href].internalDFN {
 </aside>
 
 <p>
-        The declaration mechanism inside some
-        <code>@context</code> is specified by JSON-LD. A TD instance complies to version 1.1 of
-        this specification [[?json-ld11]]. The TD instance can be also processed as an RDF
-        document (details are given in <a href="#note-jsonld11-processing"></a>).
+    The declaration mechanism inside some
+    <code>@context</code> is specified by JSON-LD. A TD instance complies to version 1.1 of
+    that specification [[?json-ld11]]. Hence, a TD instance can be also processed as an RDF
+    document (for details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+    <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
 </p>
 
 </section>
@@ -725,21 +726,6 @@ regarding Thing Description serialization.
 A JSON Schema [[?JSON-SCHEMA-VALIDATION]] to validate Thing Description instances
 is provided in Appendix <a href="#json-schema-for-validation"></a>.
 </p>
-
-<p>
-    A set of SHACL shapes [[SHACL]] is provided under the TD
-    namespace IRI as an alternative to validate Thing Description instances
-    after transformation to RDF. See Appendix <a href="#note-jsonld11-processing"></a>.
-</p>
-
-<!-- <p class="issue">
-    The validation file is currently available
-    <a href="https://w3c.github.io/wot-thing-description/validation/td-validation.ttl">
-      on w3c.github.io
-  </a>
-  but is should eventually be put under the TD namespace, on w3.org. E.g. at
-  <code>https://www.w3.org/2019/td/td-validation.ttl</code>.
-</p> -->
 
 </section>
 
@@ -1370,10 +1356,11 @@ where a sequence of three numbers separated by a dot indicates the major version
       <h2>Data Schema Vocabulary Definitions</h2>
       <p>
         The data schema definition is reflecting a very common subset of the terms defined by JSON Schema [[?JSON-SCHEMA-VALIDATION]]. It is noted
-        that data schema definitions within Thing Description instances are not limited to this defined subset and MAY use additional terms
-        found in JSON Schema. In that case, it is recommended to use a <a>TD Context Extension</a> for the additional terms as described in
+        that data schema definitions within Thing Description instances are not limited to this defined subset and may use additional terms
+        found in JSON Schema using a <a>TD Context Extension</a> for the additional terms as described in
         <a href="#sec-context-extensions"></a>, otherwise these terms are semantically ignored by <a>TD Processors</a>
-        (also see <a href="#note-jsonld11-processing"></a>).
+        (for details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+        <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
       </p>
 
         <section><h3><code>DataSchema</code></h3><p>Metadata that describes the data format used. It can be used for validation.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types)</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display a text for UI representation) based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
@@ -1794,8 +1781,9 @@ IANA HTTP content coding registry</a>.
   the syntax of JSON-LD 1.1 [[?json-ld11]]
   in order to streamline semantic evaluation.
   Hence, the TD representation format can be processed either as raw JSON
-  or with a JSON-LD 1.1 processor,
-  as further detailed in <a href="#note-jsonld11-processing"></a>.
+  or with a JSON-LD 1.1 processor
+  (for details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+  <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
   </p>
 
 <p>
@@ -5623,346 +5611,10 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </pre>
     </section>
     
-     </section>   
-     </section> 
-    
-<section id="note-jsonld11-processing" class="appendix informative">
-<h1>Transformation to RDF</h1>
+  </section>
+</section>
 
-        <p>
-            To integrate a Thing Description instance with external knowledge and
-            contextual information (like SAREF annotations), the use of
-            JSON-LD 1.1 and its processing API [[json-ld11-api]], as well as RDF-based
-            tools [[rdf11-concepts]] and libraries is highly recommended. This appendix
-            introduces two non-normative elements of the Thing Description model based
-            on RDF: the default JSON-LD context for TD and the TD ontology.
-        </p>
-
-        <section>
-            <h3>Thing Description JSON-LD Context</h3>
-
-            <p>
-                A TD document can be transformed into RDF by a standard JSON-LD processor
-                (to then be uploaded to an RDF store for further processing).
-                The following procedure loads the context of the TD, given by the
-                term <code>@context</code>, and generates RDF triples:
-            </p>
-
-            <p>
-                <a href="https://www.w3.org/TR/json-ld11-api/#deserialize-json-ld-to-rdf-algorithm">
-                    <code>JsonLdProcessor.toRdf</code>
-                </a>
-            </p>
-            
-            <p>
-                When applying this procedure to <a href="#saref-state-annotation-example"></a>,
-                including annotations and <a>Default Values</a>, the following triples are obtained:
-            </p>
-            
-            <aside class="example with-default" id="simple-thing-description-rdf">
-                <div class="with-default-control">
-                    <input type="checkbox"/>
-                    <span><i>after transformation to RDF</i></span>
-                </div>
-                <pre>{
-    "@context": [
-        "https://www.w3.org/2019/wot/td/v1",
-        { 
-            "saref": "https://w3id.org/saref#",
-            "ssn": "http://www.w3.org/ns/ssn/",
-            "htv": "http://www.w3.org/2011/http#"
-        }
-    ],
-    "id": "urn:dev:ops:32473-WoTLamp-1234",
-    "title": "MyLampThing",
-    "@type": "saref:LightSwitch",
-    "saref:hasState": {
-        "@id": "urn:dev:ops:32473-WoTLamp-1234/state",
-        "@type": "saref:OnOffState"
-    },
-    "securityDefinitions": {"basic_sc": {
-        "scheme": "basic",
-        "in": "header"
-    }},
-    "security": ["basic_sc"],
-    "properties": {
-        "status": {
-            "ssn:forProperty": "urn:dev:ops:32473-WoTLamp-1234/state",
-            "type": "string",
-            "forms": [{
-                "href": "https://mylamp.example.com/status",
-                "op": "readproperty",
-                "htv:methodName": "GET"
-            }, {
-                "href": "https://mylamp.example.com/status",
-                "op": "writeproperty",
-                "contentType": "application/json",
-                "htv:methodName": "PUT"
-            }]
-        }
-    },
-    "actions": {
-        "toggle": {
-            "safe": false,
-            "idempotent": false,
-            "forms": [{
-                "href": "https://mylamp.example.com/toggle",
-                "op": "invokeaction",
-                "contentType": "application/json",
-                "htv:methodName": "POST"
-            }]
-        }
-    },
-    "events": {
-        "overheating": {
-            "data": {"type": "string"},
-            "forms": [{
-                "href": "https://mylamp.example.com/oh",
-                "op": "subscribeevent",
-                "contentType": "application/json"
-            }]
-        }
-    }
-}</pre><pre>
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://w3id.org/saref#LightSwitch&gt; .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://w3id.org/saref#hasState&gt; &lt;urn:dev:ops:32473-WoTLamp-1234/state&gt; .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasActionAffordance&gt; _:b0 .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasEventAffordance&gt; _:b2 .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasPropertyAffordance&gt; _:b5 .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasSecurityConfiguration&gt; &lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#title&gt; &quot;MyLampThing&quot; .
-_:b0 &lt;https://www.w3.org/2019/wot/td#name&gt; &quot;toggle&quot; .
-_:b0 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b1 .
-_:b0 &lt;https://www.w3.org/2019/wot/td#isIdempotent&gt; &quot;false&quot;^^&lt;http://www.w3.org/2001/XMLSchema#boolean&gt; .
-_:b0 &lt;https://www.w3.org/2019/wot/td#isSafe&gt; &quot;false&quot;^^&lt;http://www.w3.org/2001/XMLSchema#boolean&gt; .
-_:b1 &lt;http://www.w3.org/2011/http#methodName&gt; &quot;POST&quot; .
-_:b1 &lt;https://www.w3.org/2019/wot/hypermedia#forContentType&gt; &quot;application/json&quot; .
-_:b1 &lt;https://www.w3.org/2019/wot/hypermedia#forOperationType&gt; &quot;invokeaction&quot; .
-_:b1 &lt;https://www.w3.org/2019/wot/hypermedia#hasTarget&gt; &quot;https://mylamp.example.com/toggle&quot; .
-_:b2 &lt;https://www.w3.org/2019/wot/td#name&gt; &quot;overheating&quot; .
-_:b2 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b3 .
-_:b2 &lt;https://www.w3.org/2019/wot/td#hasNotificationSchema&gt; _:b4 .
-_:b3 &lt;https://www.w3.org/2019/wot/hypermedia#forContentType&gt; &quot;application/json&quot; .
-_:b3 &lt;https://www.w3.org/2019/wot/hypermedia#forOperationType&gt; &quot;subscribeevent&quot; .
-_:b3 &lt;https://www.w3.org/2019/wot/hypermedia#hasTarget&gt; &quot;https://mylamp.example.com/oh&quot; .
-_:b4 &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://www.w3.org/2019/wot/json-schema#StringSchema&gt; .
-_:b5 &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://www.w3.org/2019/wot/json-schema#StringSchema&gt; .
-_:b5 &lt;https://www.w3.org/2019/wot/td#name&gt; &quot;status&quot; .
-_:b5 &lt;http://www.w3.org/ns/ssn/forProperty&gt; &quot;urn:dev:ops:32473-WoTLamp-1234/state&quot; .
-_:b5 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b6 .
-_:b5 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b7 .
-_:b6 &lt;http://www.w3.org/2011/http#methodName&gt; &quot;GET&quot; .
-_:b6 &lt;https://www.w3.org/2019/wot/hypermedia#forOperationType&gt; &quot;readproperty&quot; .
-_:b6 &lt;https://www.w3.org/2019/wot/hypermedia#hasTarget&gt; &quot;https://mylamp.example.com/status&quot; .
-_:b7 &lt;http://www.w3.org/2011/http#methodName&gt; &quot;PUT&quot; .
-_:b7 &lt;https://www.w3.org/2019/wot/hypermedia#forContentType&gt; &quot;application/json&quot; .
-_:b7 &lt;https://www.w3.org/2019/wot/hypermedia#forOperationType&gt; &quot;writeproperty&quot; .
-_:b7 &lt;https://www.w3.org/2019/wot/hypermedia#hasTarget&gt; &quot;https://mylamp.example.com/status&quot; .
-&lt;urn:dev:ops:32473-WoTLamp-1234/state&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://w3id.org/saref#OnOffState&gt; .
-&lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://www.w3.org/2019/wot/security#BasicSecurityScheme&gt; .
-&lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; &lt;https://www.w3.org/2019/wot/security#in&gt; &quot;header&quot; .</pre>
-            </aside>
-
-            <p>
-                Most importantly, the JSON-LD context maps JSON strings to RDF IRIs (hence, the notion
-                of <em>context</em>: in two different contexts, the same string can have different
-                meanings). The mapping here is rather straightforward: every vocabulary of the TD
-                information model is defined its own namespace and every vocabulary term maps to some
-                name, appended to the corresponding namespace. Strings that are not part of any
-                vocabulary map to RDF literals (strings with an optional datatype). For instance,
-                <code>title</code> maps to <code>https://www.w3.org/2019/wot/td#title</code> and
-                <code>MyLampThing</code> remains unchanged. Applying this mapping is called
-                <a href="https://www.w3.org/TR/json-ld11/#expanded-document-form">context expansion</a>.
-            </p>
-
-            <p>
-                Then, after expanding JSON strings to full IRIs, all map structures of the
-                TD document must be turned into RDF triples. In a simple case, a
-                triple is produced for every key/value pair in the map. For instance, the
-                very first triple of the example above was produced from <code>"title": "myLampThing"</code>.
-            </p>
-
-            <p>
-                Other cases rely on specific JSON-LD features. Most of these features were
-                introduced in the 1.1 version of the standard and thus require an appropriate
-                JSON-LD 1.1 implementation. They are listed below:
-            </p>
-
-            <ul>
-                <li>
-                    <a href="https://www.w3.org/TR/json-ld11/#aliasing-keywords"><em>Aliasing keywords</em></a>:
-                    JSON-LD reserved keywords always start with <code>@</code> but in certain cases, it is
-                    more convenient to define aliases for these keywords, e.g. to more easily process JSON-LD
-                    document in a specific programming environment. In the TD core vocabulary, <code>id</code>
-                    is an alias for <code>@id</code>, which must be an IRI used as the subject of triples when
-                    producing RDF. For this reason, the first triples in the example have
-                    <code>urn:dev:ops:32473-WoTLamp-1234</code> as a subject instead of an arbitrary
-                    blank node.
-                </li>
-                <li>
-                    <a href="https://www.w3.org/TR/json-ld11/#scoped-contexts"><em>Scoped contexts</em></a>:
-                    The term <code>properties</code> is used both in the core vocabulary and in the data schema
-                    vocabulary. Yet, a JSON string cannot map to two IRIs simultaneously in the same context
-                    definition. The mapping from <code>properties</code> to
-                    <code>https://www.w3.org/2019/wot/json-schema#properties</code> must therefore be <em>scoped</em>
-                    to instances of <code>DataSchema</code> only.
-                </li>
-                <li>
-                    <a href="https://github.com/w3c/json-ld-api/issues/65"><em>Property-based data indexing</em></a>:
-                    in the example above, <code>status</code>, <code>toggle</code> and <code>overheating</code>
-                    appear as keys in a map but they do not produce triples in which they become predicates. This special
-                    structure is called an <a href="https://www.w3.org/TR/json-ld11/#data-indexing">index map</a>.
-                    Without any indication in the context, the index key is lost when an index map is turned into RDF.
-                    To make the transformation to RDF reversible, it is possible to indicate that index keys should
-                    produce triples with a given predicate. Each vocabulary can include an RDF term for this purpose.
-                    In the core vocabulary, the property <code>https://www.w3.org/2019/wot/td#name</code> is used.
-                </li>
-                <li>
-                    <a href="https://github.com/w3c/json-ld-syntax/issues/19"><em>Indexing without a predicate</em></a>:
-                    in a TD, the security definitions container is mostly syntactic sugar to avoid redundancy
-                    in the <code>security</code> definitions. JSON-LD 1.1 includes another indexing mechanism for
-                    that purpose. In the above example, <code>securityDefinitions</code> does not produce any
-                    triple.
-                </li>
-            </ul>
-
-            <p class="ednote">
-                The last two JSON-LD features (property-based data indexing and indexing without a
-                predicate) are still experimental; they have not been published in any Editors'
-                Draft yet.
-            </p>
-    
-            <!-- <p class="issue">
-                An experimental JSON-LD 1.1 context for the TD model is provided in the
-                repository: <code>td-context-1.1.jsonld</code>. Currently, it is not the
-                context served at <code>https://www.w3.org/2019/wot/td/v1</code>, though.
-            </p> -->
-        </section>
-
-        <section>
-            <h3>Thing Description Ontology</h3>
-
-            <p>
-                As presented in the previous section, all <a>Vocabulary Terms</a> (including those
-                denoting <a>Classes</a>) follow the RDF convention of belonging to a <a>Vocabulary</a>
-                identified by a namespace IRI.
-                As a result, the TD information model can be reformulated in the Web Ontology Language
-                (OWL) [[owl2-overview]]. <a>Class</a> definitions become OWL axioms defined on the
-                <a>Vocabulary Terms</a> of the TD model. The axioms that are particularly
-                of interest in the present document are those of the TD ontology (available under the
-                <a href="https://www.w3.org/2019/wot/td">TD namespace IRI</a>), both as an RDF file and
-                as a human-readable HTML documentation. <a>Default Values</a> cannot be directly translated
-                to OWL, they are therefore ignored in the TD ontology.
-            </p>
-
-            <p>
-                The axioms included in the TD ontology may be used to validate a TD but its primary
-                purpose is to serve as an entry point for a deeper semantic description of WoT Things
-                that would make <a>Consumers</a> behave in a more autonomous way, as desired in WoT
-                [[wot-architecture]]. A semantic description is nothing more than a description of the
-                physical world, in which WoT systems may have tangible effects. OWL should be the
-                preferred language for this purpose. It is indeed a language to specify <em>ontologies</em>,
-                that is, conceptualizations of the physical world. To this end, an ontology does not cover
-                one possible model of the physical world by constructing abstract data structures. Instead,
-                it provides necessary constraints on all possible models of the world for these models to
-                be sound. This principle, at the basis of <em>model theory</em>, is what the semantics of RDF
-                (and OWL) is based on [[rdf11-mt]]. In the following diagram, because the only fact
-                we know about <code>urn:dev:ops:32473-WoTLamp-1234</code> is that it is a <a>Thing</a>
-                with generic affordances, it could be <em>any</em> <a>Thing</a>, including intangible entities.
-                Even when knowing it is a light switch through TD annotations, it can still be a mechanical,
-                digital or even virtual device.
-            </p>
-            
-            <figure>
-                <img src="images/model-theory-explainer.png">
-                <figcaption><a>TD Serialization</a>, <a>TD</a> and <a>Thing</a> on a light switch example</figcaption>
-            </figure>
-
-            <p>
-                As a consequence, the TD ontology is meant to be integrated into a larger ontology,
-                as it would not suffice to describe physical world objects alone. An ontology is
-                generally designed for a specific domain of application, like transportation or home
-                automation. For the latter domain, the TD ontology can e.g. be
-                integrated with SAREF, as illustrated in <a href="#saref-state-annotation-example"></a>.
-            </p>
-
-            <p>
-                In particular, the <a>Terms</a> included in the TD ontology may be used to express
-                what affordances should be <em>expected</em> from <a>Things</a> of a certain type,
-                like <code>saref:LightSwitch</code> or, more generally, anything that has a
-                state. The following rules can be read as sentences: a light switch exposes a property
-                affordance to access its on/off state and an action affordance to act on this state.
-            </p>
-
-            <aside class="example" id="light-switch-rules">
-<pre class="nohighlight">
-td:Thing(X), saref:hasState(X, Y)
-→ td:hasPropertyAffordance(X, Z), ssn:forProperty(Z, Y) .
-
-td:Thing(X), saref:hasState(X, Y)
-→ td:hasActionAffordance(X, Z), saref:actsUpon(Z, Y) .
-</pre>
-            </aside>
-
-            <p>
-                Note that these rules do not prevent one affordance from implying the other. In fact,
-                the TD ontology itself contains a rule specifying that every <a>Property</a> with
-                a <code>writeproperty</code> operation is conceptually equivalent to an (idempotent)
-                <a>Action</a> with the <a>Property</a>'s data schema as input. The rule can be
-                expressed as follows:
-            </p>
-
-            <aside class="example" id="property-action-equivalence">
-<pre class="nohighlight">
-td:Thing(X), td:hasPropertyAffordance(X, Y),
-td:hasForm(Y, Z), hyperm:forOperationType(Z, "writeproperty")
-→ td:hasActionAffordance(X, Yp),
-  isIdempotent(Yp, true),
-  td:hasInputSchema(Yp, Y) .
-</pre>
-            </aside>
-
-            <p>
-                An intelligent WoT <a>Consumer</a> can be assigned the task of turning a light off
-                in ontological terms, using SAREF. For instance, the task could be expressed as
-                a post-condition on the <code>saref:OnOffState</code> of some <code>saref:LightSwitch</code>.
-                Assuming a server exposes the TD of <a href="#saref-state-annotation-example"></a>,
-                the <a>Consumer</a> has two possibilities to perform this task: it can either write
-                the <code>status</code> property as <code>off</code> or it can invoke the action
-                <code>toggle</code> and see if the resulting <code>status</code> is indeed
-                equal to <code>off</code>.
-            </p>
-
-            <p>
-                Given the TD of <a href="#saref-state-annotation-example"></a>, it is straightforward
-                for a <a>Consumer</a> to infer what to do from the internal state description embedded in the TD.
-                However, provided the rules (or axioms) given above, it can be inferred that for all possible
-                models of the light switch described in the TD, an <a>Action</a> may also have the desired effect.
-                A <a>Consumer</a> can therefore adaptively choose to operate on either affordance of the light switch
-                to perform the task. In fact, its behavoir would be unaltered even if the TD did not
-                exposed its state. A single type statement including <code>saref:LightSwitch</code> would
-                suffice, since all light switches behave the same way.
-            </p>
-
-            <p>
-                Note that, in the case the internal state is hidden, the result of the operation cannot
-                be known for certain. However, by selecting certain models of the physical world,
-                either by statistical means or by further axiomatization, <a>Consumers</a> can still
-                reach a certain level of autonomy with an ontological approach and e.g. learn from their
-                own behavior via a trial and error procedure. In critical applications, it is however
-                strongly recommended that the internal state of a <a>Thing</a> be entirely exposed semantically.
-            </p>
-
-            <!-- <p class="issue">
-                Currently, the ontology documentation is available
-                <a href="https://w3c.github.io/wot-thing-description/ontology/td.html">on w3c.github.io</a>
-                but it should eventually be put under the TD namespace, on w3.org.
-            </p> -->
-        </section>
-
-    </section>
-
-  <section id="changes" class="appendix">
+<section id="changes" class="appendix">
   <h1>Recent Specification Changes</h1>
   <h2 id="changes-from-candidate-recommendation">Changes from Candidate Recommendation</h2>
   <ul>
@@ -5997,7 +5649,6 @@ td:hasForm(Y, Z), hyperm:forOperationType(Z, "writeproperty")
     </ul>
 
     </ul>
-
   </ul>
 
   <h2 id="changes-from-third-public-working-draft">Changes from Third Public Working Draft</h2>
@@ -6005,14 +5656,14 @@ td:hasForm(Y, Z), hyperm:forOperationType(Z, "writeproperty")
   <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#changes">Candidate Recommendation</a>
   </p>
 
-  </section>
+</section>
 
-  <section id="acknowledgements" class="appendix normative">
+<section id="acknowledgements" class="appendix normative">
   <h1>Acknowledgements</h1>
   <p>The editors would like to thank Michael Koster, Michael Lagally, Kazuyuki Ashimura, Ege Korkan, Daniel Peintner, Toru Kawaguchi, María Poveda, Dave Raggett, Kunihiko Toumura, Takeshi Yamada, Ben Francis, Manu Sporny, Klaus Hartke, Addison Phillips, Jose M. Cantera, Tomoaki Mizushima, Soumya Kanti Datta and Benjamin Klotz for providing contributions, guidance and expertise.</p>
   <p>Also, many thanks to the W3C staff and all other current and former active Participants of the W3C Web of Things Interest Group (WoT IG) and Working Group (WoT WG) for their support, technical input and suggestions that led to improvements to this document.</p>
   <p>Finally, special thanks to Joerg Heuer for leading the WoT IG for 2 years from its inception and guiding the group to come up with the concept of WoT building blocks including the Thing Description.</p>
-  </section>
+</section>
 
 </body>
 </html>

--- a/index.template.html
+++ b/index.template.html
@@ -596,10 +596,11 @@ a[href].internalDFN {
 </aside>
 
 <p>
-        The declaration mechanism inside some
-        <code>@context</code> is specified by JSON-LD. A TD instance complies to version 1.1 of
-        this specification [[?json-ld11]]. The TD instance can be also processed as an RDF
-        document (details are given in <a href="#note-jsonld11-processing"></a>).
+    The declaration mechanism inside some
+    <code>@context</code> is specified by JSON-LD. A TD instance complies to version 1.1 of
+    that specification [[?json-ld11]]. Hence, a TD instance can be also processed as an RDF
+    document (for details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+    <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
 </p>
 
 </section>
@@ -617,21 +618,6 @@ regarding Thing Description serialization.
 A JSON Schema [[?JSON-SCHEMA-VALIDATION]] to validate Thing Description instances
 is provided in Appendix <a href="#json-schema-for-validation"></a>.
 </p>
-
-<p>
-    A set of SHACL shapes [[SHACL]] is provided under the TD
-    namespace IRI as an alternative to validate Thing Description instances
-    after transformation to RDF. See Appendix <a href="#note-jsonld11-processing"></a>.
-</p>
-
-<!-- <p class="issue">
-    The validation file is currently available
-    <a href="https://w3c.github.io/wot-thing-description/validation/td-validation.ttl">
-      on w3c.github.io
-  </a>
-  but is should eventually be put under the TD namespace, on w3.org. E.g. at
-  <code>https://www.w3.org/2019/td/td-validation.ttl</code>.
-</p> -->
 
 </section>
 
@@ -1084,10 +1070,11 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       <h2>Data Schema Vocabulary Definitions</h2>
       <p>
         The data schema definition is reflecting a very common subset of the terms defined by JSON Schema [[?JSON-SCHEMA-VALIDATION]]. It is noted
-        that data schema definitions within Thing Description instances are not limited to this defined subset and MAY use additional terms
-        found in JSON Schema. In that case, it is recommended to use a <a>TD Context Extension</a> for the additional terms as described in
+        that data schema definitions within Thing Description instances are not limited to this defined subset and may use additional terms
+        found in JSON Schema using a <a>TD Context Extension</a> for the additional terms as described in
         <a href="#sec-context-extensions"></a>, otherwise these terms are semantically ignored by <a>TD Processors</a>
-        (also see <a href="#note-jsonld11-processing"></a>).
+        (for details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+        <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
       </p>
 
         {json-schema}
@@ -1367,8 +1354,9 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
   the syntax of JSON-LD 1.1 [[?json-ld11]]
   in order to streamline semantic evaluation.
   Hence, the TD representation format can be processed either as raw JSON
-  or with a JSON-LD 1.1 processor,
-  as further detailed in <a href="#note-jsonld11-processing"></a>.
+  or with a JSON-LD 1.1 processor
+  (for details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+  <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
   </p>
 
 <p>
@@ -4044,346 +4032,10 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </pre>
     </section>
     
-     </section>   
-     </section> 
-    
-<section id="note-jsonld11-processing" class="appendix informative">
-<h1>Transformation to RDF</h1>
+  </section>
+</section>
 
-        <p>
-            To integrate a Thing Description instance with external knowledge and
-            contextual information (like SAREF annotations), the use of
-            JSON-LD 1.1 and its processing API [[json-ld11-api]], as well as RDF-based
-            tools [[rdf11-concepts]] and libraries is highly recommended. This appendix
-            introduces two non-normative elements of the Thing Description model based
-            on RDF: the default JSON-LD context for TD and the TD ontology.
-        </p>
-
-        <section>
-            <h3>Thing Description JSON-LD Context</h3>
-
-            <p>
-                A TD document can be transformed into RDF by a standard JSON-LD processor
-                (to then be uploaded to an RDF store for further processing).
-                The following procedure loads the context of the TD, given by the
-                term <code>@context</code>, and generates RDF triples:
-            </p>
-
-            <p>
-                <a href="https://www.w3.org/TR/json-ld11-api/#deserialize-json-ld-to-rdf-algorithm">
-                    <code>JsonLdProcessor.toRdf</code>
-                </a>
-            </p>
-            
-            <p>
-                When applying this procedure to <a href="#saref-state-annotation-example"></a>,
-                including annotations and <a>Default Values</a>, the following triples are obtained:
-            </p>
-            
-            <aside class="example with-default" id="simple-thing-description-rdf">
-                <div class="with-default-control">
-                    <input type="checkbox"/>
-                    <span><i>after transformation to RDF</i></span>
-                </div>
-                <pre>{
-    "@context": [
-        "https://www.w3.org/2019/wot/td/v1",
-        { 
-            "saref": "https://w3id.org/saref#",
-            "ssn": "http://www.w3.org/ns/ssn/",
-            "htv": "http://www.w3.org/2011/http#"
-        }
-    ],
-    "id": "urn:dev:ops:32473-WoTLamp-1234",
-    "title": "MyLampThing",
-    "@type": "saref:LightSwitch",
-    "saref:hasState": {
-        "@id": "urn:dev:ops:32473-WoTLamp-1234/state",
-        "@type": "saref:OnOffState"
-    },
-    "securityDefinitions": {"basic_sc": {
-        "scheme": "basic",
-        "in": "header"
-    }},
-    "security": ["basic_sc"],
-    "properties": {
-        "status": {
-            "ssn:forProperty": "urn:dev:ops:32473-WoTLamp-1234/state",
-            "type": "string",
-            "forms": [{
-                "href": "https://mylamp.example.com/status",
-                "op": "readproperty",
-                "htv:methodName": "GET"
-            }, {
-                "href": "https://mylamp.example.com/status",
-                "op": "writeproperty",
-                "contentType": "application/json",
-                "htv:methodName": "PUT"
-            }]
-        }
-    },
-    "actions": {
-        "toggle": {
-            "safe": false,
-            "idempotent": false,
-            "forms": [{
-                "href": "https://mylamp.example.com/toggle",
-                "op": "invokeaction",
-                "contentType": "application/json",
-                "htv:methodName": "POST"
-            }]
-        }
-    },
-    "events": {
-        "overheating": {
-            "data": {"type": "string"},
-            "forms": [{
-                "href": "https://mylamp.example.com/oh",
-                "op": "subscribeevent",
-                "contentType": "application/json"
-            }]
-        }
-    }
-}</pre><pre>
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://w3id.org/saref#LightSwitch&gt; .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://w3id.org/saref#hasState&gt; &lt;urn:dev:ops:32473-WoTLamp-1234/state&gt; .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasActionAffordance&gt; _:b0 .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasEventAffordance&gt; _:b2 .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasPropertyAffordance&gt; _:b5 .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasSecurityConfiguration&gt; &lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; .
-&lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#title&gt; &quot;MyLampThing&quot; .
-_:b0 &lt;https://www.w3.org/2019/wot/td#name&gt; &quot;toggle&quot; .
-_:b0 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b1 .
-_:b0 &lt;https://www.w3.org/2019/wot/td#isIdempotent&gt; &quot;false&quot;^^&lt;http://www.w3.org/2001/XMLSchema#boolean&gt; .
-_:b0 &lt;https://www.w3.org/2019/wot/td#isSafe&gt; &quot;false&quot;^^&lt;http://www.w3.org/2001/XMLSchema#boolean&gt; .
-_:b1 &lt;http://www.w3.org/2011/http#methodName&gt; &quot;POST&quot; .
-_:b1 &lt;https://www.w3.org/2019/wot/hypermedia#forContentType&gt; &quot;application/json&quot; .
-_:b1 &lt;https://www.w3.org/2019/wot/hypermedia#forOperationType&gt; &quot;invokeaction&quot; .
-_:b1 &lt;https://www.w3.org/2019/wot/hypermedia#hasTarget&gt; &quot;https://mylamp.example.com/toggle&quot; .
-_:b2 &lt;https://www.w3.org/2019/wot/td#name&gt; &quot;overheating&quot; .
-_:b2 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b3 .
-_:b2 &lt;https://www.w3.org/2019/wot/td#hasNotificationSchema&gt; _:b4 .
-_:b3 &lt;https://www.w3.org/2019/wot/hypermedia#forContentType&gt; &quot;application/json&quot; .
-_:b3 &lt;https://www.w3.org/2019/wot/hypermedia#forOperationType&gt; &quot;subscribeevent&quot; .
-_:b3 &lt;https://www.w3.org/2019/wot/hypermedia#hasTarget&gt; &quot;https://mylamp.example.com/oh&quot; .
-_:b4 &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://www.w3.org/2019/wot/json-schema#StringSchema&gt; .
-_:b5 &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://www.w3.org/2019/wot/json-schema#StringSchema&gt; .
-_:b5 &lt;https://www.w3.org/2019/wot/td#name&gt; &quot;status&quot; .
-_:b5 &lt;http://www.w3.org/ns/ssn/forProperty&gt; &quot;urn:dev:ops:32473-WoTLamp-1234/state&quot; .
-_:b5 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b6 .
-_:b5 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b7 .
-_:b6 &lt;http://www.w3.org/2011/http#methodName&gt; &quot;GET&quot; .
-_:b6 &lt;https://www.w3.org/2019/wot/hypermedia#forOperationType&gt; &quot;readproperty&quot; .
-_:b6 &lt;https://www.w3.org/2019/wot/hypermedia#hasTarget&gt; &quot;https://mylamp.example.com/status&quot; .
-_:b7 &lt;http://www.w3.org/2011/http#methodName&gt; &quot;PUT&quot; .
-_:b7 &lt;https://www.w3.org/2019/wot/hypermedia#forContentType&gt; &quot;application/json&quot; .
-_:b7 &lt;https://www.w3.org/2019/wot/hypermedia#forOperationType&gt; &quot;writeproperty&quot; .
-_:b7 &lt;https://www.w3.org/2019/wot/hypermedia#hasTarget&gt; &quot;https://mylamp.example.com/status&quot; .
-&lt;urn:dev:ops:32473-WoTLamp-1234/state&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://w3id.org/saref#OnOffState&gt; .
-&lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://www.w3.org/2019/wot/security#BasicSecurityScheme&gt; .
-&lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; &lt;https://www.w3.org/2019/wot/security#in&gt; &quot;header&quot; .</pre>
-            </aside>
-
-            <p>
-                Most importantly, the JSON-LD context maps JSON strings to RDF IRIs (hence, the notion
-                of <em>context</em>: in two different contexts, the same string can have different
-                meanings). The mapping here is rather straightforward: every vocabulary of the TD
-                information model is defined its own namespace and every vocabulary term maps to some
-                name, appended to the corresponding namespace. Strings that are not part of any
-                vocabulary map to RDF literals (strings with an optional datatype). For instance,
-                <code>title</code> maps to <code>https://www.w3.org/2019/wot/td#title</code> and
-                <code>MyLampThing</code> remains unchanged. Applying this mapping is called
-                <a href="https://www.w3.org/TR/json-ld11/#expanded-document-form">context expansion</a>.
-            </p>
-
-            <p>
-                Then, after expanding JSON strings to full IRIs, all map structures of the
-                TD document must be turned into RDF triples. In a simple case, a
-                triple is produced for every key/value pair in the map. For instance, the
-                very first triple of the example above was produced from <code>"title": "myLampThing"</code>.
-            </p>
-
-            <p>
-                Other cases rely on specific JSON-LD features. Most of these features were
-                introduced in the 1.1 version of the standard and thus require an appropriate
-                JSON-LD 1.1 implementation. They are listed below:
-            </p>
-
-            <ul>
-                <li>
-                    <a href="https://www.w3.org/TR/json-ld11/#aliasing-keywords"><em>Aliasing keywords</em></a>:
-                    JSON-LD reserved keywords always start with <code>@</code> but in certain cases, it is
-                    more convenient to define aliases for these keywords, e.g. to more easily process JSON-LD
-                    document in a specific programming environment. In the TD core vocabulary, <code>id</code>
-                    is an alias for <code>@id</code>, which must be an IRI used as the subject of triples when
-                    producing RDF. For this reason, the first triples in the example have
-                    <code>urn:dev:ops:32473-WoTLamp-1234</code> as a subject instead of an arbitrary
-                    blank node.
-                </li>
-                <li>
-                    <a href="https://www.w3.org/TR/json-ld11/#scoped-contexts"><em>Scoped contexts</em></a>:
-                    The term <code>properties</code> is used both in the core vocabulary and in the data schema
-                    vocabulary. Yet, a JSON string cannot map to two IRIs simultaneously in the same context
-                    definition. The mapping from <code>properties</code> to
-                    <code>https://www.w3.org/2019/wot/json-schema#properties</code> must therefore be <em>scoped</em>
-                    to instances of <code>DataSchema</code> only.
-                </li>
-                <li>
-                    <a href="https://github.com/w3c/json-ld-api/issues/65"><em>Property-based data indexing</em></a>:
-                    in the example above, <code>status</code>, <code>toggle</code> and <code>overheating</code>
-                    appear as keys in a map but they do not produce triples in which they become predicates. This special
-                    structure is called an <a href="https://www.w3.org/TR/json-ld11/#data-indexing">index map</a>.
-                    Without any indication in the context, the index key is lost when an index map is turned into RDF.
-                    To make the transformation to RDF reversible, it is possible to indicate that index keys should
-                    produce triples with a given predicate. Each vocabulary can include an RDF term for this purpose.
-                    In the core vocabulary, the property <code>https://www.w3.org/2019/wot/td#name</code> is used.
-                </li>
-                <li>
-                    <a href="https://github.com/w3c/json-ld-syntax/issues/19"><em>Indexing without a predicate</em></a>:
-                    in a TD, the security definitions container is mostly syntactic sugar to avoid redundancy
-                    in the <code>security</code> definitions. JSON-LD 1.1 includes another indexing mechanism for
-                    that purpose. In the above example, <code>securityDefinitions</code> does not produce any
-                    triple.
-                </li>
-            </ul>
-
-            <p class="ednote">
-                The last two JSON-LD features (property-based data indexing and indexing without a
-                predicate) are still experimental; they have not been published in any Editors'
-                Draft yet.
-            </p>
-    
-            <!-- <p class="issue">
-                An experimental JSON-LD 1.1 context for the TD model is provided in the
-                repository: <code>td-context-1.1.jsonld</code>. Currently, it is not the
-                context served at <code>https://www.w3.org/2019/wot/td/v1</code>, though.
-            </p> -->
-        </section>
-
-        <section>
-            <h3>Thing Description Ontology</h3>
-
-            <p>
-                As presented in the previous section, all <a>Vocabulary Terms</a> (including those
-                denoting <a>Classes</a>) follow the RDF convention of belonging to a <a>Vocabulary</a>
-                identified by a namespace IRI.
-                As a result, the TD information model can be reformulated in the Web Ontology Language
-                (OWL) [[owl2-overview]]. <a>Class</a> definitions become OWL axioms defined on the
-                <a>Vocabulary Terms</a> of the TD model. The axioms that are particularly
-                of interest in the present document are those of the TD ontology (available under the
-                <a href="https://www.w3.org/2019/wot/td">TD namespace IRI</a>), both as an RDF file and
-                as a human-readable HTML documentation. <a>Default Values</a> cannot be directly translated
-                to OWL, they are therefore ignored in the TD ontology.
-            </p>
-
-            <p>
-                The axioms included in the TD ontology may be used to validate a TD but its primary
-                purpose is to serve as an entry point for a deeper semantic description of WoT Things
-                that would make <a>Consumers</a> behave in a more autonomous way, as desired in WoT
-                [[wot-architecture]]. A semantic description is nothing more than a description of the
-                physical world, in which WoT systems may have tangible effects. OWL should be the
-                preferred language for this purpose. It is indeed a language to specify <em>ontologies</em>,
-                that is, conceptualizations of the physical world. To this end, an ontology does not cover
-                one possible model of the physical world by constructing abstract data structures. Instead,
-                it provides necessary constraints on all possible models of the world for these models to
-                be sound. This principle, at the basis of <em>model theory</em>, is what the semantics of RDF
-                (and OWL) is based on [[rdf11-mt]]. In the following diagram, because the only fact
-                we know about <code>urn:dev:ops:32473-WoTLamp-1234</code> is that it is a <a>Thing</a>
-                with generic affordances, it could be <em>any</em> <a>Thing</a>, including intangible entities.
-                Even when knowing it is a light switch through TD annotations, it can still be a mechanical,
-                digital or even virtual device.
-            </p>
-            
-            <figure>
-                <img src="images/model-theory-explainer.png">
-                <figcaption><a>TD Serialization</a>, <a>TD</a> and <a>Thing</a> on a light switch example</figcaption>
-            </figure>
-
-            <p>
-                As a consequence, the TD ontology is meant to be integrated into a larger ontology,
-                as it would not suffice to describe physical world objects alone. An ontology is
-                generally designed for a specific domain of application, like transportation or home
-                automation. For the latter domain, the TD ontology can e.g. be
-                integrated with SAREF, as illustrated in <a href="#saref-state-annotation-example"></a>.
-            </p>
-
-            <p>
-                In particular, the <a>Terms</a> included in the TD ontology may be used to express
-                what affordances should be <em>expected</em> from <a>Things</a> of a certain type,
-                like <code>saref:LightSwitch</code> or, more generally, anything that has a
-                state. The following rules can be read as sentences: a light switch exposes a property
-                affordance to access its on/off state and an action affordance to act on this state.
-            </p>
-
-            <aside class="example" id="light-switch-rules">
-<pre class="nohighlight">
-td:Thing(X), saref:hasState(X, Y)
-→ td:hasPropertyAffordance(X, Z), ssn:forProperty(Z, Y) .
-
-td:Thing(X), saref:hasState(X, Y)
-→ td:hasActionAffordance(X, Z), saref:actsUpon(Z, Y) .
-</pre>
-            </aside>
-
-            <p>
-                Note that these rules do not prevent one affordance from implying the other. In fact,
-                the TD ontology itself contains a rule specifying that every <a>Property</a> with
-                a <code>writeproperty</code> operation is conceptually equivalent to an (idempotent)
-                <a>Action</a> with the <a>Property</a>'s data schema as input. The rule can be
-                expressed as follows:
-            </p>
-
-            <aside class="example" id="property-action-equivalence">
-<pre class="nohighlight">
-td:Thing(X), td:hasPropertyAffordance(X, Y),
-td:hasForm(Y, Z), hyperm:forOperationType(Z, "writeproperty")
-→ td:hasActionAffordance(X, Yp),
-  isIdempotent(Yp, true),
-  td:hasInputSchema(Yp, Y) .
-</pre>
-            </aside>
-
-            <p>
-                An intelligent WoT <a>Consumer</a> can be assigned the task of turning a light off
-                in ontological terms, using SAREF. For instance, the task could be expressed as
-                a post-condition on the <code>saref:OnOffState</code> of some <code>saref:LightSwitch</code>.
-                Assuming a server exposes the TD of <a href="#saref-state-annotation-example"></a>,
-                the <a>Consumer</a> has two possibilities to perform this task: it can either write
-                the <code>status</code> property as <code>off</code> or it can invoke the action
-                <code>toggle</code> and see if the resulting <code>status</code> is indeed
-                equal to <code>off</code>.
-            </p>
-
-            <p>
-                Given the TD of <a href="#saref-state-annotation-example"></a>, it is straightforward
-                for a <a>Consumer</a> to infer what to do from the internal state description embedded in the TD.
-                However, provided the rules (or axioms) given above, it can be inferred that for all possible
-                models of the light switch described in the TD, an <a>Action</a> may also have the desired effect.
-                A <a>Consumer</a> can therefore adaptively choose to operate on either affordance of the light switch
-                to perform the task. In fact, its behavoir would be unaltered even if the TD did not
-                exposed its state. A single type statement including <code>saref:LightSwitch</code> would
-                suffice, since all light switches behave the same way.
-            </p>
-
-            <p>
-                Note that, in the case the internal state is hidden, the result of the operation cannot
-                be known for certain. However, by selecting certain models of the physical world,
-                either by statistical means or by further axiomatization, <a>Consumers</a> can still
-                reach a certain level of autonomy with an ontological approach and e.g. learn from their
-                own behavior via a trial and error procedure. In critical applications, it is however
-                strongly recommended that the internal state of a <a>Thing</a> be entirely exposed semantically.
-            </p>
-
-            <!-- <p class="issue">
-                Currently, the ontology documentation is available
-                <a href="https://w3c.github.io/wot-thing-description/ontology/td.html">on w3c.github.io</a>
-                but it should eventually be put under the TD namespace, on w3.org.
-            </p> -->
-        </section>
-
-    </section>
-
-  <section id="changes" class="appendix">
+<section id="changes" class="appendix">
   <h1>Recent Specification Changes</h1>
   <h2 id="changes-from-candidate-recommendation">Changes from Candidate Recommendation</h2>
   <ul>
@@ -4418,7 +4070,6 @@ td:hasForm(Y, Z), hyperm:forOperationType(Z, "writeproperty")
     </ul>
 
     </ul>
-
   </ul>
 
   <h2 id="changes-from-third-public-working-draft">Changes from Third Public Working Draft</h2>
@@ -4426,14 +4077,14 @@ td:hasForm(Y, Z), hyperm:forOperationType(Z, "writeproperty")
   <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#changes">Candidate Recommendation</a>
   </p>
 
-  </section>
+</section>
 
-  <section id="acknowledgements" class="appendix normative">
+<section id="acknowledgements" class="appendix normative">
   <h1>Acknowledgements</h1>
   <p>The editors would like to thank Michael Koster, Michael Lagally, Kazuyuki Ashimura, Ege Korkan, Daniel Peintner, Toru Kawaguchi, María Poveda, Dave Raggett, Kunihiko Toumura, Takeshi Yamada, Ben Francis, Manu Sporny, Klaus Hartke, Addison Phillips, Jose M. Cantera, Tomoaki Mizushima, Soumya Kanti Datta and Benjamin Klotz for providing contributions, guidance and expertise.</p>
   <p>Also, many thanks to the W3C staff and all other current and former active Participants of the W3C Web of Things Interest Group (WoT IG) and Working Group (WoT WG) for their support, technical input and suggestions that led to improvements to this document.</p>
   <p>Finally, special thanks to Joerg Heuer for leading the WoT IG for 2 years from its inception and guiding the group to come up with the concept of WoT building blocks including the Thing Description.</p>
-  </section>
+</section>
 
 </body>
 </html>


### PR DESCRIPTION
Removed Appendix D about RDF processing.
Pointing to ontology documentation files under the namespace IRIs instead now.
Removed text about SHACL.