### PR TITLE
Remove `format: markdown`

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
             , noLegacyStyle:  true
             , inlineCSS:      true
             , noIDLIn:        true
-            , format:         "markdown"
             , wg:             "Web of Things Working Group"
             , wgURI:          "https://www.w3.org/WoT/WG/"
             , charterDisclosureURI : "https://www.w3.org/2004/01/pp-impl/95969/status"


### PR DESCRIPTION
This spec does not use markdown, so I propose removing that configuration option. (We in ReSpec are planning a change in `format: "markdown"` and we have found that this spec will get severe regressions.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/wot-thing-description/pull/876.html" title="Last updated on Jan 28, 2020, 12:16 PM UTC (09bf7b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/876/5b667fe...saschanaz:09bf7b4.html" title="Last updated on Jan 28, 2020, 12:16 PM UTC (09bf7b4)">Diff</a>