### PR TITLE
References to semantic processing made consistent (for issue #846)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1053,7 +1053,8 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             all <a>Vocabulary Terms</a> involved in the <a>TD Information Model</a> as RDF
             resources, so as to integrate them in a larger model of the physical world
             (an ontology).
-            For details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+            For details about semantic processing, please refer to 
+            <a href="#json-ld-ctx-usage"></a> and the documentation under the namespace IRIs, e.g.,
             <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>.
         </p>
 
@@ -1266,7 +1267,8 @@ where a sequence of three numbers separated by a dot indicates the major version
         that data schema definitions within Thing Description instances are not limited to this defined subset and may use additional terms
         found in JSON Schema using a <a>TD Context Extension</a> for the additional terms as described in
         <a href="#sec-context-extensions"></a>, otherwise these terms are semantically ignored by <a>TD Processors</a>
-        (for details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+        (for details about semantic processing, please refer to 
+        <a href="#json-ld-ctx-usage"></a> and the documentation under the namespace IRIs, e.g.,
         <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
       </p>
       <p>A data schema is an abstract notation for data contained in data formats. 
@@ -1686,7 +1688,8 @@ to the <a>Consumer</a>.
   in order to streamline semantic evaluation.
   Hence, the TD representation format can be processed either as raw JSON
   or with a JSON-LD 1.1 processor
-  (for details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+  (for details about semantic processing, please refer to 
+  <a href="#json-ld-ctx-usage"></a> and the documentation under the namespace IRIs, e.g.,
   <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
   </p>
 
@@ -2576,8 +2579,8 @@ In summary, this requires the following:
                     "type": "number",
                     "minimum": 0.0,
                     "maximum": 100.0
-                    },
-                    "rgb": {
+                },
+                "rgb": {
                     "type": "array",
                     "items" : {
                         "type" : "number",

--- a/index.template.html
+++ b/index.template.html
@@ -1002,7 +1002,8 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             all <a>Vocabulary Terms</a> involved in the <a>TD Information Model</a> as RDF
             resources, so as to integrate them in a larger model of the physical world
             (an ontology).
-            For details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+            For details about semantic processing, please refer to 
+            <a href="#json-ld-ctx-usage"></a> and the documentation under the namespace IRIs, e.g.,
             <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>.
         </p>
 
@@ -1037,7 +1038,8 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         that data schema definitions within Thing Description instances are not limited to this defined subset and may use additional terms
         found in JSON Schema using a <a>TD Context Extension</a> for the additional terms as described in
         <a href="#sec-context-extensions"></a>, otherwise these terms are semantically ignored by <a>TD Processors</a>
-        (for details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+        (for details about semantic processing, please refer to 
+        <a href="#json-ld-ctx-usage"></a> and the documentation under the namespace IRIs, e.g.,
         <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
       </p>
       <p>A data schema is an abstract notation for data contained in data formats. 
@@ -1316,7 +1318,8 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
   in order to streamline semantic evaluation.
   Hence, the TD representation format can be processed either as raw JSON
   or with a JSON-LD 1.1 processor
-  (for details about semantic processing, please refer to the documentation under the namespace IRIs, e.g.,
+  (for details about semantic processing, please refer to 
+  <a href="#json-ld-ctx-usage"></a> and the documentation under the namespace IRIs, e.g.,
   <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
   </p>
 


### PR DESCRIPTION
References to semantic processing were present in multiple places. 
They were previously inconsistent. This PR fixes this inconsistency.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/takuki/wot-thing-description/pull/852.html" title="Last updated on Nov 28, 2019, 12:31 AM UTC (46360c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/852/a80bdd2...takuki:46360c6.html" title="Last updated on Nov 28, 2019, 12:31 AM UTC (46360c6)">Diff</a>