### PR TITLE
List td-writeall-consumer as at-risk

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,6 +420,7 @@ a[href].internalDFN {
         <code>implicit</code>, <code>password</code>, and <code>client</code> flows in <a href="#oauth2securityscheme"></a>.
       </li>
       <li>All default values related to the above in <a href="#sec-default-values"></a>.</li>
+      <li>A <a href="#td-writeall-consumer">behavioral assertion</a> for <code>writeallproperties</code> that allows rejection of incomplete writes.</li>
     </ul>
   </section>
 

--- a/index.template.html
+++ b/index.template.html
@@ -369,6 +369,7 @@ a[href].internalDFN {
         <code>implicit</code>, <code>password</code>, and <code>client</code> flows in <a href="#oauth2securityscheme"></a>.
       </li>
       <li>All default values related to the above in <a href="#sec-default-values"></a>.</li>
+      <li>A <a href="#td-writeall-consumer">behavioral assertion</a> for <code>writeallproperties</code> that allows rejection of incomplete writes.</li>
     </ul>
   </section>
 

--- a/testing/inputs/results/template.csv
+++ b/testing/inputs/results/template.csv
@@ -78,7 +78,6 @@
 "td-default-alg","null",
 "td-default-alg-pop","null",
 "td-default-contentType","null",
-"td-default-flow","null",
 "td-default-format","null",
 "td-default-format-pop","null",
 "td-default-http-method","null",
@@ -311,4 +310,5 @@
 "td-vocab-version--Thing","null",
 "td-vocab-writeOnly--DataSchema","null",
 "td-vocabulary-defaults","null",
+"td-writeall-consumer","null",
 "well-known-operation-types-only","null",


### PR DESCRIPTION
A new assertion was added, td-writeall-consumer, but there is no test case for it, so it shows up as at-risk in the document.  The set of at-risk items needs to be explicitly listed in the "Status of This Document".   This PR does that (note that a previous update of the IR rendering also fixed the CSS so the at-risk items are highlighted...).