### PR TITLE
fix duplicate definition of dfn-td-processor

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,7 +663,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         this specification.
     </dd>
     <dt>
-    <dfn id="dfn-td-processor">Thing Model</dfn>
+    <dfn id="dfn-thing-model">Thing Model</dfn>
     </dt>
     <dd>
         A <a>Thing Model</a> is a description for a class of Things that have the same 

--- a/index.template.html
+++ b/index.template.html
@@ -663,7 +663,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         this specification.
     </dd>
     <dt>
-    <dfn id="dfn-td-processor">Thing Model</dfn>
+    <dfn id="dfn-thing-model">Thing Model</dfn>
     </dt>
     <dd>
         A <a>Thing Model</a> is a description for a class of Things that have the same 


### PR DESCRIPTION
for FPWD publication based on my comment:
  https://lists.w3.org/Archives/Member/member-wot-wg/2020Nov/0008.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1009.html" title="Last updated on Nov 23, 2020, 9:22 AM UTC (d5aea3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1009/2d577f2...d5aea3d.html" title="Last updated on Nov 23, 2020, 9:22 AM UTC (d5aea3d)">Diff</a>