### PR TITLE
A note in section 6.4 Identification should be removed

### DIFF
--- a/index.html
+++ b/index.html
@@ -3111,11 +3111,6 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   CoAP Content-Format ID <code>432</code> (see <a href="#iana-section"></a>).
   </p>
 
-  <p class="note" title="CoAP Content-Format">
-  CoAP-based WoT implementations can use the experimental Content-Format
-  <code>65100</code> until the final Content-Format ID has been assigned.
-  </p>
-
 </section>
 </section> <!-- end of id="sec-td-serialization"-->
 

--- a/index.template.html
+++ b/index.template.html
@@ -3060,11 +3060,6 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   CoAP Content-Format ID <code>432</code> (see <a href="#iana-section"></a>).
   </p>
 
-  <p class="note" title="CoAP Content-Format">
-  CoAP-based WoT implementations can use the experimental Content-Format
-  <code>65100</code> until the final Content-Format ID has been assigned.
-  </p>
-
 </section>
 </section> <!-- end of id="sec-td-serialization"-->
 

--- a/render.sh
+++ b/render.sh
@@ -3,7 +3,7 @@
 if ! [[ -e .install/fuseki.jar ]] ; then
 	mkdir .install
 	echo "Downloading RDF store (Apache Fuseki server)..."
-	curl http://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-server/3.9.0/jena-fuseki-server-3.9.0.jar -o .install/fuseki.jar
+	curl https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-server/3.9.0/jena-fuseki-server-3.9.0.jar -o .install/fuseki.jar
 
 	echo "Installing Node.js dependencies..."
 	npm install


### PR DESCRIPTION
Now that CoAP Content-Format ID 432 was assigned officially, we can remove a note in section 6.4.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/takuki/wot-thing-description/pull/881.html" title="Last updated on Feb 28, 2020, 12:15 AM UTC (df74f79)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/881/d27a184...takuki:df74f79.html" title="Last updated on Feb 28, 2020, 12:15 AM UTC (df74f79)">Diff</a>