### PR TITLE
PR that moves WoT-Arch to informative references section

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,7 @@ a[href].internalDFN {
   Events (<a href="#eventaffordance"><code>EventAffordance</code></a> class) are used
   for the push model of communication where notifications,
   discrete events, or streams of values are sent asynchronously to the receiver.
-  See [[WOT-ARCHITECTURE]] for details.
+  See [[?WOT-ARCHITECTURE]] for details.
   </p>
   <p>
   In general, the TD provides metadata for different <a>Protocol Bindings</a>
@@ -709,7 +709,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
   <dfn>WoT Interface</dfn>,
   <dfn>WoT Runtime</dfn>,
   etc. is defined in <a href="https://www.w3.org/TR/wot-architecture/#terminology">Section 3</a>
-  of the WoT Architecture specification [[WOT-ARCHITECTURE]].
+  of the WoT Architecture specification [[?WOT-ARCHITECTURE]].
   </p>
 
   <p>
@@ -886,7 +886,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             <li>
                 the <em>core</em> TD <a>Vocabulary</a>, which reflects the
                 <a>Interaction Model</a> with the <a>Properties</a>, <a>Actions</a>, and <a>Events</a>
-                <a>Interaction Affordances</a> [[WOT-ARCHITECTURE]]
+                <a>Interaction Affordances</a> [[?WOT-ARCHITECTURE]]
             </li>
             <li>
                 the <em>Data Schema</em> <a>Vocabulary</a>, including (a subset of)
@@ -1466,7 +1466,7 @@ IANA HTTP content coding registry</a>.
 
 <p>The list of possible operation types of a form is fixed. As of this version of the specification, it only includes the
 well-known types necessary to implement the WoT interaction model described in
-[[WOT-ARCHITECTURE]]. Future versions of the standard may extend this list but
+[[?WOT-ARCHITECTURE]]. Future versions of the standard may extend this list but
 <span class="rfc2119-assertion" id="well-known-operation-types-only">
 operations types SHOULD NOT be arbitrarily set by servients.
 </span>
@@ -3588,7 +3588,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     Every form in a WoT Thing Description must have a submission target,
     given by the <code>href</code> member. The URI scheme of this
     submission target indicates what <a>Protocol Binding</a> the <a>Thing</a> implements
-    [[WOT-ARCHITECTURE]].
+    [[?WOT-ARCHITECTURE]].
     For instance, if the target starts with <code>http</code> or
     <code>https</code>, a <a>Consumer</a> can then infer the <a>Thing</a> implements the
     HTTP <a>Protocol Binding</a> and it should expect HTTP-specific terms in the

--- a/index.template.html
+++ b/index.template.html
@@ -399,7 +399,7 @@ a[href].internalDFN {
   Events (<a href="#eventaffordance"><code>EventAffordance</code></a> class) are used
   for the push model of communication where notifications,
   discrete events, or streams of values are sent asynchronously to the receiver.
-  See [[WOT-ARCHITECTURE]] for details.
+  See [[?WOT-ARCHITECTURE]] for details.
   </p>
   <p>
   In general, the TD provides metadata for different <a>Protocol Bindings</a>
@@ -601,7 +601,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
   <dfn>WoT Interface</dfn>,
   <dfn>WoT Runtime</dfn>,
   etc. is defined in <a href="https://www.w3.org/TR/wot-architecture/#terminology">Section 3</a>
-  of the WoT Architecture specification [[WOT-ARCHITECTURE]].
+  of the WoT Architecture specification [[?WOT-ARCHITECTURE]].
   </p>
 
   <p>
@@ -778,7 +778,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             <li>
                 the <em>core</em> TD <a>Vocabulary</a>, which reflects the
                 <a>Interaction Model</a> with the <a>Properties</a>, <a>Actions</a>, and <a>Events</a>
-                <a>Interaction Affordances</a> [[WOT-ARCHITECTURE]]
+                <a>Interaction Affordances</a> [[?WOT-ARCHITECTURE]]
             </li>
             <li>
                 the <em>Data Schema</em> <a>Vocabulary</a>, including (a subset of)
@@ -3161,7 +3161,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     Every form in a WoT Thing Description must have a submission target,
     given by the <code>href</code> member. The URI scheme of this
     submission target indicates what <a>Protocol Binding</a> the <a>Thing</a> implements
-    [[WOT-ARCHITECTURE]].
+    [[?WOT-ARCHITECTURE]].
     For instance, if the target starts with <code>http</code> or
     <code>https</code>, a <a>Consumer</a> can then infer the <a>Thing</a> implements the
     HTTP <a>Protocol Binding</a> and it should expect HTTP-specific terms in the

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -345,7 +345,7 @@ the value assigned to op MUST be  <code>invokeaction</code>.
 """
 <p>The list of possible operation types of a form is fixed. As of this version of the specification, it only includes the
 well-known types necessary to implement the WoT interaction model described in
-[[WOT-ARCHITECTURE]]. Future versions of the standard may extend this list but
+[[?WOT-ARCHITECTURE]]. Future versions of the standard may extend this list but
 <span class=\"rfc2119-assertion\" id=\"well-known-operation-types-only\">
 operations types SHOULD NOT be arbitrarily set by servients.
 </span>


### PR DESCRIPTION
requested PR from today's TD meeting. Also see https://github.com/w3c/wot-thing-description/pull/820


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/821.html" title="Last updated on Oct 18, 2019, 5:52 AM UTC (f959c1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/821/aa525e4...f959c1e.html" title="Last updated on Oct 18, 2019, 5:52 AM UTC (f959c1e)">Diff</a>