### PR TITLE
add "(WoT)" to the title

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Web of Things Thing Description 1.1</title>
+    <title>Web of Things (WoT) Thing Description 1.1</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class='remove'>
           var respecConfig = {

--- a/index.template.html
+++ b/index.template.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Web of Things Thing Description 1.1</title>
+    <title>Web of Things (WoT) Thing Description 1.1</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class='remove'>
           var respecConfig = {


### PR DESCRIPTION
The title of the WoT Thing Description 1.1 is currently "Web of Things Thing Description 1.1" and missing "(WoT)" right after "Web of Things". However, we should add "(WoT)" to make the title consistent with the 1.0 version spec, i.e., "Web of Things (WoT) Thing Description".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/996.html" title="Last updated on Nov 3, 2020, 8:02 AM UTC (1b8de19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/996/6e55ac6...1b8de19.html" title="Last updated on Nov 3, 2020, 8:02 AM UTC (1b8de19)">Diff</a>