### PR TITLE
Fix typo in validation schema

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -49,7 +49,7 @@
                 }
             ]
         },
-        "subProtocol": {
+        "subprotocol": {
             "type": "string",
             "enum": [
                 "longpoll",
@@ -225,8 +225,8 @@
                 "contentCoding": {
                     "type": "string"
                 },
-                "subProtocol": {
-                    "$ref": "#/definitions/subProtocol"
+                "subprotocol": {
+                    "$ref": "#/definitions/subprotocol"
                 },
                 "security": {
                     "$ref": "#/definitions/security"
@@ -278,8 +278,8 @@
                 "contentCoding": {
                     "type": "string"
                 },
-                "subProtocol": {
-                    "$ref": "#/definitions/subProtocol"
+                "subprotocol": {
+                    "$ref": "#/definitions/subprotocol"
                 },
                 "security": {
                     "$ref": "#/definitions/security"
@@ -333,8 +333,8 @@
                 "contentCoding": {
                     "type": "string"
                 },
-                "subProtocol": {
-                    "$ref": "#/definitions/subProtocol"
+                "subprotocol": {
+                    "$ref": "#/definitions/subprotocol"
                 },
                 "security": {
                     "$ref": "#/definitions/security"
@@ -392,8 +392,8 @@
                 "contentCoding": {
                     "type": "string"
                 },
-                "subProtocol": {
-                    "$ref": "#/definitions/subProtocol"
+                "subprotocol": {
+                    "$ref": "#/definitions/subprotocol"
                 },
                 "security": {
                     "$ref": "#/definitions/security"


### PR DESCRIPTION
The subprotocol was written with a capital P, i.e. it was subProtocol instead of subprotocol