### PR TITLE
Address feedback from IANA

### DIFF
--- a/index.html
+++ b/index.html
@@ -3989,7 +3989,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       <dt>Encoding considerations:</dt>
       <dd>See <a href="https://tools.ietf.org/html/rfc6839#section-3.1">RFC&nbsp;6839, section 3.1</a>.</dd>
       <dt>Security considerations:</dt>
-      <dd>See <a href="https://tools.ietf.org/html/rfc8259">RFC&nbsp;8259</a>.
+      <dd>See <a href="https://tools.ietf.org/html/rfc8259#section-12">RFC&nbsp;8259, section 12</a>.
         <p>
           <span class="rfc2119-assertion" id="iana-security-execution">
             Since WoT Thing Description is intended to be a pure data exchange format for
@@ -4004,7 +4004,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         <p>
           WoT Thing Descriptions can be evaluated with a JSON-LD 1.1 processor,
           which typically follows links to remote contexts (i.e., TD context
-          extensions, see <a href="#sec-context-extensions"></a>)
+          extensions, see <a href="https://www.w3.org/TR/wot-thing-description/#sec-context-extensions">W3C WoT Thing Description, section 7</a>)
           automatically, resulting in the transfer of files
           without the explicit request of the <a>Consumer</a> for each one. If remote
           contexts are served by third parties, it may allow them to gather
@@ -4020,7 +4020,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
           through a secure software update mechanism instead.
         </p>
         <p>
-          Context Extensions (see <a href="#sec-context-extensions"></a>)
+          Context Extensions (see <a href="https://www.w3.org/TR/wot-thing-description/#sec-context-extensions">W3C WoT Thing Description, section 7</a>)
           that are loaded from the Web over non-secure connections,
           such as HTTP, run the risk of being altered by an attacker such that
           they may modify the <a>TD Information Model</a> in a way that could

--- a/index.template.html
+++ b/index.template.html
@@ -3938,7 +3938,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       <dt>Encoding considerations:</dt>
       <dd>See <a href="https://tools.ietf.org/html/rfc6839#section-3.1">RFC&nbsp;6839, section 3.1</a>.</dd>
       <dt>Security considerations:</dt>
-      <dd>See <a href="https://tools.ietf.org/html/rfc8259">RFC&nbsp;8259</a>.
+      <dd>See <a href="https://tools.ietf.org/html/rfc8259#section-12">RFC&nbsp;8259, section 12</a>.
         <p>
           <span class="rfc2119-assertion" id="iana-security-execution">
             Since WoT Thing Description is intended to be a pure data exchange format for
@@ -3953,7 +3953,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         <p>
           WoT Thing Descriptions can be evaluated with a JSON-LD 1.1 processor,
           which typically follows links to remote contexts (i.e., TD context
-          extensions, see <a href="#sec-context-extensions"></a>)
+          extensions, see <a href="https://www.w3.org/TR/wot-thing-description/#sec-context-extensions">W3C WoT Thing Description, section 7</a>)
           automatically, resulting in the transfer of files
           without the explicit request of the <a>Consumer</a> for each one. If remote
           contexts are served by third parties, it may allow them to gather
@@ -3969,7 +3969,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
           through a secure software update mechanism instead.
         </p>
         <p>
-          Context Extensions (see <a href="#sec-context-extensions"></a>)
+          Context Extensions (see <a href="https://www.w3.org/TR/wot-thing-description/#sec-context-extensions">W3C WoT Thing Description, section 7</a>)
           that are loaded from the Web over non-secure connections,
           such as HTTP, run the risk of being altered by an attacker such that
           they may modify the <a>TD Information Model</a> in a way that could


### PR DESCRIPTION
Today we received the feedback from IANA about the mediaType registration. There was the request to provide the concrete section for the RFC 8259 reference (-->section 12) and we should provide the absolute path (and not the relative path) to the section 7 in the Thing Description specification.

This minor changes are addressed in this PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/874.html" title="Last updated on Jan 10, 2020, 10:01 AM UTC (47b88ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/874/5725d82...47b88ab.html" title="Last updated on Jan 10, 2020, 10:01 AM UTC (47b88ab)">Diff</a>