### PR TITLE
WIP: Fix #839: Clarify DataSchema vs contentType

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,24 +379,24 @@ a[href].internalDFN {
 </head>
 <body>
 
-  
+
 
   <section id="abstract">
   <p>
-  This document describes a formal model and a common representation 
-  for a Web of Things (WoT) Thing Description. 
+  This document describes a formal model and a common representation
+  for a Web of Things (WoT) Thing Description.
   A Thing Description describes the metadata and interfaces of <a>Things</a>,
   where a <a>Thing</a> is an abstraction of a physical or virtual entity that
-  provides interactions to and participates in the Web of Things. 
-  Thing Descriptions provide a set of interactions based on a small vocabulary 
-  that makes it possible both to integrate diverse devices and 
-  to allow diverse applications to interoperate. 
+  provides interactions to and participates in the Web of Things.
+  Thing Descriptions provide a set of interactions based on a small vocabulary
+  that makes it possible both to integrate diverse devices and
+  to allow diverse applications to interoperate.
   Thing Descriptions, by default, are encoded in a JSON format that also allows
   JSON-LD processing. The latter provides a powerful foundation to represent
   knowledge about <a>Things</a> in a machine-understandable way.
   A Thing Description instance can be hosted by the <a>Thing</a> itself or hosted
   externally when a <a>Thing</a> has resource restrictions (e.g., limited memory space)
-  or when a Web of Things-compatible legacy device is retrofitted 
+  or when a Web of Things-compatible legacy device is retrofitted
   with a Thing Description.
   </p>
   </section>
@@ -437,17 +437,17 @@ a[href].internalDFN {
   that indicate how the <a>Thing</a> can be used,
   <a href="#sec-data-schema-vocabulary-definition">schemas</a> for the data
   exchanged with the <a>Thing</a> for machine-understandability,
-  and, finally, <a href="#sec-hypermedia-vocabulary-definition">Web links</a> to 
+  and, finally, <a href="#sec-hypermedia-vocabulary-definition">Web links</a> to
   express any formal or informal relation to other <a>Things</a> or documents on the Web.
   </p>
   <p>
   The <a>Interaction Model</a> of W3C WoT defines three types of <a>Interaction Affordances</a>:
   Properties (<a href="#propertyaffordance"><code>PropertyAffordance</code></a> class)
-  can be used for sensing and controlling parameters, such as getting the current value or 
+  can be used for sensing and controlling parameters, such as getting the current value or
   setting an operation state.
   Actions (<a href="#actionaffordance"><code>ActionAffordance</code></a> class) model
-  invocation of physical (and hence time-consuming) processes, but can also be used to 
-  abstract RPC-like calls of existing platforms. 
+  invocation of physical (and hence time-consuming) processes, but can also be used to
+  abstract RPC-like calls of existing platforms.
   Events (<a href="#eventaffordance"><code>EventAffordance</code></a> class) are used
   for the push model of communication where notifications,
   discrete events, or streams of values are sent asynchronously to the receiver.
@@ -502,14 +502,14 @@ a[href].internalDFN {
 
 
   <p>
-  From this TD example, 
+  From this TD example,
   we know there exists one <a href="#propertyaffordance">Property affordance</a>
-  with the title <i>status</i>. 
-  In addition, 
-  information is provided to indicate that this Property is accessible via 
-  (the secure form of) the HTTP protocol with a GET method 
-  at the URI <code>https://mylamp.example.com/status</code> 
-  (announced within the <code>forms</code> structure by the 
+  with the title <i>status</i>.
+  In addition,
+  information is provided to indicate that this Property is accessible via
+  (the secure form of) the HTTP protocol with a GET method
+  at the URI <code>https://mylamp.example.com/status</code>
+  (announced within the <code>forms</code> structure by the
   <code>href</code> member), and will return a string-based status value.
   The use of the GET method is not stated explicitly,
   but is one of the default assumptions defined by this document.
@@ -523,15 +523,15 @@ a[href].internalDFN {
   <p>
   The <a href="#eventaffordance">Event affordance</a> enables a mechanism for asynchronous messages
   to be sent by a <a>Thing</a>.
-  Here, a subscription to be notified upon a possible overheating event 
+  Here, a subscription to be notified upon a possible overheating event
   of the lamp can be obtained by using HTTP with its long polling
   subprotocol on <code>https://mylamp.example.com/oh</code>.
   </p>
- 
+
   <p>
-  This example also specifies the <code>basic</code> security scheme, 
+  This example also specifies the <code>basic</code> security scheme,
   requiring a username and password for access.
-  Note that a security scheme is first given a name in 
+  Note that a security scheme is first given a name in
   <code>securityDefinitions</code> and then activated by specifying
   that name in a <code>security</code> section.
   In combination with the use of the HTTP protocol this example
@@ -551,7 +551,7 @@ a[href].internalDFN {
         in some namespace. This mechanism can be used to integrate additional semantics
         to the content of the Thing Description instance, provided that formal knowledge,
         e.g., logic rules for a specific domain of application, can be found under the
-        given namespace. Contextual information can also help specify some configurations and 
+        given namespace. Contextual information can also help specify some configurations and
         behavior of the underlying communication protocols declared in the <code>forms</code> field.
         <a href="#thing-description-full-serialization">Example 2</a> extends the TD sample from
         Example 1 by introducing a second defintion in the <code>@context</code> to declare the
@@ -566,7 +566,7 @@ a[href].internalDFN {
   </p>
 
 
- 
+
  <aside class="example" id="thing-description-full-serialization" title="Thing Description with TD Context Extension for semantic annotations">
               <pre>
     {
@@ -623,11 +623,11 @@ a[href].internalDFN {
 
 <section id="conformance">
 <p>
-A Thing Description instance complies with this specification if it follows 
+A Thing Description instance complies with this specification if it follows
 the normative statements in
 <a href="#sec-vocabulary-definition"></a>
 and
-<a href="#sec-td-serialization"></a> 
+<a href="#sec-td-serialization"></a>
 regarding Thing Description serialization.
 </p>
 <p>
@@ -637,7 +637,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
 </section>
 
-<section id="terminology" class="informative"> 
+<section id="terminology" class="informative">
 <h2>Terminology</h2>
 
   <p>The fundamental WoT terminology such as
@@ -760,7 +760,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         Each <a>Vocabulary</a> used in the <a>TD Information Model</a> has its own namespace IRI,
         as follows:
     </p>
-  
+
     <table class="def">
     <thead>
         <tr>
@@ -787,7 +787,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         </tr>
     </tbody>
     </table>
-  
+
     <p>
         The <a>Vocabularies</a> are independent from each other.
         They may be reused and extended in other W3C specifications.
@@ -801,7 +801,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
     <p>
         Because a <a>Vocabulary</a> under some namespace IRI can only undergo non-breaking
-        changes, its content can be safely cached or embedded in applications. One 
+        changes, its content can be safely cached or embedded in applications. One
         advantage of exposing relatively static content under a namespace IRI is to
         optimize payload sizes of messages exchanged between constrained devices. It
         also avoids any privacy leakage resulting from devices accessing publicly
@@ -810,7 +810,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
     </p>
 
   </section>
-  
+
 
   <section id="sec-vocabulary-definition" class="normative">
     <h1>TD Information Model</h1>
@@ -824,7 +824,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
       <section>
       <h2>Overview</h2>
-    
+
       <p>
         The <a>TD Information Model</a> is built upon the following, independent <a>Vocabularies</a>:
         <ul>
@@ -868,30 +868,30 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           as directed arrows. For the sake of readability, the diagram was split in
           four parts, one for each of the four base <a>Vocabularies</a>.
       </p>
-      
+
       <!--<p><a href="http://visualdataweb.de/webvowl/#iri=https://rawgit.com/w3c/wot-thing-description/TD-JSON-LD-1.1/ontology/td.ttl">Click here for the visualization</a></p>-->
 
     <figure id="td-core-model">
       <img src="visualization/td.png" alt="UML diagram of the TD information model for the TD core vocabulary"/>
       <figcaption>TD core vocabulary</figcaption>
     </figure>
-    
+
     <hr>
 
     <figure id="td-data-schema-model">
       <img src="visualization/json-schema.png" alt="UML diagram of the TD information model for the Data schema vocabulary"/>
       <figcaption>Data schema vocabulary</figcaption>
     </figure>
-    
+
     <hr>
-    
+
     <figure id="td-security-model">
       <img src="visualization/wot-security.png" alt="UML diagram of the TD information model for the WoT security vocabulary"/>
       <figcaption>WoT security vocabulary</figcaption>
     </figure>
-    
+
     <hr>
-    
+
     <figure id="hypermedia-model">
       <img src="visualization/hypermedia.png" alt="UML diagram of the TD information model for the hypermedia controls vocabulary"/>
       <figcaption>Hypermedia controls vocabulary</figcaption>
@@ -1018,7 +1018,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
         <p>
             By convention, <a>Simple Types</a> are denoted by names starting with lowercase.
-            The <a>TD Information Model</a> references the following <a>Simple Types</a> 
+            The <a>TD Information Model</a> references the following <a>Simple Types</a>
             defined in XML Schema [[XMLSCHEMA11-2-20120405]]:
             <code>string</code>,
             <code>anyURI</code>,
@@ -1055,13 +1055,13 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             all <a>Vocabulary Terms</a> involved in the <a>TD Information Model</a> as RDF
             resources, so as to integrate them in a larger model of the physical world
             (an ontology).
-            For details about semantic processing, please refer to 
+            For details about semantic processing, please refer to
             <a href="#json-ld-ctx-usage"></a> and the documentation under the namespace IRIs, e.g.,
             <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>.
         </p>
 
     </section>
-    
+
       <section>
 
         <h2>Class Definitions</h2>
@@ -1127,7 +1127,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
     <li>
         <span class="rfc2119-assertion" id="td-context-default-language-direction-heuristic">
             If no language tag is given,
-            the base direction SHOULD be inferred through 
+            the base direction SHOULD be inferred through
             first-strong heuristics or detection algorithms such as the CLDR Likely Subtags [[?LDML]].
         </span>
     </li>
@@ -1137,16 +1137,16 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
     </span></li>
     <li><span class="rfc2119-assertion" id="td-context-ns-multilanguage-text-direction-infer">
         Inside of <code>MultiLanguage</code> <a>Maps</a>,
-        the base direction of each value of the name-value pairs 
+        the base direction of each value of the name-value pairs
         MAY be inferred from the language tag given in the corresponding name.
     </span></li>
     <li>
         <span class="rfc2119-assertion" id="td-context-default-language-direction-script">
             In cases where a language can be written in more than one script with different base directions,
             the corresponding language tag given in <code>@language</code> or <code>MultiLanguage</code> <a>Maps</a>
-            MUST include a script subtag, so that an appropriate base direction can be inferred. 
+            MUST include a script subtag, so that an appropriate base direction can be inferred.
         </span>
-        An example is Azeri, which is written LTR when Latin script is used (specified using <code>az-Latn</code>) 
+        An example is Azeri, which is written LTR when Latin script is used (specified using <code>az-Latn</code>)
         and RTL when Arabic script is used (specified using <code>az-Arab</code>).
     </li>
 </ul>
@@ -1158,7 +1158,7 @@ Mixed direction text can occur in any language,
 even when the language is properly identified.
 </p>
 <p>
-TD producers should attempt to provide mixed direction strings in a way that 
+TD producers should attempt to provide mixed direction strings in a way that
 can be displayed successfully by a naive user agent.
 For example, if an RTL string begins with an LTR run (such as a number or a brand or trade name in Latin script),
 including an RLM character at the start of the string or wrapping opposite direction runs in bidi controls can assist in proper display.
@@ -1175,9 +1175,9 @@ including an RLM character at the start of the string or wrapping opposite direc
     which are indicated by <code>Form</code> instances in its optional <code>forms</code> <a>Array</a>.
     <span class="rfc2119-assertion" id="td-op-for-thing">
     When the <code>forms</code> <a>Array</a> of a <a>Thing</a> instance contains <code>Form</code> instances,
-    the string values assigned to the name <code>op</code>, either directly or within an <a>Array</a>, 
+    the string values assigned to the name <code>op</code>, either directly or within an <a>Array</a>,
     MUST be one of the following <em>opteration types</em>:
-    <code>readallproperties</code>, <code>writeallproperties</code>, 
+    <code>readallproperties</code>, <code>writeallproperties</code>,
     <code>readmultipleproperties</code>, or <code>writemultipleproperties</code>.
     </span>
     (See <a href="#td-forms-readall-example"> an example</a> for an usage of <code>form</code> in a Thing instance.)
@@ -1212,10 +1212,10 @@ including an RLM character at the start of the string or wrapping opposite direc
     <code>readOnly</code> and <code>writeOnly</code> members, among
     others.
 </p>
-<p><code>PropertyAffordance</code> is a <a>Subclass</a> of the <code>InteractionAffordance</code> <a>Class</a> and the <code>DataSchema</code> <a>Class</a>. 
+<p><code>PropertyAffordance</code> is a <a>Subclass</a> of the <code>InteractionAffordance</code> <a>Class</a> and the <code>DataSchema</code> <a>Class</a>.
     <span class="rfc2119-assertion" id="td-op-for-property">
-When a Form instance is within a <code>PropertyAffordance</code> instance, 
-the value assigned to <code>op</code> MUST be one of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>, 
+When a Form instance is within a <code>PropertyAffordance</code> instance,
+the value assigned to <code>op</code> MUST be one of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>,
 <code>unobserveproperty</code> or an  <a>Array</a> containing a combination of these terms.
     </span>
 </p>
@@ -1227,7 +1227,7 @@ the value assigned to <code>op</code> MUST be one of <code>readproperty</code>, 
 <tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance"><td><code>idempotent</code></td><td>Indicates whether the Action is idempotent (=true) or not. Informs whether the Action can be called repeatedly with the same result, if present, based on the same input.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table>
 <p><code>ActionAffordance</code> is a <a>Subclass</a> of the <code>InteractionAffordance</code> <a>Class</a>.
     <span class="rfc2119-assertion" id="td-op-for-action">
-When a Form instance is within an <code>ActionAffordance</code> instance, 
+When a Form instance is within an <code>ActionAffordance</code> instance,
 the value assigned to op MUST be  <code>invokeaction</code>.
     </span>
 </p>
@@ -1237,7 +1237,7 @@ the value assigned to op MUST be  <code>invokeaction</code>.
 <tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance"><td><code>cancellation</code></td><td>Defines any data that needs to be passed to cancel a subscription, e.g., a specific message to remove a Webhook.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table>
 <p><code>EventAffordance</code> is a <a>Subclass</a> of the <code>InteractionAffordance</code> <a>Class</a>.
     <span class="rfc2119-assertion" id="td-op-for-event">
-    When a Form instance is within an <code>EventAffordance</code> instance, 
+    When a Form instance is within an <code>EventAffordance</code> instance,
     the value assigned to <code>op</code> MUST be either <code>subscribeevent</code>, <code>unsubscribeevent</code>, or both terms within an  <a>Array</a>.
     </span>
 </p>
@@ -1249,11 +1249,11 @@ where a sequence of three numbers separated by a dot indicates the major version
     </section>
 <section><h3><code>MultiLanguage</code></h3><p>A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
 <p>
-<span class="rfc2119-assertion" id="td-multilanguage-language-tag"> 
+<span class="rfc2119-assertion" id="td-multilanguage-language-tag">
     Each name of the <code>MultiLanguage</code> <a>Map</a>
     MUST be a language tag as defined in [[!BCP47]].
 </span>
-<span class="rfc2119-assertion" id="td-multilanguage-value"> 
+<span class="rfc2119-assertion" id="td-multilanguage-value">
     Each value of the <code>MultiLanguage</code> <a>Map</a>
     MUST be of type <code>string</code>.
 </span>
@@ -1261,27 +1261,72 @@ where a sequence of three numbers separated by a dot indicates the major version
 </section>
 
       </section>
-    
+
       <section id="sec-data-schema-vocabulary-definition">
       <h2>Data Schema Vocabulary Definitions</h2>
       <p>
-        The data schema vocabulary definition is reflecting a very common subset of the terms defined by JSON Schema [[?JSON-SCHEMA]]. It is noted
-        that data schema definitions within Thing Description instances are not limited to this defined subset and may use additional terms
-        found in JSON Schema using a <a>TD Context Extension</a> for the additional terms as described in
-        <a href="#sec-context-extensions"></a>, otherwise these terms are semantically ignored by <a>TD Processors</a>
-        (for details about semantic processing, please refer to 
-        <a href="#json-ld-ctx-usage"></a> and the documentation under the namespace IRIs, e.g.,
+        A data schema is an abstract notation for describing data structures.
+      </p>
+      <p>
+        The data schema vocabulary definition is a subset of the terms defined
+        by JSON Schema [[?JSON-SCHEMA]]. However, data schema definitions within
+        Thing Description instances MAY use additional terms found in
+        JSON Schema using a <a>TD Context Extension</a> for the
+        additional terms, as described in <a href="#sec-context-extensions"></a>.
+        Unknown semantic terms are ignored by <a>TD Processors</a>
+        (for details about semantic processing, please refer to
+        <a href="#json-ld-ctx-usage"></a> and the documentation under the
+        namespace IRIs, e.g.,
         <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
       </p>
-      <p>A data schema is an abstract notation for data contained in data formats. 
-         In a TD, concrete data formats are specified in Forms (see <a href="#form"></a>) using content types.
-         When the value of a content type in an instance of the Form is <code>application/json</code>, 
-         the data schema can be processed directly by JSON Schema processors.
-         Otherwise, Web of Things (WoT) Binding Templates [[?WOT-BINDING-TEMPLATES]] defines data schema's 
-         available mappings to other content types such as XML [[?xml]]. 
-         If the content type in an instance of the Form is not <code>application/json</code> and 
-         if no mapping is defined for the content type, specifying a data schema does not make sense 
-         for the content type.
+      <p>
+        Interactions with a <a>Thing</a> are described by number of
+        <a href="#form">Form</a>s that specify a <code>contentType</code>
+        for the interaction.
+        For a number of supported content types that denote structured data,
+        the data formats can be further described by a data schema.
+        For instance, when the value of a content type in an instance of the
+        Form is <code>application/json</code>, the data schema can be processed
+        directly by JSON Schema processors.
+        The Web of Things (WoT) Binding Templates [[?WOT-BINDING-TEMPLATES]]
+        defines data schema's available mappings to other content types.
+      </p>
+      <div>
+        The following content types MAY use data schema:
+        <table class="simple">
+          <tr>
+            <th><strong>Structure</strong></th>
+            <th><strong>Content type</strong></th>
+          </tr>
+          <tr>
+            <td>JSON</td>
+            <td>
+              `application/json`, <br>
+              `application/vnd.oma.lwm2m+json`, <br>`
+              application/senml+json`
+            </td>
+          </tr>
+          <tr>
+            <td>CBOR</td>
+            <td>
+              `application/cbor`, <br>
+              `application/vnd.ocf+cbor`, <br>
+              `application/senml+cbor`
+            </td>
+          </tr>
+          <tr>
+            <td>XMLl</td>
+            <td>`application/senml+xml`</td>
+          </tr>
+          <tr>
+            <td>LD-JSON</td>
+            <td>`application/ld+json`</td>
+          </tr>
+        </table>
+      </div>
+      <p>
+        Specifying a data schema for other content types does not currently
+        make sense.
       </p>
 
         <section><h3><code>DataSchema</code></h3><p>Metadata that describes the data format used. It can be used for validation.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types)</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display a text for UI representation) based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
@@ -1302,13 +1347,13 @@ where a sequence of three numbers separated by a dot indicates the major version
 <li><a href="#objectschema"><code>ObjectSchema</code></a></li>
 <li><a href="#stringschema"><code>StringSchema</code></a></li>
 <li><a href="#nullschema"><code>NullSchema</code></a></li></ul>
-<p>The <code>format</code> string values are known from a fixed set of values and their corresponding format rules 
-defined in [[?JSON-SCHEMA]] (Section 7.3 Defined Formats in particular). 
+<p>The <code>format</code> string values are known from a fixed set of values and their corresponding format rules
+defined in [[?JSON-SCHEMA]] (Section 7.3 Defined Formats in particular).
 <span class="rfc2119-assertion" id="td-format-validation-known-values">
-Servients MAY use the <code>format</code> value to perform additional validation accordingly. 
+Servients MAY use the <code>format</code> value to perform additional validation accordingly.
 </span>
 <span class="rfc2119-assertion" id="td-format-validation-other-values">
-When a value that is not found in the known set of values is assigned to <code>format</code>, 
+When a value that is not found in the known set of values is assigned to <code>format</code>,
 such a validation SHOULD succeed.
 </span>
 </p>
@@ -1327,7 +1372,7 @@ such a validation SHOULD succeed.
 <section><h3><code>NullSchema</code></h3><p>Metadata describing data of type <code>null</code>. This <a>Subclass</a> is indicated by the value <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. This Subclass describes only one acceptable value, namely <code>null</code>. It can be used as part of a <code>oneOf</code> declaration, where it is used to indicate, that the data can also be <code>null</code>.</p></section>
 
       </section>
-    
+
       <section id="sec-security-vocabulary-definition">
       <h2>Security Vocabulary Definitions</h2>
 
@@ -1335,8 +1380,8 @@ such a validation SHOULD succeed.
       This specification provides a selection of well-established security mechanisms
       that are directly built into protocols eligible as <a>Protocol Bindings</a> for W3C WoT
       or are widely in use with those protocols.
-      The current set of HTTP security schemes is partly based on 
-      <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject">OpenAPI 3.0.1</a> (see also [[?OPENAPI]]). 
+      The current set of HTTP security schemes is partly based on
+      <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject">OpenAPI 3.0.1</a> (see also [[?OPENAPI]]).
       However while the HTTP security schemes, <a>Vocabulary</a>, and syntax
       given in this specification share many similarities with OpenAPI, they are not compatible.
       </p>
@@ -1391,8 +1436,8 @@ such a validation SHOULD succeed.
 <tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link"><td><code>anchor</code></td><td>Overrides the link context (by default the Thing itself identified by its <code>id</code>) with the given URI or IRI.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr></tbody></table></section>
 <section><h3><code>Form</code></h3><p>A form can be viewed as a statement of "To perform an <b><em>operation type</em></b> operation on <b><em>form context</b></em>, make a <b><em>request method</b></em> request to <b><em>submission target</b></em>" where the optional <b><em>form fields</b></em> may further describe the required request. In Thing Descriptions, the <b><em>form context</b></em> is the surrounding Object, such as Properties, Actions, and Events or the Thing itself for meta-interactions.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-op--Form"><td><code>op</code></td><td>Indicates the semantic intention of performing the operation(s) described by the form.
 
-For example, the Property interaction allows get and set operations.  
-The protocol binding may contain a form for the get operation and a different form for the set operation.  
+For example, the Property interaction allows get and set operations.
+The protocol binding may contain a form for the get operation and a different form for the set operation.
 The op attribute indicates which form is for which and allows the client to select the correct form for the operation required.
 
 op can be assigned one or more interaction verb(s) each representing a semantic intention of an operation.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>, <code>unobserveproperty</code>, <code>invokeaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>, <code>readallproperties</code>, <code>writeallproperties</code>, <code>readmultipleproperties</code>, or <code>writemultipleproperties</code>)</td></tr>
@@ -1400,7 +1445,7 @@ op can be assigned one or more interaction verb(s) each representing a semantic 
 <tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form"><td><code>contentType</code></td><td>Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters (e.g., <code>charset=utf-8</code>) for the media type [[RFC2046]].</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form"><td><code>contentCoding</code></td><td>Content coding values indicate an encoding transformation that has been or can be applied to a representation. Content codings are primarily used to allow a representation to be compressed or otherwise usefully transformed without losing the identity of its underlying media type and without loss of information. Examples of content coding include "gzip", "deflate", etc. .</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form"><td><code>subprotocol</code></td><td>Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when there are multiple options.
-     
+
 For example, for HTTP and Events, it indicates which of several available mechanisms should be used for asynchronous notifications such as long polling (<code>longpoll</code>), WebSub [[websub]] (<code>websub</code>), Server-Sent Events [[eventsource]] (<code>sse</code>). Please note that there is no restriction on the subprotocol selection and other mechanisms can also be announced by this subprotocol term.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-security--Form"><td><code>security</code></td><td>Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.  These must all be satisfied for access to resources.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided as an array.  These are provided in tokens returned by an authorization server and associated with forms in order to identify what resources a client may access and how.  The values associated with a form should be chosen from those defined in an <code>OAuth2SecurityScheme</code> active on that form.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
@@ -1421,12 +1466,12 @@ operations types SHOULD NOT be arbitrarily set by servients.
 
 <p>
 The optional <code>response</code> name-value pair can be used to provide metadata for the expected response message.
-With the core vocabulary, it only includes content type information, but TD Context Extensions could be applied. 
+With the core vocabulary, it only includes content type information, but TD Context Extensions could be applied.
 <span class="rfc2119-assertion" id="td-expectedResponse-default-contentType">
-If no <code>response</code> name-value pair is provided, it MUST be assumed that the content type of the 
+If no <code>response</code> name-value pair is provided, it MUST be assumed that the content type of the
 response is equal to the content type assigned to the Form instance.</span>
-Note that <code>contentType</code> within an <code>ExpectedResponse</code> <a>Class</a> does not have a <a>Default Value</a>. 
-For instance, if the value of the content type of the form is <code>application/xml</code> the assumed value of the content type of 
+Note that <code>contentType</code> within an <code>ExpectedResponse</code> <a>Class</a> does not have a <a>Default Value</a>.
+For instance, if the value of the content type of the form is <code>application/xml</code> the assumed value of the content type of
 the response will be also <code>application/xml</code>.
 </p>
 
@@ -1436,10 +1481,10 @@ In some use cases, input and output data might be represented in a different for
 <span class="rfc2119-assertion" id="td-expectedResponse-contentType">
 If the content type of the expected response differs from the content type of the form,
 the <code>Form</code> instance MUST include a name-value pair with the name <code>response</code>.
-</span> 
+</span>
 For instance, an <code>ActionAffordance</code> could only accept <code>application/json</code> for its input data, while it
-will respond with an <code>image/jpeg</code> content type for its output data. In that case the content types differ and the 
-<code>response</code> name-value pair has to be used to provide response content type (<code>image/jpeg</code>) information 
+will respond with an <code>image/jpeg</code> content type for its output data. In that case the content types differ and the
+<code>response</code> name-value pair has to be used to provide response content type (<code>image/jpeg</code>) information
 to the <a>Consumer</a>.
 
 </p>
@@ -1463,7 +1508,7 @@ to the <a>Consumer</a>.
             <a href="#sec-default-values"></a>.
           </span>
       </p>
-      
+
       <p>
           The following table gives all <a>Default Values</a> defined in the
           <a>TD Information Model</a>.
@@ -1686,19 +1731,19 @@ to the <a>Consumer</a>.
   in order to streamline semantic evaluation.
   Hence, the TD representation format can be processed either as raw JSON
   or with a JSON-LD 1.1 processor
-  (for details about semantic processing, please refer to 
+  (for details about semantic processing, please refer to
   <a href="#json-ld-ctx-usage"></a> and the documentation under the namespace IRIs, e.g.,
   <a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>).
   </p>
 
 <p>
 In order to support interoperable internationalization,
-<span class="rfc2119-assertion" id="td-json-open">TDs MUST be serialized according to the 
+<span class="rfc2119-assertion" id="td-json-open">TDs MUST be serialized according to the
 requirements defined in Section 8.1 of RFC8259 [[!RFC8259]] for open ecosystems.</span>
 In summary, this requires the following:
 <ul>
 <li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[!RFC3629]].</span</li>
-<li><span class="rfc2119-assertion" id="td-json-open_no-byte-order">Implementations MUST NOT 
+<li><span class="rfc2119-assertion" id="td-json-open_no-byte-order">Implementations MUST NOT
   add a byte order mark (U+FEFF) to the beginning of a TD document.</span></li>
 <li><span class="rfc2119-assertion" id="td-json-open_accept-byte-order"><a>TD Processors</a> MAY ignore
   the presence of a byte order mark rather than treating it as an error.</span></li>
@@ -1720,7 +1765,7 @@ In summary, this requires the following:
     Every <a>Simple Type</a> mentioned in
     <a href="#class-definitions"></a> (i.e., <code>string</code>, <code>anyURI</code>,
     <code>dateTime</code>, <code>integer</code>, <code>unsignedInt</code>,
-    <code>double</code>, and <code>boolean</code>) maps to a primitive JSON 
+    <code>double</code>, and <code>boolean</code>) maps to a primitive JSON
     type (string, number, boolean), as per the rules listed below. These
     rules apply to values in name-value pairs:
   </p>
@@ -1738,8 +1783,8 @@ In summary, this requires the following:
         <code>2015-07-11T09:32:26+08:00</code>.
     <span class="rfc2119-assertion" id="td-datetime-recommended-type">
         Values that are of type <code>dateTime</code>
-        SHOULD use the literal <code>Z</code> 
-        representing the UTC time zone instead 
+        SHOULD use the literal <code>Z</code>
+        representing the UTC time zone instead
         of an offset.
     </span>
   </li>
@@ -1756,7 +1801,7 @@ In summary, this requires the following:
         MUST be serialized as JSON boolean.
   </span></li>
   </ul>
-  
+
   <p>
     Every complex type of the <a>TD Information Model</a> (i.e., <a>Arrays</a>, <a>Maps</a>, and <a>Class</a> instances)
     maps to a structured JSON type (array and object), as per the rules listed below:
@@ -1778,7 +1823,7 @@ In summary, this requires the following:
   </ul>
 
 </section>
-  
+
 <section id="omitting-default-values">
 <h2>Omitting Default Values</h2>
 
@@ -1928,7 +1973,7 @@ In summary, this requires the following:
   includes a member with the name <code>@context</code> and a value of type
   string or array that equals or respectively contains <code>https://www.w3.org/2019/wot/td/v1</code>.
   </span></p>
-  
+
   <p>
   In general, this URI is used to identify the
   TD representation format version defined by this specification.
@@ -1937,7 +1982,7 @@ In summary, this requires the following:
   </p>
 
 <pre class="example">
-{  
+{
     "@context": "https://www.w3.org/2019/wot/td/v1",
     ...
 }
@@ -2013,7 +2058,7 @@ In summary, this requires the following:
 <h3>Human-Readable Metadata</h3>
 
   <p>
-    JSON members named <code>title</code> and <code>description</code> are 
+    JSON members named <code>title</code> and <code>description</code> are
     used within a TD document to provide human-readable metadata.
     They can be used as comments for developers inspecting a TD document
     or as display texts for user interface.
@@ -2033,21 +2078,21 @@ In summary, this requires the following:
   </p>
 
   <p class="note">
-    Strings on the Web [[?STRING-META]] suggests 
+    Strings on the Web [[?STRING-META]] suggests
     both strong-first and language-based inferencing as means
     to determine the base text direction.
-    Given that the Thing Description format is based on JSON-LD 1.1 
+    Given that the Thing Description format is based on JSON-LD 1.1
     [[?json-ld11]], which currently lacks explicit direction metadata,
-    these approaches are currently considered appropriate 
-    at the time of this publication. 
+    these approaches are currently considered appropriate
+    at the time of this publication.
     However, if JSON-LD 1.1 adopts support for explicit
     base direction metadata as recommended by [[?STRING-META]],
-    the Thing Description format should be updated to take advantage of 
+    the Thing Description format should be updated to take advantage of
     that feature.
   </p>
-  
+
   <p>
-  A TD snippet using <code>title</code> and <code>description</code> is 
+  A TD snippet using <code>title</code> and <code>description</code> is
   shown below. The default language is set to <code>en</code> through the
   definition of the <code>@language</code> member within a JSON object in the <code>@context</code> array.
   </p>
@@ -2079,7 +2124,7 @@ In summary, this requires the following:
 </pre>
 
   <p>
-  The JSON members named <code>titles</code> and <code>descriptions</code> are 
+  The JSON members named <code>titles</code> and <code>descriptions</code> are
   used within the TD document to provide human-readable metadata
   in multiple languages within a single TD document.
   <span class="rfc2119-assertion" id="td-multi-languages">
@@ -2096,7 +2141,7 @@ In summary, this requires the following:
   </p>
 
   <p>A TD snippet using <code>titles</code> and <code>descriptions</code> at different levels is given below:</p>
-    
+
 <pre class="example">
 {
     "@context": "https://www.w3.org/2019/wot/td/v1",
@@ -2105,14 +2150,14 @@ In summary, this requires the following:
         "en":"MyThing",
         "de": "MeinDing",
         "ja" : "私の物",
-        "zh-Hans" : "我的东西", 
+        "zh-Hans" : "我的东西",
         "zh-Hant" : "我的東西"
     },
     "descriptions": {
         "en":"Human readable information.",
         "de": "Menschenlesbare Informationen.",
         "ja" : "人間が読むことができる情報",
-        "zh-Hans" : "人们可阅读的信息", 
+        "zh-Hans" : "人们可阅读的信息",
         "zh-Hant" : "人們可閱讀的資訊"
     },
     ...
@@ -2142,7 +2187,7 @@ In summary, this requires the following:
     ...
 }
 </pre>
-    
+
   <p>
   TD instances may also combine the use of <code>title</code> and <code>description</code>
   with <code>titles</code> and <code>descriptions</code>.
@@ -2162,7 +2207,7 @@ In summary, this requires the following:
   The language of the default text is indicated by the default language,
   which is usually set by the creator of the Thing Description instance.
   </p>
-    
+
 <pre class="example">
 {
     "@context": [
@@ -2174,7 +2219,7 @@ In summary, this requires the following:
         "en":"MyThing",
         "de": "MeinDing",
         "ja" : "私の物",
-        "zh-Hans" : "我的东西", 
+        "zh-Hans" : "我的东西",
         "zh-Hant" : "我的東西"
     },
     "description": "Menschenlesbare Informationen.",
@@ -2182,7 +2227,7 @@ In summary, this requires the following:
         "en":"Human readable information.",
         "de": "Menschenlesbare Informationen.",
         "ja" : "人間が読むことができる情報",
-        "zh-Hans" : "人们可阅读的信息", 
+        "zh-Hans" : "人们可阅读的信息",
         "zh-Hant" : "人們可閱讀的資訊"
     },
     ...
@@ -2244,7 +2289,7 @@ In summary, this requires the following:
     MUST be serialized as JSON members with the <a>Vocabulary Term</a> as name.
   </span></p>
 
-  
+
   <p>A TD snippet of a version information object is given below:</p>
 
 <pre class="example">
@@ -2256,7 +2301,7 @@ In summary, this requires the following:
 </pre>
 
   <p>
-        The <code>version</code> member is intended as container for additional application- and/or device-specific version information based 
+        The <code>version</code> member is intended as container for additional application- and/or device-specific version information based
         on <a>TD Context Extensions</a>. See <a href="#semantic-annotations"></a> for details.
   </p>
 
@@ -2354,10 +2399,10 @@ In summary, this requires the following:
   </p>
 
   <p>
-  The <code>nosec</code> security scheme is provided for the case that 
+  The <code>nosec</code> security scheme is provided for the case that
   no security is needed.
   The minimal security configuration for a <a>Thing</a> is activation
-  of the <code>nosec</code> security scheme 
+  of the <code>nosec</code> security scheme
   at the Thing level, as shown in the following example:
   </p>
 
@@ -2375,10 +2420,10 @@ In summary, this requires the following:
     "events": {...},
     "links": [...]
 }
-</pre> 
+</pre>
 
   <p>
-  To give a more complex example, 
+  To give a more complex example,
   suppose we have a <a>Thing</a> where all <a>Interaction Affordances</a>
   require basic authentication except for one, for which
   no authentication is required.
@@ -2434,11 +2479,11 @@ In summary, this requires the following:
   mechanisms are allowed.  Here is a TD snippet demonstrating three possible
   ways to activate a Property affordance: via HTTPS with basic authentication,
   with digest authentication, with bearer token authentication.
-  In other words, 
+  In other words,
   the use of different security configurations within multiple forms
   provides a way to combine security mechanisms in an "OR" fashion.
   In contrast, putting multiple security configurations in the same
-  <code>security</code> member combines them in an "AND" fashion, 
+  <code>security</code> member combines them in an "AND" fashion,
   since in that case they would all need to be satisfied to allow activation of the <a>Interaction Affordance</a>.
   Note that activating one (default) configuration at the Thing level is still mandatory.
   </p>
@@ -2472,9 +2517,9 @@ In summary, this requires the following:
 </pre>
 
   <p>
-  As another more complex example, OAuth2 makes use of scopes. 
-  These are identifiers that 
-  may appear in tokens and must match with corresponding identifiers in a resource to allow 
+  As another more complex example, OAuth2 makes use of scopes.
+  These are identifiers that
+  may appear in tokens and must match with corresponding identifiers in a resource to allow
   access to that resource (or <a>Interaction Affordance</a> in the case of W3C WoT).
   For example, in the following, the <code>status</code> Property can be
   read by <a>Consumers</a> using bearer tokens containing the scope <code>limited</code>,
@@ -2482,7 +2527,7 @@ In summary, this requires the following:
   with a token containing the <code>special</code> scope.
   Scopes are not identical to roles, but are often associated with them;
   for example, perhaps only those in an administrative role are authorized to perform "special" interactions.
-  Tokens can have more than one scope.  
+  Tokens can have more than one scope.
   In this example, an administrator would
   probably be issued tokens with both the <code>limited</code> and <code>special</code> scopes,
   while ordinary users would only be issued tokens with the <code>limited</code> scope.
@@ -2525,11 +2570,11 @@ In summary, this requires the following:
 }
 </pre>
 
-</section> <!-- end of id="security-serialization-json"-->    
+</section> <!-- end of id="security-serialization-json"-->
 
 <section id="property-serialization-json">
 <h3><code>properties</code></h3>
-  
+
   <p>
   The value assigned to <code>properties</code> in a <code>Thing</code> instance
   is a <a>Map</a> of instances of <code>PropertyAffordance</code>.
@@ -2673,7 +2718,7 @@ In summary, this requires the following:
     ...
 </pre>
 </aside>
- 
+
 
 </section> <!-- end of id="action-serialization-json"-->
 
@@ -2736,7 +2781,7 @@ In summary, this requires the following:
 </aside>
 
 <p>
-Event affordances have been defined in a flexible manner, 
+Event affordances have been defined in a flexible manner,
 in order to adopt existing (e.g., WebSub [[websub]]) or customer-oriented event mechanisms (e.g., Webhooks).
 For this reason, <code>subscription</code> and <code>cancellation</code> can be defined according to the desired mechanism. Please find further details in [[?WOT-BINDING-TEMPLATES]].
 Example <a href="#webhook-example-serialization"></a> illustrates how Events can use <code>subscription</code> and <code>cancellation</code> to describe Webhooks.
@@ -3107,7 +3152,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
 <h2>Identification</h2>
 
   <p>
-  The JSON-based serialization of Thing Descriptions is identified by 
+  The JSON-based serialization of Thing Descriptions is identified by
   the media type <code>application/td+json</code> or the
   CoAP Content-Format ID <code>T.B.D.</code> (see <a href="#iana-section"></a>).
   </p>
@@ -3195,7 +3240,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
       by adding version numbers for the hardware and firmware of the <a>Thing</a>, and uses
       values from external <a>Vocabularies</a> for the <a>Thing</a> and for the
       data schema unit: <a href="https://w3id.org/saref">SAREF</a>,
-      also used in <a href="#thing-description-full-serialization"></a>, and 
+      also used in <a href="#thing-description-full-serialization"></a>, and
       <a href="http://www.ontology-of-units-of-measure.org/resource/om-2/">OM</a>, the
       Ontology of Units of Measure [[?RIJGERSBERG]]. These <a>Vocabularies</a>
       are used as examples—others may exist, in particular in the home automation domain.
@@ -3311,7 +3356,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   through additional <a>Vocabulary Terms</a> serialized into JSON objects representing a <code>Form</code> instance.
   (see also <a href="#protocol-bindings"></a>).
   </p>
-    
+
   <p>
   The following TD example uses a fictional CoAP <a>Protocol Binding</a>,
   as no such <a>Protocol Binding</a> is available at the time of writing this specification.
@@ -3323,7 +3368,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   <code>POST</code> for the CoAP Method Code 0.02,
   or <code>iPATCH</code> for CoAP Method Code 0.07).
   </p>
-    
+
 <aside class="example" id="context-extension-for-forms" title="Specialization of forms through TD Context Extension">
 <pre>
 {
@@ -3354,12 +3399,12 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
 }
 </pre>
 </aside>
-    
+
 </section>
-    
+
 <section>
 <h2>Adding Security Schemes</h2>
-    
+
   <p>
   Finally, new security schemes that are not included in <a href="#sec-security-vocabulary-definition"></a>
   can be imported using the <a>TD Context Extension</a> mechanism.
@@ -3369,7 +3414,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   Note that such additional security schemes must be <a>Subclasses</a> of the
   <a>Class</a> <a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>.
   </p>
-    
+
 <pre class="example">
 {
     @context: [
@@ -3423,51 +3468,51 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   Note that all security schemes defined in <a href="#sec-security-vocabulary-definition"></a>
   are already part of the TD context and need not to be included through a <a>TD Context Extension</a>.
   </p>
-    
+
 </section>
 </section>
 
 <section id="behavior" class="normative">
 <h2>Behavioral Assertions</h2>
  <p>
- The following assertions relate to the behavior of components of a 
- WoT system, as opposed to the representation or information model of the TD. 
+ The following assertions relate to the behavior of components of a
+ WoT system, as opposed to the representation or information model of the TD.
  However, note that TDs are descriptive, and may in particular be used to
  describe pre-existing network interfaces. In these cases, assertions cannot
  be made that constrain the behavior of such pre-existing interfaces.  Instead,
  the assertions must be interpreted as constraints on the TD to accurately
- represent such interfaces. 
- </p> 
+ represent such interfaces.
+ </p>
 <section id="behavior-security">
 <h3>Security Configurations</h3>
  <p>
- To enable secure interoperation, 
+ To enable secure interoperation,
  security configurations must accurately reflect the requirements of the <a>Thing</a>:
 <ul>
 <li>
  <span class="rfc2119-assertion" id="td-security-binding">
  If a <a>Thing</a> requires a specific access mechanism for an interaction, that
  mechanism MUST be specified in the security configuration of the Thing Description.
- </span>  
+ </span>
 </li>
 <li>
  <span class="rfc2119-assertion" id="td-security-no-extras">
  If a <a>Thing</a> does not require a specific access mechanism for an interaction, that
  mechanism MUST NOT be specified in the security configuration of the Thing Description.
- </span>  
+ </span>
 </li>
 </ul>
- Some security protocols may ask for authentication 
- information dynamically, including required encoding or encryption schemes. 
+ Some security protocols may ask for authentication
+ information dynamically, including required encoding or encryption schemes.
  One consequence of the above is that if a protocol asks for
- a form of security credentials or an encoding or encryption scheme 
- not declared in the Thing Description 
+ a form of security credentials or an encoding or encryption scheme
+ not declared in the Thing Description
  then the Thing Description is to be considered invalid.
  </p>
 </section> <!-- end of id="behavior-security"-->
 <section id="behavior-data">
 <h3>Data Schemas</h3>
-<p>The data schemas provided in the TD should accurately represent the 
+<p>The data schemas provided in the TD should accurately represent the
 data payloads returned and accepted by the described <a>Thing</a>
 in the interactions specified in the TD.  In general, <a>Consumers</a> should
 follow the data schemas strictly, not generating anything not given
@@ -3477,26 +3522,26 @@ but <a>Consumers</a> are <em>constrained</em> to follow WoT Thing Descriptions w
 interacting with <a>Things</a>.
 <ul>
 <li>
-<span class="rfc2119-assertion" 
+<span class="rfc2119-assertion"
       id="client-data-schema">
 A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another target <a>Thing</a>
-described in a WoT Thing Description MUST generate data  
+described in a WoT Thing Description MUST generate data
 organized according to the data schemas given in the corresponding
 interactions.
 </span>
 </li>
 <li>
-<span class="rfc2119-assertion" 
+<span class="rfc2119-assertion"
       id="server-data-schema">
-A WoT Thing Description MUST accurately describe the 
+A WoT Thing Description MUST accurately describe the
 data returned and accepted by each interaction.
 </span>
 </li>
 <li>
-<span class="rfc2119-assertion" 
+<span class="rfc2119-assertion"
       id="server-data-schema-extras">
 A <a>Thing</a> MAY return additional data from an interaction
-even when such data is 
+even when such data is
 not described in the data schemas given in its WoT Thing Description.
 </span>
 This applies to <code>ObjectSchema</code> and <code>ArraySchema</code> (when <code>items</code> is an Array of
@@ -3504,10 +3549,10 @@ This applies to <code>ObjectSchema</code> and <code>ArraySchema</code> (when <co
 <code>"additionalProperties":true</code> or <code>"additionalItems":true</code> as defined in [[?JSON-SCHEMA]].
 </li>
 <li>
-<span class="rfc2119-assertion" 
+<span class="rfc2119-assertion"
       id="client-data-schema-accept-extras">
 A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another <a>Thing</a> MUST accept without
-error any additional data  
+error any additional data
 not described in the data schemas given in the Thing Description of the target <a>Thing</a>.
 </span>
 This applies to <code>ObjectSchema</code> and <code>ArraySchema</code> (when <code>items</code> is an Array of
@@ -3515,14 +3560,14 @@ This applies to <code>ObjectSchema</code> and <code>ArraySchema</code> (when <co
 <code>"additionalProperties":true</code> or <code>"additionalItems":true</code> as defined in [[?JSON-SCHEMA]].
 </li>
 <li>
-<span class="rfc2119-assertion" 
+<span class="rfc2119-assertion"
       id="client-data-schema-no-extras">
 A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another <a>Thing</a> MUST NOT generate data
 not described in the data schemas given in the Thing Description of that <a>Thing</a>.
 </span>
 </li>
 <li>
-<span class="rfc2119-assertion" 
+<span class="rfc2119-assertion"
       id="client-uri-template">
 A <a>Thing</a> acting as a <a>Consumer</a> when interacting with another <a>Thing</a> MUST generate URIs
 according to the URI Templates, base URIs, and form href parameters
@@ -3530,7 +3575,7 @@ given in the Thing Description of the target <a>Thing</a>.
 </span>
 </li>
 <li>
-<span class="rfc2119-assertion" 
+<span class="rfc2119-assertion"
       id="server-uri-template">
 URI Templates, base URIs, and href members
 in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of the <a>Thing</a>.
@@ -3580,11 +3625,11 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     <h4>Protocol Binding based on HTTP</h4>
 
     <p>
-        Per default the Thing Description supports the <a>Protocol Binding</a> based on HTTP 
+        Per default the Thing Description supports the <a>Protocol Binding</a> based on HTTP
         by including the HTTP RDF vocabulary definitions from <em>HTTP Vocabulary in RDF 1.0</em> [[?HTTP-in-RDF10]].
-        This vocabulary can be 
-        directly used within TD instances by the usage of the prefix <code>htv</code>, which 
-        points to <code>http://www.w3.org/2011/http#</code>. 
+        This vocabulary can be
+        directly used within TD instances by the usage of the prefix <code>htv</code>, which
+        points to <code>http://www.w3.org/2011/http#</code>.
         Further details of <a>Protocol Binding</a> based on HTTP can be found in [[?WOT-BINDING-TEMPLATES]].
     </p>
     <p>
@@ -3595,7 +3640,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         sake of conciseness, the <a>Protocol Binding</a> based on HTTP defines <a>Default Values</a> for the operation types listed below,
         which also aims at convergence of the methods expected by <a>Things</a> (e.g., GET to read, PUT to write).
         <span class="rfc2119-assertion" id="td-default-http-method">
-            When no method is indicated in a form representing an <a>Protocol Binding</a> based on HTTP, 
+            When no method is indicated in a form representing an <a>Protocol Binding</a> based on HTTP,
             a <a>Default Value</a> MUST be assumed as shown in
             the following table.
         </span>
@@ -3642,7 +3687,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
     <p>
         For example, the <a href="#simple-thing-description-sample">Example 1</a> in <a href="#introduction"></a>
-        does not contain operation types and HTTP methods in the forms. 
+        does not contain operation types and HTTP methods in the forms.
         The following <a>Default Values</a> should be assumed for the forms in the <a href="#simple-thing-description-sample">Example 1</a>:
     </p>
 
@@ -3776,26 +3821,26 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
 <section id="sec-security-consideration" class="informative">
   <h4>Security and Privacy Considerations</h4>
-  
+
   <p>
-  In general the security measures taken to protect a WoT 
+  In general the security measures taken to protect a WoT
   system will depend on the threats and attackers that system
   may face and the value of the assets needs to protect.
-  In addition privacy risks will depend on the association of 
-  Things with identifiable people and both the direct information and 
+  In addition privacy risks will depend on the association of
+  Things with identifiable people and both the direct information and
   the inferred information available from such an association.
   A detailed discussion of security and privacy considerations for the Web of Things,
   including a threat model that can be adapted to various circumstances, is
-  presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
+  presented in the informative document [[WOT-SECURITY-GUIDELINES]].
   This section discusses only security and privacy risks
   and possible mitigations directly relevant to the WoT Thing Description.
   </p>
-  <p>A WoT Thing Description can describe both secure and 
-  insecure network interfaces.  When a Thing Description is 
-  retro-fitted to an existing network interface, no change in the 
+  <p>A WoT Thing Description can describe both secure and
+  insecure network interfaces.  When a Thing Description is
+  retro-fitted to an existing network interface, no change in the
   security status of the network interface is to be expected.
   </p>
-  <p>The use of a WoT Thing Description introduces  
+  <p>The use of a WoT Thing Description introduces
   the security and privacy risks given in the following sections.
   After each risk, we suggest some possible mitigations.
   </p>
@@ -3815,10 +3860,10 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
           Vocabulary files should be cached whenever possible.
           Ideally they would be made immutable, built into the interpreting device,
           and not fetched at all,
-          with the URI in the <code>@context</code> member serving only as 
-          an identifier of the (known) vocabulary. 
+          with the URI in the <code>@context</code> member serving only as
+          an identifier of the (known) vocabulary.
           This requires the use of strict version control, as updates
-          should use a new URI to ensure that existing URIs can refer to 
+          should use a new URI to ensure that existing URIs can refer to
           immutable data.
           Use well-known standard vocabulary files whenever possible to
           improve the chances that the context file will be available locally
@@ -3830,9 +3875,9 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       <p>A Thing Description containing an identifier (<code>id</code>) may
          describe a Thing that is associated with an identifiable
          person.  Such identifiers pose various risks including tracking.
-         However, if the identifier is also immutable, then the 
+         However, if the identifier is also immutable, then the
          tracking risk is amplified, since a device
-         may be sold or given to another person and the known ID used to 
+         may be sold or given to another person and the known ID used to
          track that person.
       </p>
       <dl><dt>Mitigation:</dt><dd>
@@ -3848,13 +3893,13 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
           old <a>Thing</a> ceases to exist and a new <a>Thing</a> is created.
           This can be sufficient to break a tracking chain when, for
           example, a device is sold to a new owner.
-          Alternatively, if more frequent changes are desired during 
+          Alternatively, if more frequent changes are desired during
           the operational phase of a device,
           a mechanism can be put into place to notify only authorized users
           of the change in identifier when a change is made.
           Note however that some classes of devices, e.g., medical devices,
           may require immutable IDs by law in some jurisdictions.
-          In this case extra attention should be paid to secure 
+          In this case extra attention should be paid to secure
           access to files, such as Thing Descriptions, containing such
           immutable identifiers.  It may also be desirable to not share
           the "true" immutable identifier in such a case in the TD whenever possible.
@@ -3863,10 +3908,10 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
    </section>
    <section id="sec-security-consideration-fingerprint">
    <h5>Fingerprinting Privacy Risk</h5>
-      <p>As noted above, the <code>id</code> member in a TD can pose a privacy risk.  
+      <p>As noted above, the <code>id</code> member in a TD can pose a privacy risk.
       However, even if the <code>id</code> is updated as described to mitigate its
       tracking risk, it may still be possible to associate
-      a TD with a particular physical device, and from there to an identifiable person, 
+      a TD with a particular physical device, and from there to an identifiable person,
       through fingerprinting.
       </p>
       <p>Even if a specific device instance cannot be identified through fingerprinting,
@@ -3878,13 +3923,13 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
           Only authorized users should be provided access
           to the Thing Description for a <a>Thing</a>, and only the amount of
           information needed for the level of authorization and the use case should be provided.
-          If the TD is only distributed to authorized users 
+          If the TD is only distributed to authorized users
           through secure and confidential channels, for
           example through a directory service that requires authentication,
           then external unauthorized parties will not have access to the TD to fingerprint it.
           To further mitigate this risk, information not necessary for a particular
           use case of a TD should be omitted whenever possible.  For example,
-          for an ad-hoc connection to a device where the Consumer does 
+          for an ad-hoc connection to a device where the Consumer does
           not store state about the Thing, the <code>id</code> can be omitted.
           If the Consumer does not need certain interactions for its use case, they can be omitted.
           If the Consumer is not authorized to use certain interactions, they can likewise be omitted.
@@ -3899,7 +3944,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       </p>
       <dl><dt>Mitigation:</dt><dd>
           The <code>id</code> field in TDs are intentionally not required to be globally unique.
-          There are several cryptographic mechanisms available to generate suitable IDs in a 
+          There are several cryptographic mechanisms available to generate suitable IDs in a
           distributed fashion that do
           not require a central registry.  These mechanisms typically have a very low probability
           of generating duplicate identifiers, and this needs to be taken into account in the system
@@ -3911,7 +3956,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
    <section id="sec-security-consideration-TD-tampering">
    <h5>TD Interception and Tampering Security Risk</h5>
       <p>Intercepting and tampering with TDs can be used to launch man-in-the-middle attacks,
-      for example by rewriting URLs in TDs to redirect accesses to a malicious 
+      for example by rewriting URLs in TDs to redirect accesses to a malicious
       intermediary that can capture or manipulate data.
       </p>
       <dl><dt>Mitigation:</dt><dd>
@@ -3925,13 +3970,13 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
    <section id="sec-security-consideration-context-tampering">
    <h5>Context Interception and Tampering Security Risk</h5>
       <p>Intercepting and tampering with context files can be used to facilitate attacks
-      by modifying the interpretation of vocabulary. 
+      by modifying the interpretation of vocabulary.
       </p>
       <dl><dt>Mitigation:</dt><dd>
 	      Ideally context files would only be obtained through authenticated channels
 	      but it is notable (and unfortunate) that many contexts are indicated using
-	      HTTP URLs, which are vulnerable to interception and modification if 
-	      dereferenced.  However, if context files are immutable and cached, 
+	      HTTP URLs, which are vulnerable to interception and modification if
+	      dereferenced.  However, if context files are immutable and cached,
 	      and dereferencing is avoided whenever possible, then this risk can be reduced.
       </dd></dl>
    </section>
@@ -3952,16 +3997,16 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       which can lead to additional inferences about that person.
       </p>
       <dl><dt>Mitigation:</dt><dd>
-          Treat a Thing Description associated with a 
+          Treat a Thing Description associated with a
 	      personal device as if it contained
 	      personally identifiable information.
           As an example application of this principle,
-          consider how to obtain user consent.  
+          consider how to obtain user consent.
           Consent for usage of personally identifiable data
           generated by a <a>Thing</a> is often obtained when a <a>Thing</a> is paired with system
           consuming the data,
           which is frequently also when the Thing Description
-          is registered with a local directory or the system consuming the 
+          is registered with a local directory or the system consuming the
           Thing Description in order to access the device.
           In this case, consent for using data from a <a>Thing</a> can be combined with
           consent for accessing the Thing Description of the <a>Thing</a>.
@@ -4106,12 +4151,12 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
   <section id="example-serialization" class="appendix informative">
     <h2>Example Thing Description Instances</h2>
-  
+
     <section id="myLampThing-example-serialization">
     <h3>MyLampThing Example with CoAP Protocol Binding</h3>
-  
+
     <p>Feature list of the <a>Thing</a>:</p>
-  
+
     <ul>
         <li>Title: MyLampThing</li>
         <li>Context Extensions: none</li>
@@ -4120,7 +4165,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         <li>Protocol Binding: CoAP [[?RFC7252]] over TLS</li>
         <li>Comment: Also see <a href="#adding-protocol-bindings"></a>.</li>
     </ul>
-  
+
   <pre class="example" title="MyLampThing with CoAP Protocol Binding">
   {
      "@context": [
@@ -4141,7 +4186,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
               "forms": [{
                   "op": "readproperty",
                   "href": "coaps://mylamp.example.com/status",
-                  "cov:methodName" : "GET" 
+                  "cov:methodName" : "GET"
               }]
           }
       },
@@ -4150,7 +4195,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
               "description" : "Turn on or off the lamp",
               "forms": [{
                   "href": "coaps://mylamp.example.com/toggle",
-                  "cov:methodName" : "POST" 
+                  "cov:methodName" : "POST"
               }]
           }
       },
@@ -4161,31 +4206,31 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
               "forms": [{
                   "href": "coaps://mylamp.example.com/oh",
                   "cov:methodName" : "GET",
-                  "subprotocol" : "cov:observe" 
+                  "subprotocol" : "cov:observe"
               }]
           }
       }
   }
   </pre>
   </section>
-  
+
     <section id="myLightSensor-example-serialization">
     <h3>MyIlluminanceSensor Example with MQTT Protocol Binding</h3>
-  
+
     <p>Feature list of the <a>Thing</a>:</p>
-  
+
     <ul>
         <li>Title: MyIlluminanceSensor</li>
         <li>Context Extensions: none</li>
         <li>Offered affordances: 1 Event</li>
         <li>Security: none</li>
         <li>Protocol Binding: MQTT [[?MQTT]]</li>
-        <li>Comment: An MQTT client frequently publishes the illuminance data (number is serialized in text format) to 
+        <li>Comment: An MQTT client frequently publishes the illuminance data (number is serialized in text format) to
             the topic <code>/illuminance</code> by the MQTT broker running behind the address 192.168.1.187:1883.</li>
     </ul>
-  
+
   <pre class="example" title="MyIlluminanceSensor with MQTT Protocol Binding">
-          {   
+          {
               "@context": "https://www.w3.org/2019/wot/td/v1",
               "title": "MyIlluminanceSensor",
               "id": "urn:dev:ops:32473-WoTIlluminanceSensor-1234",
@@ -4202,17 +4247,17 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
                           }
                       ]
                   }
-              } 
+              }
           }
   </pre>
     </section>
-  
-  
+
+
     <section id="webhook-example-serialization">
       <h3>Webhook Event Example</h3>
-    
+
       <p>Feature list of the <a>Thing</a>:</p>
-    
+
       <ul>
           <li>Title: WebhookThing</li>
           <li>Context Extensions: use HTTP <a>Protocol Binding</a> supplements (htv prefix already included in TD context)</li>
@@ -4234,7 +4279,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
               and combine this with a <code>unsubscribeevent</code> form that describes a POST request with payload to unsubscribe.
           </li>
       </ul>
-    
+
 <pre class="example" title="Temperature Event with subscription and cancellation">
 {
     "@context": "https://www.w3.org/2019/wot/td/v1",
@@ -4305,13 +4350,13 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     <p>
         Below is a JSON Schema [[?JSON-SCHEMA]] document for syntactically validating Thing Description instances serialized in JSON based format.
     </p>
-    <p class="note">The Thing Description defined by this document allows for 
-        adding external vocabularies by using <code>@context</code> mechanism 
+    <p class="note">The Thing Description defined by this document allows for
+        adding external vocabularies by using <code>@context</code> mechanism
         known from JSON-LD [[?json-ld11]], and the terms in those external vocabularies can be
-        used in addition to the terms defined in <a href="#sec-vocabulary-definition"></a>. 
-        For this reason, the below JSON schema is intentionally non-strict in that 
-        regard. You can replace the value of <code>additionalProperties</code> schema 
-        property <code>true</code> with <code>false</code> in different scopes/levels in 
+        used in addition to the terms defined in <a href="#sec-vocabulary-definition"></a>.
+        For this reason, the below JSON schema is intentionally non-strict in that
+        regard. You can replace the value of <code>additionalProperties</code> schema
+        property <code>true</code> with <code>false</code> in different scopes/levels in
         order to perform a stricter validation in case no external vocabularies are used.
     </p>
 
@@ -5364,7 +5409,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
   <section id="thing-templates" class="appendix informative">
   <h1>Thing Description Templates</h1>
-      
+
     <p>
     A <em>Thing Description Template</em> is a description for a <em>class</em> of <a>Things</a>.
     It describes the properties, actions, events and common metadata that are shared for an entire group of <a>Things</a>,
@@ -5386,7 +5431,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     information, such as a serial number, GPS location, security information or concrete protocol endpoints.
     </p><p>
     Since a Thing Description Template does not contain a <a>Protocol Binding</a> to specific endpoints and
-    does not define a specific security mechanism, the <em>forms</em> and <em>securityDefinitions</em> and 
+    does not define a specific security mechanism, the <em>forms</em> and <em>securityDefinitions</em> and
     <em>security</em> keys must not be present.
     </p><p>
      The same Thing Description Template can be implemented by <a>Things</a> from multiple vendors,
@@ -5404,22 +5449,22 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     All devices with the same Thing Description Template can be managed in the same way by cloud applications.
     It is easy to create multiple simulated devices, if the interface and the instance are treated separately.
     </p><p>
-        Since a Thing Description Template is a subset of the Thing Description in which some optional and mandatory <a>Vocabulary Terms</a> 
-        do not exist, however, it can be serialized in the same way and in the same formats as a Thing Description. Note that Thing 
+        Since a Thing Description Template is a subset of the Thing Description in which some optional and mandatory <a>Vocabulary Terms</a>
+        do not exist, however, it can be serialized in the same way and in the same formats as a Thing Description. Note that Thing
         Template instances cannot be validated in the same way as Thing Description instances due to some missing mandatory terms.
     </p>
-    
+
       <section id="thing-template-examples">
      <h2>Thing Description Template Examples</h2>
-    
+
     This section shows a Thing Description Template for a lamp and a Thing Description Template for a buzzer.
-    
+
       <section id="lamp-thing-template">
       <h3>Thing Description Template: Lamp</h3>
-    
+
     <pre class="example" title="MyLampThingTemplate serialized in JSON">
     {
-        "@context": ["https://www.w3.org/2019/wot/td/v1"], 
+        "@context": ["https://www.w3.org/2019/wot/td/v1"],
         "@type" : "ThingTemplate",
         "title": "Lamp Thing Description Template",
         "description" : "Lamp Thing Description Template",
@@ -5444,13 +5489,13 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     }
     </pre>
     </section>
-    
+
     <section id="buzzer-thing-template">
     <h3>Thing Description Template: Buzzer</h3>
-    
+
     <pre class="example" title="MyBuzzerThingTemplate serialized in JSON">
     {
-        "@context": ["https://www.w3.org/2019/wot/td/v1"], 
+        "@context": ["https://www.w3.org/2019/wot/td/v1"],
         "@type" : "ThingTemplate",
         "title": "Buzzer Thing Description Template",
         "description" : "Thing Description Template of a buzzer that makes noise for 10 seconds",
@@ -5462,7 +5507,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     }
     </pre>
     </section>
-    
+
   </section>
 </section>
 
@@ -5653,7 +5698,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
   </ul>
 
   <h2 id="changes-from-third-public-working-draft">Changes from Third Public Working Draft</h2>
-  <p>Changes from Third Public Working Draft are described in the 
+  <p>Changes from Third Public Working Draft are described in the
   <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#changes">Candidate Recommendation</a>
   </p>
 


### PR DESCRIPTION
This is a change to [DataSchema Vocabulary](https://w3c.github.io/wot-thing-description/#sec-data-schema-vocabulary-definition) section from line 1268, but it could be also moved to the [Representation Formats / Data Schemas](https://w3c.github.io/wot-thing-description/#data-schema-serialization-json) section.

Rendered version can also be checked here:
https://zolkis.github.io/wot-td/index.html#sec-data-schema-vocabulary-definition 

In addition, my editor removed end-of-line spaces (which are considered errors usually), that's a lot of fake change. BTW the spec source would need some formatting alignments.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/wot-thing-description/pull/867.html" title="Last updated on Dec 11, 2019, 9:28 AM UTC (a110a59)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/867/111c078...zolkis:a110a59.html" title="Last updated on Dec 11, 2019, 9:28 AM UTC (a110a59)">Diff</a>