### PR TITLE
chore: fix ReSpec errors

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Web of Things (WoT) Thing Description</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class='remove'>
           var respecConfig = {
               specStatus:     "ED"
@@ -17,7 +17,6 @@
             , noLegacyStyle:  true
             , inlineCSS:      true
             , noIDLIn:        true
-            , format:         "markdown"
             , wg:             "Web of Things Working Group"
             , wgURI:          "https://www.w3.org/WoT/WG/"
             , charterDisclosureURI : "https://www.w3.org/2004/01/pp-impl/95969/status"
@@ -4486,6 +4485,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
 <section id="changes" class="appendix">
   <h1>Recent Specification Changes</h1>
+  <section>
   <h2 id="changes-from-candidate-recommendation2">Changes from Second Candidate Recommendation</h2>
     <ul>
       <li>At-risk features <code>CertSecurityScheme</code>, <code>PublicSecurityScheme</code>, <code>PoPSecurityScheme</code> as well as <code>implicit</code>, <code>password</code> and <code>client</code> flows in <a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a> were removed.</li>
@@ -4495,6 +4495,9 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 the contexts in which default values <code>GET</code> or <code>PUT</code> are used for vocabulary term <code>htv:methodName</code> were clarified.</li>
       <li>The example Thing Description in appendix section <a href="#myLightSensor-example-serialization"></a> was improved to make a better example using MQTT.</li>
     </ul>
+  </section>
+
+  <section>
   <h2 id="changes-from-candidate-recommendation">Changes from First Candidate Recommendation</h2>
   <ul>
     <li>General</li>
@@ -4570,11 +4573,14 @@ the contexts in which default values <code>GET</code> or <code>PUT</code> are us
         <li>A reference to the WoT Architecture specification [[?WOT-ARCHITECTURE]] is informative.</li>
     </ul>
   </ul>
+  </section>
 
+  <section>
   <h2 id="changes-from-third-public-working-draft">Changes from Third Public Working Draft</h2>
   <p>Changes from Third Public Working Draft are described in the 
   <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#changes">Candidate Recommendation</a>
   </p>
+  </section>
 
 </section>
 


### PR DESCRIPTION
There have been some changes in markdown processing, which are incompatible with this document. Also, markdown is not used in the document, so removing it.

Also, use jquery-less ReSpec script, as it's lighter.

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sidvishnoi/wot-thing-description/pull/872.html" title="Last updated on Jan 29, 2020, 8:26 AM UTC (7d9bc0e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/872/134652f...sidvishnoi:7d9bc0e.html" title="Last updated on Jan 29, 2020, 8:26 AM UTC (7d9bc0e)">Diff</a>