### PR TITLE
"HTTP Protocol Binding" is now "Protocol Binding based on HTTP".

### DIFF
--- a/index.html
+++ b/index.html
@@ -3598,7 +3598,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     [[WOT-ARCHITECTURE]].
     For instance, if the target starts with <code>http</code> or
     <code>https</code>, a <a>Consumer</a> can then infer the <a>Thing</a> implements the
-    HTTP <a>Protocol Binding</a> and it should expect HTTP-specific terms in the
+    <a>Protocol Binding</a> based on HTTP and it should expect HTTP-specific terms in the
     form instance (see next section, <a href="#http-binding-assertions"></a>).
     <ul>
         <li>
@@ -3619,25 +3619,26 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
   </p>
 
   <section id="http-binding-assertions">
-    <h4>HTTP Protocol Binding</h4>
+    <h4>Protocol Binding based on HTTP</h4>
 
     <p>
-        Per default the Thing Description supports the HTTP <a>Protocol Binding</a> and
-        includes the HTTP RDF vocabulary definitions from <em>HTTP Vocabulary in RDF 1.0</em> [[?HTTP-in-RDF10]].
+        Per default the Thing Description supports the <a>Protocol Binding</a> based on HTTP 
+        by including the HTTP RDF vocabulary definitions from <em>HTTP Vocabulary in RDF 1.0</em> [[?HTTP-in-RDF10]].
         This vocabulary can be 
         directly used within TD instances by the usage of the prefix <code>htv</code>, which 
         points to <code>http://www.w3.org/2011/http#</code>. 
+        Further details of <a>Protocol Binding</a> based on HTTP can be found in [[?WOT-BINDING-TEMPLATES]].
     </p>
     <p>
-        To interact with a <a>Thing</a> that implements the HTTP <a>Protocol Binding</a>, a <a>Consumer</a>
+        To interact with a <a>Thing</a> that implements the <a>Protocol Binding</a> based on HTTP, a <a>Consumer</a>
         needs to know what HTTP method to use when submitting a form. In the general case,
         a Thing Description can explicitly include a term indicating the method, i.e.,
         <code>htv:methodName</code>. For the
-        sake of conciseness, the HTTP <a>Protocol Binding</a> defines <a>Default Values</a> for each operation type,
+        sake of conciseness, the <a>Protocol Binding</a> based on HTTP defines <a>Default Values</a> for each operation type,
         which also aims at convergence of the methods expected by <a>Things</a> (e.g., GET to read, PUT to write).
         <span class="rfc2119-assertion" id="td-default-http-method">
-            When no method is indicated in a form representing an HTTP
-            <a>Protocol Binding</a>, a <a>Default Value</a> MUST be assumed as shown in
+            When no method is indicated in a form representing an <a>Protocol Binding</a> based on HTTP, 
+            a <a>Default Value</a> MUST be assumed as shown in
             the following table.
         </span>
     </p>
@@ -3682,13 +3683,15 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </table>
 
     <p>
-        For example, the following <a>Default Values</a> should be assumed for forms in the introductory TD example:
+        For example, the <a href="#simple-thing-description-sample">Example 1</a> in <a href="#introduction"></a>
+        does not contain operation types and HTTP methods in the forms. 
+        The following <a>Default Values</a> should be assumed for the forms in the <a href="#simple-thing-description-sample">Example 1</a>:
     </p>
 
     <aside class="example with-default">
             <div class="with-default-control">
                 <input type="checkbox">
-                <span><i>with default HTTP Protocol Binding values</i></span>
+                <span><i>with default values for Protocol Binding based on HTTP</i></span>
             </div>
             <pre>{
     "@context": "https://www.w3.org/2019/wot/td/v1",

--- a/index.template.html
+++ b/index.template.html
@@ -3171,7 +3171,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     [[WOT-ARCHITECTURE]].
     For instance, if the target starts with <code>http</code> or
     <code>https</code>, a <a>Consumer</a> can then infer the <a>Thing</a> implements the
-    HTTP <a>Protocol Binding</a> and it should expect HTTP-specific terms in the
+    <a>Protocol Binding</a> based on HTTP and it should expect HTTP-specific terms in the
     form instance (see next section, <a href="#http-binding-assertions"></a>).
     <ul>
         <li>
@@ -3192,25 +3192,26 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
   </p>
 
   <section id="http-binding-assertions">
-    <h4>HTTP Protocol Binding</h4>
+    <h4>Protocol Binding based on HTTP</h4>
 
     <p>
-        Per default the Thing Description supports the HTTP <a>Protocol Binding</a> and
-        includes the HTTP RDF vocabulary definitions from <em>HTTP Vocabulary in RDF 1.0</em> [[?HTTP-in-RDF10]].
+        Per default the Thing Description supports the <a>Protocol Binding</a> based on HTTP 
+        by including the HTTP RDF vocabulary definitions from <em>HTTP Vocabulary in RDF 1.0</em> [[?HTTP-in-RDF10]].
         This vocabulary can be 
         directly used within TD instances by the usage of the prefix <code>htv</code>, which 
         points to <code>http://www.w3.org/2011/http#</code>. 
+        Further details of <a>Protocol Binding</a> based on HTTP can be found in [[?WOT-BINDING-TEMPLATES]].
     </p>
     <p>
-        To interact with a <a>Thing</a> that implements the HTTP <a>Protocol Binding</a>, a <a>Consumer</a>
+        To interact with a <a>Thing</a> that implements the <a>Protocol Binding</a> based on HTTP, a <a>Consumer</a>
         needs to know what HTTP method to use when submitting a form. In the general case,
         a Thing Description can explicitly include a term indicating the method, i.e.,
         <code>htv:methodName</code>. For the
-        sake of conciseness, the HTTP <a>Protocol Binding</a> defines <a>Default Values</a> for each operation type,
+        sake of conciseness, the <a>Protocol Binding</a> based on HTTP defines <a>Default Values</a> for each operation type,
         which also aims at convergence of the methods expected by <a>Things</a> (e.g., GET to read, PUT to write).
         <span class="rfc2119-assertion" id="td-default-http-method">
-            When no method is indicated in a form representing an HTTP
-            <a>Protocol Binding</a>, a <a>Default Value</a> MUST be assumed as shown in
+            When no method is indicated in a form representing an <a>Protocol Binding</a> based on HTTP, 
+            a <a>Default Value</a> MUST be assumed as shown in
             the following table.
         </span>
     </p>
@@ -3255,13 +3256,15 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </table>
 
     <p>
-        For example, the following <a>Default Values</a> should be assumed for forms in the introductory TD example:
+        For example, the <a href="#simple-thing-description-sample">Example 1</a> in <a href="#introduction"></a>
+        does not contain operation types and HTTP methods in the forms. 
+        The following <a>Default Values</a> should be assumed for the forms in the <a href="#simple-thing-description-sample">Example 1</a>:
     </p>
 
     <aside class="example with-default">
             <div class="with-default-control">
                 <input type="checkbox">
-                <span><i>with default HTTP Protocol Binding values</i></span>
+                <span><i>with default values for Protocol Binding based on HTTP</i></span>
             </div>
             <pre>{
     "@context": "https://www.w3.org/2019/wot/td/v1",


### PR DESCRIPTION
This is to address issue #791 .


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/takuki/wot-thing-description/pull/828.html" title="Last updated on Oct 17, 2019, 1:28 AM UTC (e2f8b62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/828/72188d1...takuki:e2f8b62.html" title="Last updated on Oct 17, 2019, 1:28 AM UTC (e2f8b62)">Diff</a>