### PR TITLE
provide CoAP content-format id 432 in the TD spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -3111,11 +3111,6 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   CoAP Content-Format ID <code>432</code> (see <a href="#iana-section"></a>).
   </p>
 
-  <p class="note" title="CoAP Content-Format">
-  CoAP-based WoT implementations can use the experimental Content-Format
-  <code>65100</code> until the final Content-Format ID has been assigned.
-  </p>
-
 </section>
 </section> <!-- end of id="sec-td-serialization"-->
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Web of Things (WoT) Thing Description</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class='remove'>
           var respecConfig = {
               specStatus:     "ED"
@@ -17,7 +17,6 @@
             , noLegacyStyle:  true
             , inlineCSS:      true
             , noIDLIn:        true
-            , format:         "markdown"
             , wg:             "Web of Things Working Group"
             , wgURI:          "https://www.w3.org/WoT/WG/"
             , charterDisclosureURI : "https://www.w3.org/2004/01/pp-impl/95969/status"
@@ -3109,7 +3108,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   <p>
   The JSON-based serialization of Thing Descriptions is identified by 
   the media type <code>application/td+json</code> or the
-  CoAP Content-Format ID <code>T.B.D.</code> (see <a href="#iana-section"></a>).
+  CoAP Content-Format ID <code>432</code> (see <a href="#iana-section"></a>).
   </p>
 
   <p class="note" title="CoAP Content-Format">
@@ -4090,7 +4089,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       subregistry within the
       <a href="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml">Constrained RESTful Environments (CoRE) Parameters</a>
       registry [[RFC7252]].
-      The Content-Format ID for WoT Thing Description is (t.b.d.) in the 256-9999 range (IETF Review or IESG Approval).
+      The Content-Format ID for WoT Thing Description is 432.
     </p>
     <dl>
       <dt>Media Type:</dt>
@@ -4098,7 +4097,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       <dt>Encoding:</dt>
       <dd>-</dd>
       <dt>ID:</dt>
-      <dd>T.B.D.</dd>
+      <dd>432</dd>
       <dt>Reference:</dt>
       <dd>[<a href="https://w3c.github.io/wot-thing-description">"Web of Things (WoT) Thing Description", May 2019</a>]</dd>
     </section>
@@ -4373,7 +4372,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
                 }
             ]
         },
-        "subProtocol": {
+        "subprotocol": {
             "type": "string",
             "enum": [
                 "longpoll",
@@ -4549,8 +4548,8 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
                 "contentCoding": {
                     "type": "string"
                 },
-                "subProtocol": {
-                    "$ref": "#/definitions/subProtocol"
+                "subprotocol": {
+                    "$ref": "#/definitions/subprotocol"
                 },
                 "security": {
                     "$ref": "#/definitions/security"
@@ -4602,8 +4601,8 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
                 "contentCoding": {
                     "type": "string"
                 },
-                "subProtocol": {
-                    "$ref": "#/definitions/subProtocol"
+                "subprotocol": {
+                    "$ref": "#/definitions/subprotocol"
                 },
                 "security": {
                     "$ref": "#/definitions/security"
@@ -4657,8 +4656,8 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
                 "contentCoding": {
                     "type": "string"
                 },
-                "subProtocol": {
-                    "$ref": "#/definitions/subProtocol"
+                "subprotocol": {
+                    "$ref": "#/definitions/subprotocol"
                 },
                 "security": {
                     "$ref": "#/definitions/security"
@@ -4716,8 +4715,8 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
                 "contentCoding": {
                     "type": "string"
                 },
-                "subProtocol": {
-                    "$ref": "#/definitions/subProtocol"
+                "subprotocol": {
+                    "$ref": "#/definitions/subprotocol"
                 },
                 "security": {
                     "$ref": "#/definitions/security"
@@ -5357,6 +5356,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     ],
     "additionalProperties": true
 }
+
     </pre>
 
   </section>
@@ -5571,6 +5571,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
 <section id="changes" class="appendix">
   <h1>Recent Specification Changes</h1>
+  <section>
   <h2 id="changes-from-candidate-recommendation2">Changes from Second Candidate Recommendation</h2>
     <ul>
       <li>At-risk features <code>CertSecurityScheme</code>, <code>PublicSecurityScheme</code>, <code>PoPSecurityScheme</code> as well as <code>implicit</code>, <code>password</code> and <code>client</code> flows in <a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a> were removed.</li>
@@ -5580,6 +5581,9 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 the contexts in which default values <code>GET</code> or <code>PUT</code> are used for vocabulary term <code>htv:methodName</code> were clarified.</li>
       <li>The example Thing Description in appendix section <a href="#myLightSensor-example-serialization"></a> was improved to make a better example using MQTT.</li>
     </ul>
+  </section>
+
+  <section>
   <h2 id="changes-from-candidate-recommendation">Changes from First Candidate Recommendation</h2>
   <ul>
     <li>General</li>
@@ -5655,11 +5659,14 @@ the contexts in which default values <code>GET</code> or <code>PUT</code> are us
         <li>A reference to the WoT Architecture specification [[?WOT-ARCHITECTURE]] is informative.</li>
     </ul>
   </ul>
+  </section>
 
+  <section>
   <h2 id="changes-from-third-public-working-draft">Changes from Third Public Working Draft</h2>
   <p>Changes from Third Public Working Draft are described in the 
   <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#changes">Candidate Recommendation</a>
   </p>
+  </section>
 
 </section>
 

--- a/index.template.html
+++ b/index.template.html
@@ -3060,11 +3060,6 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   CoAP Content-Format ID <code>432</code> (see <a href="#iana-section"></a>).
   </p>
 
-  <p class="note" title="CoAP Content-Format">
-  CoAP-based WoT implementations can use the experimental Content-Format
-  <code>65100</code> until the final Content-Format ID has been assigned.
-  </p>
-
 </section>
 </section> <!-- end of id="sec-td-serialization"-->
 

--- a/index.template.html
+++ b/index.template.html
@@ -3057,7 +3057,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   <p>
   The JSON-based serialization of Thing Descriptions is identified by 
   the media type <code>application/td+json</code> or the
-  CoAP Content-Format ID <code>T.B.D.</code> (see <a href="#iana-section"></a>).
+  CoAP Content-Format ID <code>432</code> (see <a href="#iana-section"></a>).
   </p>
 
   <p class="note" title="CoAP Content-Format">
@@ -4038,7 +4038,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       subregistry within the
       <a href="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml">Constrained RESTful Environments (CoRE) Parameters</a>
       registry [[RFC7252]].
-      The Content-Format ID for WoT Thing Description is (t.b.d.) in the 256-9999 range (IETF Review or IESG Approval).
+      The Content-Format ID for WoT Thing Description is 432.
     </p>
     <dl>
       <dt>Media Type:</dt>
@@ -4046,7 +4046,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       <dt>Encoding:</dt>
       <dd>-</dd>
       <dt>ID:</dt>
-      <dd>T.B.D.</dd>
+      <dd>432</dd>
       <dt>Reference:</dt>
       <dd>[<a href="https://w3c.github.io/wot-thing-description">"Web of Things (WoT) Thing Description", May 2019</a>]</dd>
     </section>

--- a/render.sh
+++ b/render.sh
@@ -3,7 +3,7 @@
 if ! [[ -e .install/fuseki.jar ]] ; then
 	mkdir .install
 	echo "Downloading RDF store (Apache Fuseki server)..."
-	curl http://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-server/3.9.0/jena-fuseki-server-3.9.0.jar -o .install/fuseki.jar
+	curl https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-server/3.9.0/jena-fuseki-server-3.9.0.jar -o .install/fuseki.jar
 
 	echo "Installing Node.js dependencies..."
 	npm install


### PR DESCRIPTION
Today we received the official approval from the IANA about the content-format id for CoAP. Id should be visible in the TD REC version. 

Related to issue #560


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/880.html" title="Last updated on Feb 28, 2020, 7:25 AM UTC (e327aee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/880/90fb4cb...e327aee.html" title="Last updated on Feb 28, 2020, 7:25 AM UTC (e327aee)">Diff</a>