### PR TITLE
WIP: Define Terminology Section 3 as non-normative

### DIFF
--- a/index.html
+++ b/index.html
@@ -693,7 +693,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
 </section>
 
-<section id="terminology" class="normative"> 
+<section id="terminology" class="informative"> 
 <h2>Terminology</h2>
 
   <p>The fundamental WoT terminology such as

--- a/index.template.html
+++ b/index.template.html
@@ -585,7 +585,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
 </section>
 
-<section id="terminology" class="normative"> 
+<section id="terminology" class="informative"> 
 <h2>Terminology</h2>
 
   <p>The fundamental WoT terminology such as


### PR DESCRIPTION
This PR defines the terminology section as non-normative.

However, it must be decided whether this should really be the case. Depends on the decision of the Arch document whether the terminology section is also informative.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/827.html" title="Last updated on Oct 16, 2019, 2:53 PM UTC (32679b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/827/72188d1...32679b0.html" title="Last updated on Oct 16, 2019, 2:53 PM UTC (32679b0)">Diff</a>