### PR TITLE
fix: remove wrong "," in example 17 TD snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -2663,7 +2663,7 @@ In summary, this requires the following:
                     },
                     "duration": {"type": "number"}
                 },
-                "required": ["to","duration"],
+                "required": ["to","duration"]
             },
             "output": {"type": "string"},
             "forms": [...]

--- a/index.template.html
+++ b/index.template.html
@@ -2612,7 +2612,7 @@ In summary, this requires the following:
                     },
                     "duration": {"type": "number"}
                 },
-                "required": ["to","duration"],
+                "required": ["to","duration"]
             },
             "output": {"type": "string"},
             "forms": [...]


### PR DESCRIPTION
...knowing that many TD examples are not valid JSON files as a "whole" this PR removes a wrong "," in the *middle* of a TD snippet