### PR TITLE
Fix ontology documentation file status (now ED) (#770)

### DIFF
--- a/ontology/hyperm.html
+++ b/ontology/hyperm.html
@@ -2,21 +2,44 @@
 <html>
 
 <head>
-    <meta charset='utf-8'>
-    <title>Web Linking Ontology</title>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
-    <script class='remove'>
+    <meta charset="utf-8">
+    <title>Hypermedia Controls Ontology</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script class="remove">
         var respecConfig = {
-            specStatus: "WG-NOTE",
+            specStatus: "ED",
             editors: [{
                 name: "Victor Charpenay"
             }, {
-                name: "Maxime Lefrançois"
-            }, {
-                name: "María Poveda Villalón"
+                name: "Matthias Kovatsch"
             }],
-            edDraftURI: "http://github.com/w3c/wot-thing-description",
-            shortName: "wot-td-ontology"
+            edDraftURI: "https://www.w3.org/2019/wot/hypermedia",
+            shortName: "hypermedia-ontology",
+            localBiblio: {
+                "hydra": {
+                    href: "https://www.hydra-cg.com/spec/latest/core/",
+                    title: "Hydra Core Vocabulary",
+                    publisher: "Hydra W3C Community Group",
+                    authors: [
+                        "Markus Lanthaler"
+                    ]
+                },
+                "rest" : {
+                    title : "REST: Architectural Styles and the Design of Network-based Software Architectures",
+                    author : "Roy Thomas Fielding",
+                    status : "PhD thesis",
+                    publisher : "University of California, Irvine",
+                    date : "2000"
+                },
+                "coral" : {
+                    href : "https://tools.ietf.org/html/draft-hartke-t2trg-coral",
+                    title : "The Constrained RESTful Application Language (CoRAL)",
+                    authors : [ "Klaus Hartke" ],
+                    publisher : "IETF",
+                    status : "Internet-Draft",
+                    date : " March 2019"
+                }
+            }
         };
     </script>
     <style>
@@ -55,18 +78,49 @@
 </head>
 
 <body>
-    <section id='abstract'>
+    <section id="abstract">
         <p>
-            This is required.
+            This document introduces an ontology for links and forms, the main hypermedia
+            controls in use on the Web. This ontology offers, among others, a means to reify
+            RDF statements interpreted as links between Web resources. It also provides
+            a versatile exchange format for links and forms in RESTful Web applications.
+        </p>
+        <p>
+            Hypermedia controls are of importance in the fields of the Web of Things and
+            the Embedded Web, in particular in the W3C Thing Description model and the IETF
+            Constrained RESTful Application Language.
         </p>
     </section>
-    <section id='sotd'>
-        <p>
-            This is required.
+    <section id="sotd">
+        <p class="ednote" title="The W3C WoT WG is asking for feedback">
+            Please contribute to this draft using the <a href="https://github.com/w3c/wot-thing-description/issues">GitHub Issue</a> feature of the <a href="https://github.com/w3c/wot-thing-description/">WoT Thing Description</a> repository.
         </p>
     </section>
     <section>
         <h2>Introduction</h2>
+        <p>
+            The concept of Representational State Transfer (REST) [[rest]] is at the core of most modern
+            Web applications. The state of a Web resources, exposed via a collection of Web
+            resources, can be browsed by clients by following <em>links</em> and acted upon by submitting
+            <em>forms</em> to servers.
+        </p>
+        <p>
+            Links and forms have always be present in Web technologies, including HTML [[html]]. Web
+            linking [[rfc8288]] is a fundamental principle of the Web architecture that can be leveraged to
+            drive applications, e.g. when a server returns a link to a newly created resource as the
+            result of a client's request. Conversely, forms, are request templates that servers can expose
+            to clients for them to fill in with client-specific information and send back to servers.
+            Forms are similar in spirit to operation desriptions as defined by the Open API Specification
+            [[openapis]] or by the Hydra RDF vocabulary [[hydra]].
+        </p>
+        <p>
+            Links and forms are generically referred to as <em>hypermedia controls</em>. They are
+            of increasing importance in the fields of the Web of Things and the Embedded Web,
+            which respectively led to the standardization of the Thing Description (TD) model
+            [[wot-thing-description]] and the Constrained RESTful Application Language (CoRAL)
+            [[coral]]. The present hypermedia controls ontology is an attempt to formalize the
+            concepts these two standards specify.
+        </p>
     </section>
 
     <section><h2>Axiomatization</h2><section><h3>Overview of Classes and Properties</h3><div  class="azlist"><p>Classes: <a href="#hyperm-expectedresponse">hyperm:ExpectedResponse</a> , <a href="#hyperm-link">hyperm:Link</a> , <a href="#hyperm-form">hyperm:Form</a></p></div><div  class="azlist"><p>Object Properties: </p></div><div  class="azlist"><p>Datatype Properties: <a href="#hyperm-hintsatmediatype">hyperm:hintsAtMediaType</a> , <a href="#hyperm-hasrelationtype">hyperm:hasRelationType</a> , <a href="#hyperm-forcontentcoding">hyperm:forContentCoding</a> , <a href="#hyperm-forcontenttype">hyperm:forContentType</a> , <a href="#hyperm-forsubprotocol">hyperm:forSubProtocol</a> , <a href="#hyperm-foroperationtype">hyperm:forOperationType</a> , <a href="#hyperm-hastarget">hyperm:hasTarget</a> , <a href="#hyperm-returns">hyperm:returns</a> , <a href="#hyperm-hasanchor">hyperm:hasAnchor</a></p></div></section><section><h3>Classes</h3><section class="specterm"><h4><a href="#hyperm-expectedresponse">hyperm:ExpectedResponse</a></h4><p>IRI: https://www.w3.org/2019/wot/hypermedia#ExpectedResponse</p><p><strong>a OWL Class</strong></p><em>ExpectedResponse</em> - <span>Communication metadata describing the expected response message.</span><table><tbody></tbody></table></section>
@@ -86,20 +140,20 @@ The op attribute indicates which form is for which and allows the client to sele
 
 op can be assigned one or more interaction verb(s) each representing a semantic intention of an operation.</span><table><tbody></tbody></table></section>
 <section class="specterm"><h4><a href="#hyperm-hastarget">hyperm:hasTarget</a></h4><p>IRI: https://www.w3.org/2019/wot/hypermedia#hasTarget</p><p><strong>a OWL Class</strong></p><em>hasTarget</em> - <span>target IRI of a link or submission target of a form.</span><table><tbody></tbody></table></section>
-<section class="specterm"><h4><a href="#hyperm-returns">hyperm:returns</a></h4><p>IRI: https://www.w3.org/2019/wot/hypermedia#returns</p><p><strong>a OWL Class</strong></p><em>returns</em> - <span>This optional term can be used if, e.g., the output communication metadata differ from input metdata (e.g., output contentType differ from the
-     input contentType). The response name contains metadata that is only valid for the reponse messages.</span><table><tbody></tbody></table></section>
-<section class="specterm"><h4><a href="#hyperm-hasanchor">hyperm:hasAnchor</a></h4><p>IRI: https://www.w3.org/2019/wot/hypermedia#hasAnchor</p><p><strong>a OWL Class</strong></p><em>hasAnchor</em> - <span>By default, the context, or anchor, of a link conveyed in the Link header field is the URL of the representation it is associated with, as defined in RFC7231, Section 3.1.4.1, and is serialized as a URI.</span><table><tbody></tbody></table></section></section></section><section><h2>Term Mapping</h2><table><thead><tr><th>JSON String</th><th>Ontology Term</th></tr></thead><tbody><tr><td>hyperm</td><td><a href="#hyperm-hypermedia controls ontology">hyperm:Hypermedia Controls Ontology</a></td></tr>
+<section class="specterm"><h4><a href="#hyperm-returns">hyperm:returns</a></h4><p>IRI: https://www.w3.org/2019/wot/hypermedia#returns</p><p><strong>a OWL Class</strong></p><em>returns</em> - <span>This optional term can be used if, e.g., the output communication metadata differ from input metadata (e.g., output contentType differ from the
+     input contentType). The response name contains metadata that is only valid for the response messages.</span><table><tbody></tbody></table></section>
+<section class="specterm"><h4><a href="#hyperm-hasanchor">hyperm:hasAnchor</a></h4><p>IRI: https://www.w3.org/2019/wot/hypermedia#hasAnchor</p><p><strong>a OWL Class</strong></p><em>hasAnchor</em> - <span>By default, the context, or anchor, of a link conveyed in the Link header field is the URL of the representation it is associated with, as defined in RFC7231, Section 3.1.4.1, and is serialized as a URI.</span><table><tbody></tbody></table></section></section></section><section><h2>Term Mapping</h2><table><thead><tr><th>JSON String</th><th>Ontology Term</th></tr></thead><tbody><tr><td>Form</td><td><a href="#hyperm-form">hyperm:Form</a></td></tr>
+<tr><td>hyperm</td><td><a href="#hyperm-hypermedia controls ontology">hyperm:Hypermedia Controls Ontology</a></td></tr>
 <tr><td>response</td><td><a href="#hyperm-returns">hyperm:returns</a></td></tr>
-<tr><td>Form</td><td><a href="#hyperm-form">hyperm:Form</a></td></tr>
-<tr><td>subprotocol</td><td><a href="#hyperm-forsubprotocol">hyperm:forSubProtocol</a></td></tr>
-<tr><td>Link</td><td><a href="#hyperm-link">hyperm:Link</a></td></tr>
-<tr><td>type</td><td><a href="#hyperm-hintsatmediatype">hyperm:hintsAtMediaType</a></td></tr>
-<tr><td>anchor</td><td><a href="#hyperm-hasanchor">hyperm:hasAnchor</a></td></tr>
 <tr><td>rel</td><td><a href="#hyperm-hasrelationtype">hyperm:hasRelationType</a></td></tr>
 <tr><td>contentCoding</td><td><a href="#hyperm-forcontentcoding">hyperm:forContentCoding</a></td></tr>
+<tr><td>anchor</td><td><a href="#hyperm-hasanchor">hyperm:hasAnchor</a></td></tr>
+<tr><td>type</td><td><a href="#hyperm-hintsatmediatype">hyperm:hintsAtMediaType</a></td></tr>
+<tr><td>href</td><td><a href="#hyperm-hastarget">hyperm:hasTarget</a></td></tr>
+<tr><td>Link</td><td><a href="#hyperm-link">hyperm:Link</a></td></tr>
 <tr><td>op</td><td><a href="#hyperm-foroperationtype">hyperm:forOperationType</a></td></tr>
-<tr><td>contentType</td><td><a href="#hyperm-forcontenttype">hyperm:forContentType</a></td></tr>
-<tr><td>href</td><td><a href="#hyperm-hastarget">hyperm:hasTarget</a></td></tr></tbody></table></section>
+<tr><td>subprotocol</td><td><a href="#hyperm-forsubprotocol">hyperm:forSubProtocol</a></td></tr>
+<tr><td>contentType</td><td><a href="#hyperm-forcontenttype">hyperm:forContentType</a></td></tr></tbody></table></section>
     
 </body>
 

--- a/ontology/hyperm.template.html
+++ b/ontology/hyperm.template.html
@@ -2,21 +2,44 @@
 <html>
 
 <head>
-    <meta charset='utf-8'>
-    <title>Web Linking Ontology</title>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
-    <script class='remove'>
+    <meta charset="utf-8">
+    <title>Hypermedia Controls Ontology</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script class="remove">
         var respecConfig = {
-            specStatus: "WG-NOTE",
+            specStatus: "ED",
             editors: [{
                 name: "Victor Charpenay"
             }, {
-                name: "Maxime Lefrançois"
-            }, {
-                name: "María Poveda Villalón"
+                name: "Matthias Kovatsch"
             }],
-            edDraftURI: "http://github.com/w3c/wot-thing-description",
-            shortName: "wot-td-ontology"
+            edDraftURI: "https://www.w3.org/2019/wot/hypermedia",
+            shortName: "hypermedia-ontology",
+            localBiblio: {
+                "hydra": {
+                    href: "https://www.hydra-cg.com/spec/latest/core/",
+                    title: "Hydra Core Vocabulary",
+                    publisher: "Hydra W3C Community Group",
+                    authors: [
+                        "Markus Lanthaler"
+                    ]
+                },
+                "rest" : {
+                    title : "REST: Architectural Styles and the Design of Network-based Software Architectures",
+                    author : "Roy Thomas Fielding",
+                    status : "PhD thesis",
+                    publisher : "University of California, Irvine",
+                    date : "2000"
+                },
+                "coral" : {
+                    href : "https://tools.ietf.org/html/draft-hartke-t2trg-coral",
+                    title : "The Constrained RESTful Application Language (CoRAL)",
+                    authors : [ "Klaus Hartke" ],
+                    publisher : "IETF",
+                    status : "Internet-Draft",
+                    date : " March 2019"
+                }
+            }
         };
     </script>
     <style>
@@ -55,18 +78,49 @@
 </head>
 
 <body>
-    <section id='abstract'>
+    <section id="abstract">
         <p>
-            This is required.
+            This document introduces an ontology for links and forms, the main hypermedia
+            controls in use on the Web. This ontology offers, among others, a means to reify
+            RDF statements interpreted as links between Web resources. It also provides
+            a versatile exchange format for links and forms in RESTful Web applications.
+        </p>
+        <p>
+            Hypermedia controls are of importance in the fields of the Web of Things and
+            the Embedded Web, in particular in the W3C Thing Description model and the IETF
+            Constrained RESTful Application Language.
         </p>
     </section>
-    <section id='sotd'>
-        <p>
-            This is required.
+    <section id="sotd">
+        <p class="ednote" title="The W3C WoT WG is asking for feedback">
+            Please contribute to this draft using the <a href="https://github.com/w3c/wot-thing-description/issues">GitHub Issue</a> feature of the <a href="https://github.com/w3c/wot-thing-description/">WoT Thing Description</a> repository.
         </p>
     </section>
     <section>
         <h2>Introduction</h2>
+        <p>
+            The concept of Representational State Transfer (REST) [[rest]] is at the core of most modern
+            Web applications. The state of a Web resources, exposed via a collection of Web
+            resources, can be browsed by clients by following <em>links</em> and acted upon by submitting
+            <em>forms</em> to servers.
+        </p>
+        <p>
+            Links and forms have always be present in Web technologies, including HTML [[html]]. Web
+            linking [[rfc8288]] is a fundamental principle of the Web architecture that can be leveraged to
+            drive applications, e.g. when a server returns a link to a newly created resource as the
+            result of a client's request. Conversely, forms, are request templates that servers can expose
+            to clients for them to fill in with client-specific information and send back to servers.
+            Forms are similar in spirit to operation desriptions as defined by the Open API Specification
+            [[openapis]] or by the Hydra RDF vocabulary [[hydra]].
+        </p>
+        <p>
+            Links and forms are generically referred to as <em>hypermedia controls</em>. They are
+            of increasing importance in the fields of the Web of Things and the Embedded Web,
+            which respectively led to the standardization of the Thing Description (TD) model
+            [[wot-thing-description]] and the Constrained RESTful Application Language (CoRAL)
+            [[coral]]. The present hypermedia controls ontology is an attempt to formalize the
+            concepts these two standards specify.
+        </p>
     </section>
 
     {axioms}

--- a/ontology/jsonschema.html
+++ b/ontology/jsonschema.html
@@ -2,12 +2,12 @@
 <html>
 
 <head>
-    <meta charset='utf-8'>
+    <meta charset="utf-8">
     <title>JSON Schema in RDF</title>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
-    <script class='remove'>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script class="remove">
         var respecConfig = {
-            specStatus: "WG-NOTE",
+            specStatus: "ED",
             editors: [{
                 name: "Victor Charpenay"
             }, {
@@ -15,8 +15,21 @@
             }, {
                 name: "María Poveda Villalón"
             }],
-            edDraftURI: "http://github.com/w3c/wot-thing-description",
-            shortName: "wot-td-ontology"
+            edDraftURI: "http://www.w3.org/2019/wot/json-schema",
+            shortName: "json-schema-in-rdf",
+            localBiblio: {
+                "json-schema-validation": {
+                    title: "JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
+                    , href: "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01"
+                    , authors: [
+                        "Austin Wright",
+                        "Henry Andrews",
+                        "Geraint Luff"
+                    ]
+                    , status: "Internet-Draft"
+                    , publisher: "IETF"
+                }
+            }
         };
     </script>
     <style>
@@ -55,18 +68,45 @@
 </head>
 
 <body>
-    <section id='abstract'>
+    <section id="abstract">
         <p>
-            This is required.
+            This document introduces an RDF vocabulary for JSON schema definitions.
+            This vocabulary provides a stable namespace IRI for JSON schema keywords,
+            as well as simple axioms, defined against schema.org's meta-model. Various
+            examples on how to use the vocabulary are also introduced, e.g. to annotate
+            schemas with JSON-LD metadata or to embed schema annotations inside RDF
+            graphs.
         </p>
     </section>
-    <section id='sotd'>
-        <p>
-            This is required.
+    <section id="sotd">
+        <p class="ednote" title="The W3C WoT WG is asking for feedback">
+            Please contribute to this draft using the <a href="https://github.com/w3c/wot-thing-description/issues">GitHub Issue</a> feature of the <a href="https://github.com/w3c/wot-thing-description/">WoT Thing Description</a> repository.
         </p>
     </section>
     <section>
         <h2>Introduction</h2>
+        <p>
+            JSON schema is a popular schema language for JSON documents
+            [[json-schema-validation]]. This vocabulary includes the main terms
+            defined by JSON schema in order to represent schema definitions in RDF.
+            Besides providing a stable namespace IRI for JSON schema terms, this
+            vocabulary also includes axioms based on schema.org's meta-model. Its
+            design favors simplicity of use over completeness.
+        </p>
+
+        <p>
+            Representing JSON schema in RDF was originally intended to be used
+            as part of the W3C Web of Things (WoT) framework and in particular in
+            the Thing Description model [[wot-thing-description]]. However,
+            processing JSON schema in RDF is not limited to WoT. Other use cases
+            include:
+        </p>
+
+        <ul>
+            <li>Alignment of schema definitions with RDF vocabularies and RDF shapes</li>
+            <li>Rule-based validation or transformation of JSON data</li>
+            <li>Integration of various forms of data specfications, including JSON Schema</li>
+        </ul>
     </section>
 
     <section><h2>Axiomatization</h2><section><h3>Overview of Classes and Properties</h3><div  class="azlist"><p>Classes: <a href="#jsonschema-objectschema">jsonschema:ObjectSchema</a> , <a href="#jsonschema-stringschema">jsonschema:StringSchema</a> , <a href="#jsonschema-numberschema">jsonschema:NumberSchema</a> , <a href="#jsonschema-dataschema">jsonschema:DataSchema</a> , <a href="#jsonschema-nullschema">jsonschema:NullSchema</a> , <a href="#jsonschema-booleanschema">jsonschema:BooleanSchema</a> , <a href="#jsonschema-integerschema">jsonschema:IntegerSchema</a> , <a href="#jsonschema-arrayschema">jsonschema:ArraySchema</a></p></div><div  class="azlist"><p>Object Properties: <a href="#jsonschema-properties">jsonschema:properties</a> , <a href="#jsonschema-items">jsonschema:items</a></p></div><div  class="azlist"><p>Datatype Properties: <a href="#jsonschema-oneof">jsonschema:oneOf</a> , <a href="#jsonschema-minitems">jsonschema:minItems</a> , <a href="#jsonschema-maxitems">jsonschema:maxItems</a> , <a href="#jsonschema-const">jsonschema:const</a> , <a href="#jsonschema-minimum">jsonschema:minimum</a> , <a href="#jsonschema-type">jsonschema:type</a> , <a href="#jsonschema-enum">jsonschema:enum</a> , <a href="#jsonschema-maximum">jsonschema:maximum</a> , <a href="#jsonschema-writeonly">jsonschema:writeOnly</a> , <a href="#jsonschema-format">jsonschema:format</a> , <a href="#jsonschema-readonly">jsonschema:readOnly</a> , <a href="#jsonschema-required">jsonschema:required</a></p></div></section><section><h3>Classes</h3><section class="specterm"><h4><a href="#jsonschema-objectschema">jsonschema:ObjectSchema</a></h4><p>IRI: https://www.w3.org/2019/wot/json-schema#ObjectSchema</p><p><strong>a OWL Class</strong></p><em>ObjectSchema</em> - <span>Metadata describing data of type <code>object</code>. This <a>Subclass</a> is indicated by the value <code>object</code> assigned to <code>type</code> in <code>DataSchema</code> instances.</span><table><tbody><tr><th>Sub-class of</th><td><a href="#jsonschema-dataschema">jsonschema:DataSchema</a></td></tr></tbody></table></section>
@@ -88,28 +128,28 @@
 <section class="specterm"><h4><a href="#jsonschema-writeonly">jsonschema:writeOnly</a></h4><p>IRI: https://www.w3.org/2019/wot/json-schema#writeOnly</p><p><strong>a OWL Class</strong></p><em>writeOnly</em> - <span>Boolean value that is a hint to indicate whether a property interaction / value is write only (=true) or not (=false)</span><table><tbody></tbody></table></section>
 <section class="specterm"><h4><a href="#jsonschema-format">jsonschema:format</a></h4><p>IRI: https://www.w3.org/2019/wot/json-schema#format</p><p><strong>a OWL Class</strong></p><em>format</em> - <span>Allows validation based on a format pattern such as "date-time", "email", "uri", etc.</span><table><tbody></tbody></table></section>
 <section class="specterm"><h4><a href="#jsonschema-readonly">jsonschema:readOnly</a></h4><p>IRI: https://www.w3.org/2019/wot/json-schema#readOnly</p><p><strong>a OWL Class</strong></p><em>readOnly</em> - <span>Boolean value that is a hint to indicate whether a property interaction / value is read only (=true) or not (=false)</span><table><tbody></tbody></table></section>
-<section class="specterm"><h4><a href="#jsonschema-required">jsonschema:required</a></h4><p>IRI: https://www.w3.org/2019/wot/json-schema#required</p><p><strong>a OWL Class</strong></p><em>required</em> - <span>Defines which members of the object type are mandatory.</span><table><tbody></tbody></table></section></section></section><section><h2>Term Mapping</h2><table><thead><tr><th>JSON String</th><th>Ontology Term</th></tr></thead><tbody><tr><td>number</td><td><a href="#jsonschema-numberschema">jsonschema:NumberSchema</a></td></tr>
-<tr><td>minimum</td><td><a href="#jsonschema-minimum">jsonschema:minimum</a></td></tr>
-<tr><td>object</td><td><a href="#jsonschema-objectschema">jsonschema:ObjectSchema</a></td></tr>
-<tr><td>enum</td><td><a href="#jsonschema-enum">jsonschema:enum</a></td></tr>
-<tr><td>DataSchema</td><td><a href="#jsonschema-dataschema">jsonschema:DataSchema</a></td></tr>
-<tr><td>null</td><td><a href="#jsonschema-nullschema">jsonschema:NullSchema</a></td></tr>
-<tr><td>jsonschema</td><td><a href="#jsonschema-">jsonschema:</a></td></tr>
-<tr><td>properties</td><td><a href="#jsonschema-properties">jsonschema:properties</a></td></tr>
-<tr><td>oneOf</td><td><a href="#jsonschema-oneof">jsonschema:oneOf</a></td></tr>
+<section class="specterm"><h4><a href="#jsonschema-required">jsonschema:required</a></h4><p>IRI: https://www.w3.org/2019/wot/json-schema#required</p><p><strong>a OWL Class</strong></p><em>required</em> - <span>Defines which members of the object type are mandatory.</span><table><tbody></tbody></table></section></section></section><section><h2>Term Mapping</h2><table><thead><tr><th>JSON String</th><th>Ontology Term</th></tr></thead><tbody><tr><td>string</td><td><a href="#jsonschema-stringschema">jsonschema:StringSchema</a></td></tr>
 <tr><td>items</td><td><a href="#jsonschema-items">jsonschema:items</a></td></tr>
-<tr><td>maxItems</td><td><a href="#jsonschema-maxitems">jsonschema:maxItems</a></td></tr>
-<tr><td>array</td><td><a href="#jsonschema-arrayschema">jsonschema:ArraySchema</a></td></tr>
-<tr><td>string</td><td><a href="#jsonschema-stringschema">jsonschema:StringSchema</a></td></tr>
-<tr><td>minItems</td><td><a href="#jsonschema-minitems">jsonschema:minItems</a></td></tr>
+<tr><td>minimum</td><td><a href="#jsonschema-minimum">jsonschema:minimum</a></td></tr>
+<tr><td>enum</td><td><a href="#jsonschema-enum">jsonschema:enum</a></td></tr>
+<tr><td>null</td><td><a href="#jsonschema-nullschema">jsonschema:NullSchema</a></td></tr>
 <tr><td>const</td><td><a href="#jsonschema-const">jsonschema:const</a></td></tr>
-<tr><td>maximum</td><td><a href="#jsonschema-maximum">jsonschema:maximum</a></td></tr>
-<tr><td>unit</td><td><a href="#jsonschema-unit">jsonschema:unit</a></td></tr>
-<tr><td>writeOnly</td><td><a href="#jsonschema-writeonly">jsonschema:writeOnly</a></td></tr>
-<tr><td>required</td><td><a href="#jsonschema-required">jsonschema:required</a></td></tr>
 <tr><td>integer</td><td><a href="#jsonschema-integerschema">jsonschema:IntegerSchema</a></td></tr>
-<tr><td>boolean</td><td><a href="#jsonschema-booleanschema">jsonschema:BooleanSchema</a></td></tr>
-<tr><td>readOnly</td><td><a href="#jsonschema-readonly">jsonschema:readOnly</a></td></tr></tbody></table></section>
+<tr><td>array</td><td><a href="#jsonschema-arrayschema">jsonschema:ArraySchema</a></td></tr>
+<tr><td>DataSchema</td><td><a href="#jsonschema-dataschema">jsonschema:DataSchema</a></td></tr>
+<tr><td>minItems</td><td><a href="#jsonschema-minitems">jsonschema:minItems</a></td></tr>
+<tr><td>maxItems</td><td><a href="#jsonschema-maxitems">jsonschema:maxItems</a></td></tr>
+<tr><td>unit</td><td><a href="#jsonschema-unit">jsonschema:unit</a></td></tr>
+<tr><td>object</td><td><a href="#jsonschema-objectschema">jsonschema:ObjectSchema</a></td></tr>
+<tr><td>properties</td><td><a href="#jsonschema-properties">jsonschema:properties</a></td></tr>
+<tr><td>required</td><td><a href="#jsonschema-required">jsonschema:required</a></td></tr>
+<tr><td>number</td><td><a href="#jsonschema-numberschema">jsonschema:NumberSchema</a></td></tr>
+<tr><td>jsonschema</td><td><a href="#jsonschema-">jsonschema:</a></td></tr>
+<tr><td>oneOf</td><td><a href="#jsonschema-oneof">jsonschema:oneOf</a></td></tr>
+<tr><td>maximum</td><td><a href="#jsonschema-maximum">jsonschema:maximum</a></td></tr>
+<tr><td>readOnly</td><td><a href="#jsonschema-readonly">jsonschema:readOnly</a></td></tr>
+<tr><td>writeOnly</td><td><a href="#jsonschema-writeonly">jsonschema:writeOnly</a></td></tr>
+<tr><td>boolean</td><td><a href="#jsonschema-booleanschema">jsonschema:BooleanSchema</a></td></tr></tbody></table></section>
     
 </body>
 

--- a/ontology/jsonschema.template.html
+++ b/ontology/jsonschema.template.html
@@ -2,12 +2,12 @@
 <html>
 
 <head>
-    <meta charset='utf-8'>
+    <meta charset="utf-8">
     <title>JSON Schema in RDF</title>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
-    <script class='remove'>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script class="remove">
         var respecConfig = {
-            specStatus: "WG-NOTE",
+            specStatus: "ED",
             editors: [{
                 name: "Victor Charpenay"
             }, {
@@ -15,8 +15,21 @@
             }, {
                 name: "María Poveda Villalón"
             }],
-            edDraftURI: "http://github.com/w3c/wot-thing-description",
-            shortName: "wot-td-ontology"
+            edDraftURI: "http://www.w3.org/2019/wot/json-schema",
+            shortName: "json-schema-in-rdf",
+            localBiblio: {
+                "json-schema-validation": {
+                    title: "JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
+                    , href: "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01"
+                    , authors: [
+                        "Austin Wright",
+                        "Henry Andrews",
+                        "Geraint Luff"
+                    ]
+                    , status: "Internet-Draft"
+                    , publisher: "IETF"
+                }
+            }
         };
     </script>
     <style>
@@ -55,18 +68,45 @@
 </head>
 
 <body>
-    <section id='abstract'>
+    <section id="abstract">
         <p>
-            This is required.
+            This document introduces an RDF vocabulary for JSON schema definitions.
+            This vocabulary provides a stable namespace IRI for JSON schema keywords,
+            as well as simple axioms, defined against schema.org's meta-model. Various
+            examples on how to use the vocabulary are also introduced, e.g. to annotate
+            schemas with JSON-LD metadata or to embed schema annotations inside RDF
+            graphs.
         </p>
     </section>
-    <section id='sotd'>
-        <p>
-            This is required.
+    <section id="sotd">
+        <p class="ednote" title="The W3C WoT WG is asking for feedback">
+            Please contribute to this draft using the <a href="https://github.com/w3c/wot-thing-description/issues">GitHub Issue</a> feature of the <a href="https://github.com/w3c/wot-thing-description/">WoT Thing Description</a> repository.
         </p>
     </section>
     <section>
         <h2>Introduction</h2>
+        <p>
+            JSON schema is a popular schema language for JSON documents
+            [[json-schema-validation]]. This vocabulary includes the main terms
+            defined by JSON schema in order to represent schema definitions in RDF.
+            Besides providing a stable namespace IRI for JSON schema terms, this
+            vocabulary also includes axioms based on schema.org's meta-model. Its
+            design favors simplicity of use over completeness.
+        </p>
+
+        <p>
+            Representing JSON schema in RDF was originally intended to be used
+            as part of the W3C Web of Things (WoT) framework and in particular in
+            the Thing Description model [[wot-thing-description]]. However,
+            processing JSON schema in RDF is not limited to WoT. Other use cases
+            include:
+        </p>
+
+        <ul>
+            <li>Alignment of schema definitions with RDF vocabularies and RDF shapes</li>
+            <li>Rule-based validation or transformation of JSON data</li>
+            <li>Integration of various forms of data specfications, including JSON Schema</li>
+        </ul>
     </section>
 
     {axioms}

--- a/ontology/td.html
+++ b/ontology/td.html
@@ -3,11 +3,11 @@
 
 <head>
     <meta charset='utf-8'>
-    <title>Thing Description (TD) Ontology</title>
+    <title>Web of Things (WoT) Thing Description Ontology</title>
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "WG-NOTE",
+            specStatus: "ED",
             editors: [{
                 name: "Victor Charpenay"
             }, {
@@ -15,7 +15,7 @@
             }, {
                 name: "María Poveda Villalón"
             }],
-            edDraftURI: "http://github.com/w3c/wot-thing-description",
+            edDraftURI: "http://www.w3.org/2019/wot/td",
             shortName: "wot-td-ontology"
         };
     </script>
@@ -55,21 +55,35 @@
 </head>
 
 <body>
-    <section id='abstract'>
+    <section id="abstract">
         <p>
-            This is required.
+            The Thing Description (TD) ontology is an RDF axiomatization of the TD information model,
+            one of the building blocks of the Web of Things (WoT). Besides providing an alternative
+            to the standard JSON representation format for TD documents, the TD ontology can also
+            be used to process contextual information on Things and for alignments with other
+            WoT-related ontologies.
         </p>
     </section>
-    <section id='sotd'>
-        <p>
-            This is required.
+    <section id="sotd">
+        <p class="ednote" title="The W3C WoT WG is asking for feedback">
+            Please contribute to this draft using the <a href="https://github.com/w3c/wot-thing-description/issues">GitHub Issue</a> feature of the <a href="https://github.com/w3c/wot-thing-description/">WoT Thing Description</a> repository.
         </p>
     </section>
     <section>
         <h2>Introduction</h2>
+        <p>
+            The TD ontology is an idiomatic RDF axiomatization of the TD information model [[wot-thing-description]],
+            which can be used to describe WoT things and their interaction affordances. The TD ontology imports
+            the <a href="https://www.w3.org/2019/wot/hypermedia">hypermedia controls</a> ontology.
+            However, although the TD information model also includes terms for data schemas and security
+            configurations, the TD ontology does not force the use of the corresponding
+            <a href="https://www.w3.org/2019/wot/json-schema">JSON schema</a> and
+            <a href="https://www.w3.org/2019/wot/security">WoT security</a> vocabularies. Other schema languages
+            like SHACL [[shacl]] can thus be leveraged to describe WoT Things.
+        </p>
     </section>
 
-    <section><h2>Axiomatization</h2><section><h3>Overview of Classes and Properties</h3><div  class="azlist"><p>Classes: <a href="#td-actionaffordance">td:ActionAffordance</a> , <a href="#td-propertyaffordance">td:PropertyAffordance</a> , <a href="#td-link">td:Link</a> , <a href="#td-thing">td:Thing</a> , <a href="#td-interactionaffordance">td:InteractionAffordance</a> , <a href="#td-multilanguage">td:MultiLanguage</a> , <a href="#td-versioninfo">td:VersionInfo</a> , <a href="#td-eventaffordance">td:EventAffordance</a></p></div><div  class="azlist"><p>Object Properties: <a href="#td-hasuritemplatevariable">td:hasUriTemplateVariable</a> , <a href="#td-securitydefinitions">td:securityDefinitions</a> , <a href="#td-hascancellationschema">td:hasCancellationSchema</a> , <a href="#td-hassecurityconfiguration">td:hasSecurityConfiguration</a> , <a href="#td-haseventaffordance">td:hasEventAffordance</a> , <a href="#td-hassubscriptionschema">td:hasSubscriptionSchema</a> , <a href="#td-issafe">td:isSafe</a> , <a href="#td-titles">td:titles</a> , <a href="#td-hasnotificationschema">td:hasNotificationSchema</a> , <a href="#td-isidempotent">td:isIdempotent</a> , <a href="#td-descriptions">td:descriptions</a> , <a href="#td-haspropertyaffordance">td:hasPropertyAffordance</a> , <a href="#td-hasinteractionaffordance">td:hasInteractionAffordance</a> , <a href="#td-hasinputschema">td:hasInputSchema</a> , <a href="#td-haslink">td:hasLink</a> , <a href="#td-hasoutputschema">td:hasOutputSchema</a> , <a href="#td-hasform">td:hasForm</a> , <a href="#td-hasactionaffordance">td:hasActionAffordance</a></p></div><div  class="azlist"><p>Datatype Properties: <a href="#td-description">td:description</a> , <a href="#td-title">td:title</a> , <a href="#td-baseuri">td:baseUri</a> , <a href="#td-name">td:name</a> , <a href="#td-modified">td:modified</a> , <a href="#td-isobservable">td:isObservable</a> , <a href="#td-instance">td:instance</a> , <a href="#td-created">td:created</a></p></div></section><section><h3>Classes</h3><section class="specterm"><h4><a href="#td-actionaffordance">td:ActionAffordance</a></h4><p>IRI: https://www.w3.org/2019/wot/td#ActionAffordance</p><p><strong>a OWL Class</strong></p><em>ActionAffordance</em> - <span>An Interaction Affordance that allows to invoke a function of the Thing, which manipulates state (e.g., toggling a lamp on or off) or triggers a process on the Thing (e.g., dimm a lamp over time).</span><table><tbody><tr><th>Sub-class of</th><td><a href="#td-interactionaffordance">td:InteractionAffordance</a></td></tr></tbody></table></section>
+    <section><h2>Axiomatization</h2><section><h3>Overview of Classes and Properties</h3><div  class="azlist"><p>Classes: <a href="#td-actionaffordance">td:ActionAffordance</a> , <a href="#td-propertyaffordance">td:PropertyAffordance</a> , <a href="#td-link">td:Link</a> , <a href="#td-thing">td:Thing</a> , <a href="#td-interactionaffordance">td:InteractionAffordance</a> , <a href="#td-multilanguage">td:MultiLanguage</a> , <a href="#td-versioninfo">td:VersionInfo</a> , <a href="#td-eventaffordance">td:EventAffordance</a></p></div><div  class="azlist"><p>Object Properties: <a href="#td-hasuritemplatevariable">td:hasUriTemplateVariable</a> , <a href="#td-securitydefinitions">td:securityDefinitions</a> , <a href="#td-hascancellationschema">td:hasCancellationSchema</a> , <a href="#td-hassecurityconfiguration">td:hasSecurityConfiguration</a> , <a href="#td-haseventaffordance">td:hasEventAffordance</a> , <a href="#td-hassubscriptionschema">td:hasSubscriptionSchema</a> , <a href="#td-issafe">td:isSafe</a> , <a href="#td-titles">td:titles</a> , <a href="#td-hasnotificationschema">td:hasNotificationSchema</a> , <a href="#td-isidempotent">td:isIdempotent</a> , <a href="#td-descriptions">td:descriptions</a> , <a href="#td-haspropertyaffordance">td:hasPropertyAffordance</a> , <a href="#td-hasinteractionaffordance">td:hasInteractionAffordance</a> , <a href="#td-hasinputschema">td:hasInputSchema</a> , <a href="#td-haslink">td:hasLink</a> , <a href="#td-hasoutputschema">td:hasOutputSchema</a> , <a href="#td-hasform">td:hasForm</a> , <a href="#td-hasactionaffordance">td:hasActionAffordance</a></p></div><div  class="azlist"><p>Datatype Properties: <a href="#td-description">td:description</a> , <a href="#td-title">td:title</a> , <a href="#td-baseuri">td:baseUri</a> , <a href="#td-name">td:name</a> , <a href="#td-modified">td:modified</a> , <a href="#td-isobservable">td:isObservable</a> , <a href="#td-instance">td:instance</a> , <a href="#td-created">td:created</a></p></div></section><section><h3>Classes</h3><section class="specterm"><h4><a href="#td-actionaffordance">td:ActionAffordance</a></h4><p>IRI: https://www.w3.org/2019/wot/td#ActionAffordance</p><p><strong>a OWL Class</strong></p><em>ActionAffordance</em> - <span>An Interaction Affordance that allows to invoke a function of the Thing, which manipulates state (e.g., toggling a lamp on or off) or triggers a process on the Thing (e.g., dim a lamp over time).</span><table><tbody><tr><th>Sub-class of</th><td><a href="#td-interactionaffordance">td:InteractionAffordance</a></td></tr></tbody></table></section>
 <section class="specterm"><h4><a href="#td-propertyaffordance">td:PropertyAffordance</a></h4><p>IRI: https://www.w3.org/2019/wot/td#PropertyAffordance</p><p><strong>a OWL Class</strong></p><em>PropertyAffordance</em> - <span>An Interaction Affordance that exposes state of the Thing. This state can then be retrieved (read) and optionally updated (write). Things can also choose to make Properties observable by pushing the new state after a change.</span><table><tbody><tr><th>Sub-class of</th><td><a href="#td-dataschema">td:DataSchema</a></td></tr>
 <tr><th>Sub-class of</th><td><a href="#td-interactionaffordance">td:InteractionAffordance</a></td></tr></tbody></table></section>
 <section class="specterm"><h4><a href="#td-link">td:Link</a></h4><p>IRI: https://www.w3.org/2019/wot/td#Link</p><p><strong>a OWL Class</strong></p><em>Link</em> - <span>A Web link, as specified by IETF RFC 8288 (https://tools.ietf.org/html/rfc8288).</span><table><tbody></tbody></table></section>
@@ -99,41 +113,41 @@
 <section class="specterm"><h4><a href="#td-name">td:name</a></h4><p>IRI: https://www.w3.org/2019/wot/td#name</p><p><strong>a OWL Class</strong></p><em>name</em> - <span>Indexing property to store entity names when serializing them in a JSON-LD @index container.</span><table><tbody></tbody></table></section>
 <section class="specterm"><h4><a href="#td-modified">td:modified</a></h4><p>IRI: https://www.w3.org/2019/wot/td#modified</p><p><strong>a OWL Class</strong></p><em>modified</em> - <span>Provides information when the TD instance was last modified.</span><table><tbody></tbody></table></section>
 <section class="specterm"><h4><a href="#td-isobservable">td:isObservable</a></h4><p>IRI: https://www.w3.org/2019/wot/td#isObservable</p><p><strong>a OWL Class</strong></p><em>isObservable</em> - <span>A hint that indicates whether Servients hosting the Thing and Intermediaries should provide a Protocol Binding that supports the <code>observeproperty</code> operation for this Property.</span><table><tbody></tbody></table></section>
-<section class="specterm"><h4><a href="#td-instance">td:instance</a></h4><p>IRI: https://www.w3.org/2019/wot/td#instance</p><p><strong>a OWL Class</strong></p><em>instance</em> - <span>Provides a version identicator of this TD instance.</span><table><tbody></tbody></table></section>
-<section class="specterm"><h4><a href="#td-created">td:created</a></h4><p>IRI: https://www.w3.org/2019/wot/td#created</p><p><strong>a OWL Class</strong></p><em>created</em> - <span>Provides information when the TD instance was created.</span><table><tbody></tbody></table></section></section></section><section><h2>Term Mapping</h2><table><thead><tr><th>JSON String</th><th>Ontology Term</th></tr></thead><tbody><tr><td>output</td><td><a href="#td-hasoutputschema">td:hasOutputSchema</a></td></tr>
-<tr><td>instance</td><td><a href="#td-instance">td:instance</a></td></tr>
-<tr><td>td</td><td><a href="#td-">td:</a></td></tr>
-<tr><td>events</td><td><a href="#td-haseventaffordance">td:hasEventAffordance</a></td></tr>
-<tr><td>uriVariables</td><td><a href="#td-hasuritemplatevariable">td:hasUriTemplateVariable</a></td></tr>
-<tr><td>ActionAffordance</td><td><a href="#td-actionaffordance">td:ActionAffordance</a></td></tr>
-<tr><td>subscription</td><td><a href="#td-hassubscriptionschema">td:hasSubscriptionSchema</a></td></tr>
-<tr><td>InteractionAffordance</td><td><a href="#td-interactionaffordance">td:InteractionAffordance</a></td></tr>
-<tr><td>idempotent</td><td><a href="#td-isidempotent">td:isIdempotent</a></td></tr>
-<tr><td>created</td><td><a href="#td-created">td:created</a></td></tr>
-<tr><td>base</td><td><a href="#td-baseuri">td:baseUri</a></td></tr>
-<tr><td>modified</td><td><a href="#td-modified">td:modified</a></td></tr>
-<tr><td>version</td><td><a href="#td-versioninfo">td:versionInfo</a></td></tr>
-<tr><td>title</td><td><a href="#td-title">td:title</a></td></tr>
-<tr><td>Thing</td><td><a href="#td-thing">td:Thing</a></td></tr>
-<tr><td>data</td><td><a href="#td-hasnotificationschema">td:hasNotificationSchema</a></td></tr>
-<tr><td>EventAffordance</td><td><a href="#td-eventaffordance">td:EventAffordance</a></td></tr>
-<tr><td>input</td><td><a href="#td-hasinputschema">td:hasInputSchema</a></td></tr>
-<tr><td>forms</td><td><a href="#td-hasform">td:hasForm</a></td></tr>
+<section class="specterm"><h4><a href="#td-instance">td:instance</a></h4><p>IRI: https://www.w3.org/2019/wot/td#instance</p><p><strong>a OWL Class</strong></p><em>instance</em> - <span>Provides a version indicator of this TD instance.</span><table><tbody></tbody></table></section>
+<section class="specterm"><h4><a href="#td-created">td:created</a></h4><p>IRI: https://www.w3.org/2019/wot/td#created</p><p><strong>a OWL Class</strong></p><em>created</em> - <span>Provides information when the TD instance was created.</span><table><tbody></tbody></table></section></section></section><section><h2>Term Mapping</h2><table><thead><tr><th>JSON String</th><th>Ontology Term</th></tr></thead><tbody><tr><td>PropertyAffordance</td><td><a href="#td-propertyaffordance">td:PropertyAffordance</a></td></tr>
 <tr><td>description</td><td><a href="#td-description">td:description</a></td></tr>
-<tr><td>unit</td><td><a href="#td-defaultunit">td:defaultUnit</a></td></tr>
-<tr><td>name</td><td><a href="#td-name">td:name</a></td></tr>
-<tr><td>PropertyAffordance</td><td><a href="#td-propertyaffordance">td:PropertyAffordance</a></td></tr>
-<tr><td>properties</td><td><a href="#td-haspropertyaffordance">td:hasPropertyAffordance</a></td></tr>
-<tr><td>links</td><td><a href="#td-haslink">td:hasLink</a></td></tr>
-<tr><td>actions</td><td><a href="#td-hasactionaffordance">td:hasActionAffordance</a></td></tr>
+<tr><td>uriVariables</td><td><a href="#td-hasuritemplatevariable">td:hasUriTemplateVariable</a></td></tr>
+<tr><td>td</td><td><a href="#td-">td:</a></td></tr>
+<tr><td>instance</td><td><a href="#td-instance">td:instance</a></td></tr>
+<tr><td>Thing</td><td><a href="#td-thing">td:Thing</a></td></tr>
+<tr><td>support</td><td><a href="#td-supportcontact">td:supportContact</a></td></tr>
 <tr><td>cancellation</td><td><a href="#td-hascancellationschema">td:hasCancellationSchema</a></td></tr>
 <tr><td>securityDefinitions</td><td><a href="#td-securitydefinitions">td:securityDefinitions</a></td></tr>
-<tr><td>support</td><td><a href="#td-supportcontact">td:supportContact</a></td></tr>
 <tr><td>observable</td><td><a href="#td-isobservable">td:isObservable</a></td></tr>
-<tr><td>security</td><td><a href="#td-hassecurityconfiguration">td:hasSecurityConfiguration</a></td></tr>
-<tr><td>safe</td><td><a href="#td-issafe">td:isSafe</a></td></tr>
+<tr><td>forms</td><td><a href="#td-hasform">td:hasForm</a></td></tr>
+<tr><td>EventAffordance</td><td><a href="#td-eventaffordance">td:EventAffordance</a></td></tr>
 <tr><td>descriptions</td><td><a href="#td-descriptions">td:descriptions</a></td></tr>
-<tr><td>VersionInfo</td><td><a href="#td-versioninfo">td:VersionInfo</a></td></tr></tbody></table></section>
+<tr><td>idempotent</td><td><a href="#td-isidempotent">td:isIdempotent</a></td></tr>
+<tr><td>created</td><td><a href="#td-created">td:created</a></td></tr>
+<tr><td>unit</td><td><a href="#td-defaultunit">td:defaultUnit</a></td></tr>
+<tr><td>subscription</td><td><a href="#td-hassubscriptionschema">td:hasSubscriptionSchema</a></td></tr>
+<tr><td>output</td><td><a href="#td-hasoutputschema">td:hasOutputSchema</a></td></tr>
+<tr><td>name</td><td><a href="#td-name">td:name</a></td></tr>
+<tr><td>version</td><td><a href="#td-versioninfo">td:versionInfo</a></td></tr>
+<tr><td>ActionAffordance</td><td><a href="#td-actionaffordance">td:ActionAffordance</a></td></tr>
+<tr><td>VersionInfo</td><td><a href="#td-versioninfo">td:VersionInfo</a></td></tr>
+<tr><td>InteractionAffordance</td><td><a href="#td-interactionaffordance">td:InteractionAffordance</a></td></tr>
+<tr><td>actions</td><td><a href="#td-hasactionaffordance">td:hasActionAffordance</a></td></tr>
+<tr><td>modified</td><td><a href="#td-modified">td:modified</a></td></tr>
+<tr><td>base</td><td><a href="#td-baseuri">td:baseUri</a></td></tr>
+<tr><td>events</td><td><a href="#td-haseventaffordance">td:hasEventAffordance</a></td></tr>
+<tr><td>links</td><td><a href="#td-haslink">td:hasLink</a></td></tr>
+<tr><td>input</td><td><a href="#td-hasinputschema">td:hasInputSchema</a></td></tr>
+<tr><td>security</td><td><a href="#td-hassecurityconfiguration">td:hasSecurityConfiguration</a></td></tr>
+<tr><td>data</td><td><a href="#td-hasnotificationschema">td:hasNotificationSchema</a></td></tr>
+<tr><td>properties</td><td><a href="#td-haspropertyaffordance">td:hasPropertyAffordance</a></td></tr>
+<tr><td>safe</td><td><a href="#td-issafe">td:isSafe</a></td></tr>
+<tr><td>title</td><td><a href="#td-title">td:title</a></td></tr></tbody></table></section>
     
     <section>
         <h2>Examples</h2>

--- a/ontology/td.template.html
+++ b/ontology/td.template.html
@@ -3,11 +3,11 @@
 
 <head>
     <meta charset='utf-8'>
-    <title>Thing Description (TD) Ontology</title>
+    <title>Web of Things (WoT) Thing Description Ontology</title>
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "WG-NOTE",
+            specStatus: "ED",
             editors: [{
                 name: "Victor Charpenay"
             }, {
@@ -15,7 +15,7 @@
             }, {
                 name: "María Poveda Villalón"
             }],
-            edDraftURI: "http://github.com/w3c/wot-thing-description",
+            edDraftURI: "http://www.w3.org/2019/wot/td",
             shortName: "wot-td-ontology"
         };
     </script>
@@ -55,18 +55,32 @@
 </head>
 
 <body>
-    <section id='abstract'>
+    <section id="abstract">
         <p>
-            This is required.
+            The Thing Description (TD) ontology is an RDF axiomatization of the TD information model,
+            one of the building blocks of the Web of Things (WoT). Besides providing an alternative
+            to the standard JSON representation format for TD documents, the TD ontology can also
+            be used to process contextual information on Things and for alignments with other
+            WoT-related ontologies.
         </p>
     </section>
-    <section id='sotd'>
-        <p>
-            This is required.
+    <section id="sotd">
+        <p class="ednote" title="The W3C WoT WG is asking for feedback">
+            Please contribute to this draft using the <a href="https://github.com/w3c/wot-thing-description/issues">GitHub Issue</a> feature of the <a href="https://github.com/w3c/wot-thing-description/">WoT Thing Description</a> repository.
         </p>
     </section>
     <section>
         <h2>Introduction</h2>
+        <p>
+            The TD ontology is an idiomatic RDF axiomatization of the TD information model [[wot-thing-description]],
+            which can be used to describe WoT things and their interaction affordances. The TD ontology imports
+            the <a href="https://www.w3.org/2019/wot/hypermedia">hypermedia controls</a> ontology.
+            However, although the TD information model also includes terms for data schemas and security
+            configurations, the TD ontology does not force the use of the corresponding
+            <a href="https://www.w3.org/2019/wot/json-schema">JSON schema</a> and
+            <a href="https://www.w3.org/2019/wot/security">WoT security</a> vocabularies. Other schema languages
+            like SHACL [[shacl]] can thus be leveraged to describe WoT Things.
+        </p>
     </section>
 
     {axioms}

--- a/ontology/wotsec.html
+++ b/ontology/wotsec.html
@@ -2,21 +2,19 @@
 <html>
 
 <head>
-    <meta charset='utf-8'>
+    <meta charset="utf-8">
     <title>Web of Things (WoT) Security Ontology</title>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
-    <script class='remove'>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script class="remove">
         var respecConfig = {
-            specStatus: "WG-NOTE",
+            specStatus: "ED",
             editors: [{
                 name: "Victor Charpenay"
             }, {
-                name: "Maxime Lefrançois"
-            }, {
-                name: "María Poveda Villalón"
+                name: "Michael McCool"
             }],
-            edDraftURI: "http://github.com/w3c/wot-thing-description",
-            shortName: "wot-td-ontology"
+            edDraftURI: "https://www.w3.org/2019/wot/security",
+            shortName: "wot-security-ontology"
         };
     </script>
     <style>
@@ -55,14 +53,16 @@
 </head>
 
 <body>
-    <section id='abstract'>
+    <section id="abstract">
         <p>
-            This is required.
+            This document introduces an ontology for secuity schemes used in the Internet.
+            This ontology offers, among others, vocabulary to describe schemes such as
+            HTTP Basic, Digest, Bearer Tokens, and OAuth2.
         </p>
     </section>
-    <section id='sotd'>
-        <p>
-            This is required.
+    <section id="sotd">
+        <p class="ednote" title="The W3C WoT WG is asking for feedback">
+            Please contribute to this draft using the <a href="https://github.com/w3c/wot-thing-description/issues">GitHub Issue</a> feature of the <a href="https://github.com/w3c/wot-thing-description/">WoT Thing Description</a> repository.
         </p>
     </section>
     <section>
@@ -91,28 +91,28 @@
 <section class="specterm"><h4><a href="#wotsec-alg">wotsec:alg</a></h4><p>IRI: https://www.w3.org/2019/wot/security#alg</p><p><strong>a OWL Class</strong></p><em>alg</em> - <span>Encoding, encryption, or digest algorithm.</span><table><tbody></tbody></table></section>
 <section class="specterm"><h4><a href="#wotsec-flow">wotsec:flow</a></h4><p>IRI: https://www.w3.org/2019/wot/security#flow</p><p><strong>a OWL Class</strong></p><em>flow</em> - <span>Authorization flow.</span><table><tbody></tbody></table></section>
 <section class="specterm"><h4><a href="#wotsec-scheme">wotsec:scheme</a></h4><p>IRI: https://www.w3.org/2019/wot/security#scheme</p><p><strong>a OWL Class</strong></p><em>scheme</em> - <span>Identification of the security mechanism being configured.</span><table><tbody></tbody></table></section>
-<section class="specterm"><h4><a href="#wotsec-scopes">wotsec:scopes</a></h4><p>IRI: https://www.w3.org/2019/wot/security#scopes</p><p><strong>a OWL Class</strong></p><em>scopes</em> - <span>Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an <code>OAuth2SecurityScheme</code> active on that form.  <br/>This feature is at risk.</span><table><tbody></tbody></table></section></section></section><section><h2>Term Mapping</h2><table><thead><tr><th>JSON String</th><th>Ontology Term</th></tr></thead><tbody><tr><td>format</td><td><a href="#wotsec-format">wotsec:format</a></td></tr>
-<tr><td>bearer</td><td><a href="#wotsec-bearersecurityscheme">wotsec:BearerSecurityScheme</a></td></tr>
-<tr><td>nosec</td><td><a href="#wotsec-nosecurityscheme">wotsec:NoSecurityScheme</a></td></tr>
-<tr><td>wotsec</td><td><a href="#wotsec-">wotsec:</a></td></tr>
+<section class="specterm"><h4><a href="#wotsec-scopes">wotsec:scopes</a></h4><p>IRI: https://www.w3.org/2019/wot/security#scopes</p><p><strong>a OWL Class</strong></p><em>scopes</em> - <span>Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an <code>OAuth2SecurityScheme</code> active on that form.  <br/>This feature is at risk.</span><table><tbody></tbody></table></section></section></section><section><h2>Term Mapping</h2><table><thead><tr><th>JSON String</th><th>Ontology Term</th></tr></thead><tbody><tr><td>scopes</td><td><a href="#wotsec-scopes">wotsec:scopes</a></td></tr>
+<tr><td>authorization</td><td><a href="#wotsec-authorization">wotsec:authorization</a></td></tr>
 <tr><td>basic</td><td><a href="#wotsec-basicsecurityscheme">wotsec:BasicSecurityScheme</a></td></tr>
+<tr><td>wotsec</td><td><a href="#wotsec-">wotsec:</a></td></tr>
+<tr><td>in</td><td><a href="#wotsec-in">wotsec:in</a></td></tr>
+<tr><td>flow</td><td><a href="#wotsec-flow">wotsec:flow</a></td></tr>
+<tr><td>token</td><td><a href="#wotsec-token">wotsec:token</a></td></tr>
+<tr><td>public</td><td><a href="#wotsec-publicsecurityscheme">wotsec:PublicSecurityScheme</a></td></tr>
+<tr><td>bearer</td><td><a href="#wotsec-bearersecurityscheme">wotsec:BearerSecurityScheme</a></td></tr>
+<tr><td>qop</td><td><a href="#wotsec-qop">wotsec:qop</a></td></tr>
+<tr><td>cert</td><td><a href="#wotsec-certsecurityscheme">wotsec:CertSecurityScheme</a></td></tr>
+<tr><td>digest</td><td><a href="#wotsec-digestsecurityscheme">wotsec:DigestSecurityScheme</a></td></tr>
+<tr><td>proxy</td><td><a href="#wotsec-proxy">wotsec:proxy</a></td></tr>
 <tr><td>alg</td><td><a href="#wotsec-alg">wotsec:alg</a></td></tr>
 <tr><td>oauth2</td><td><a href="#wotsec-oauth2securityscheme">wotsec:OAuth2SecurityScheme</a></td></tr>
 <tr><td>psk</td><td><a href="#wotsec-psksecurityscheme">wotsec:PSKSecurityScheme</a></td></tr>
-<tr><td>identity</td><td><a href="#wotsec-identity">wotsec:identity</a></td></tr>
-<tr><td>public</td><td><a href="#wotsec-publicsecurityscheme">wotsec:PublicSecurityScheme</a></td></tr>
-<tr><td>cert</td><td><a href="#wotsec-certsecurityscheme">wotsec:CertSecurityScheme</a></td></tr>
-<tr><td>token</td><td><a href="#wotsec-token">wotsec:token</a></td></tr>
-<tr><td>authorization</td><td><a href="#wotsec-authorization">wotsec:authorization</a></td></tr>
-<tr><td>scopes</td><td><a href="#wotsec-scopes">wotsec:scopes</a></td></tr>
 <tr><td>pop</td><td><a href="#wotsec-popsecurityscheme">wotsec:PoPSecurityScheme</a></td></tr>
-<tr><td>in</td><td><a href="#wotsec-in">wotsec:in</a></td></tr>
-<tr><td>apikey</td><td><a href="#wotsec-apikeysecurityscheme">wotsec:APIKeySecurityScheme</a></td></tr>
-<tr><td>proxy</td><td><a href="#wotsec-proxy">wotsec:proxy</a></td></tr>
 <tr><td>refresh</td><td><a href="#wotsec-refresh">wotsec:refresh</a></td></tr>
-<tr><td>flow</td><td><a href="#wotsec-flow">wotsec:flow</a></td></tr>
-<tr><td>qop</td><td><a href="#wotsec-qop">wotsec:qop</a></td></tr>
-<tr><td>digest</td><td><a href="#wotsec-digestsecurityscheme">wotsec:DigestSecurityScheme</a></td></tr></tbody></table></section>
+<tr><td>format</td><td><a href="#wotsec-format">wotsec:format</a></td></tr>
+<tr><td>identity</td><td><a href="#wotsec-identity">wotsec:identity</a></td></tr>
+<tr><td>nosec</td><td><a href="#wotsec-nosecurityscheme">wotsec:NoSecurityScheme</a></td></tr>
+<tr><td>apikey</td><td><a href="#wotsec-apikeysecurityscheme">wotsec:APIKeySecurityScheme</a></td></tr></tbody></table></section>
     
 </body>
 

--- a/ontology/wotsec.template.html
+++ b/ontology/wotsec.template.html
@@ -2,21 +2,19 @@
 <html>
 
 <head>
-    <meta charset='utf-8'>
+    <meta charset="utf-8">
     <title>Web of Things (WoT) Security Ontology</title>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
-    <script class='remove'>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script class="remove">
         var respecConfig = {
-            specStatus: "WG-NOTE",
+            specStatus: "ED",
             editors: [{
                 name: "Victor Charpenay"
             }, {
-                name: "Maxime Lefrançois"
-            }, {
-                name: "María Poveda Villalón"
+                name: "Michael McCool"
             }],
-            edDraftURI: "http://github.com/w3c/wot-thing-description",
-            shortName: "wot-td-ontology"
+            edDraftURI: "https://www.w3.org/2019/wot/security",
+            shortName: "wot-security-ontology"
         };
     </script>
     <style>
@@ -55,14 +53,16 @@
 </head>
 
 <body>
-    <section id='abstract'>
+    <section id="abstract">
         <p>
-            This is required.
+            This document introduces an ontology for secuity schemes used in the Internet.
+            This ontology offers, among others, vocabulary to describe schemes such as
+            HTTP Basic, Digest, Bearer Tokens, and OAuth2.
         </p>
     </section>
-    <section id='sotd'>
-        <p>
-            This is required.
+    <section id="sotd">
+        <p class="ednote" title="The W3C WoT WG is asking for feedback">
+            Please contribute to this draft using the <a href="https://github.com/w3c/wot-thing-description/issues">GitHub Issue</a> feature of the <a href="https://github.com/w3c/wot-thing-description/">WoT Thing Description</a> repository.
         </p>
     </section>
     <section>


### PR DESCRIPTION
Changed status to Editors' Drafts, fixed headers, and included basic text from #744.

This only affects the HTML files under the namespace IRIs, not the TD spec.