### PR TITLE
Remove heading 7.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -3335,12 +3335,6 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 }
 </pre>
 
-</section>
-
-<section>
-
-    <h3>Annotating Data Schemas</h3>
-
     <p>
         In many cases, context extension may be used to annotate pieces of a data schema, to be
         able to semantically process actual data during an interaction. For example, the internal

--- a/index.template.html
+++ b/index.template.html
@@ -2908,12 +2908,6 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 }
 </pre>
 
-</section>
-
-<section>
-
-    <h3>Annotating Data Schemas</h3>
-
     <p>
         In many cases, context extension may be used to annotate pieces of a data schema, to be
         able to semantically process actual data during an interaction. For example, the internal


### PR DESCRIPTION
This is an undo of a change introduced by @vcharpenay 

He added "7.2 Annotating Data Schemas" but then does not show how data schemas are annotated (which would be an `@type` alongside the `type` of JSON Schema).

This PR simply removes the wrong heading, but keeps the section text (basically reverts to the structure of the CR).