### PR TITLE
WIP: swap securtiy and securityDefinition in context file 

### DIFF
--- a/context/td-context-1.1.jsonld
+++ b/context/td-context-1.1.jsonld
@@ -104,7 +104,7 @@
       "@type": "@id",
       "@container": "@index"
     },
-    "security": {
+    "securityDefinitions": {
       "@id": "td:hasSecurityConfiguration",
       "@type": "@id",
       "@container": "@set",
@@ -168,7 +168,7 @@
         "oauth2": "wotsec:OAuth2SecurityScheme"
       }
     },
-    "securityDefinitions": {
+    "security": {
       "@id": "td:securityDefinitions",
       "@type": "@id",
       "@container": "@index"


### PR DESCRIPTION
This PR will fix the bug #915.

There some open questions:

- [ ] Why do we have two context files, td-context-1.1.jsonld and td-context.jsonld?
- [ ] There seems no definition for `td:securityDefinitions`, nor in validation or security ttl file:

<img width="380" alt="image" src="https://user-images.githubusercontent.com/13832739/88783483-1faa3b80-d18f-11ea-82de-be58beccbe82.png">

@vcharpenay may I ask you to check this.
