### PR TITLE
fix: duplicate section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1436,10 +1436,10 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                       information based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
                        information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema"><td><code>const</code></td><td>Provides a constant value.</td><td>optional</td><td>any type</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema"><td><code>unit</code></td><td>Provides unit information that is used, e.g.,
                 in international science, engineering, and
                 business.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema"><td><code>const</code></td><td>Provides a constant value.</td><td>optional</td><td>any type</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema"><td><code>oneOf</code></td><td>Used to ensure that the data is valid against
                 one of the specified schemas in the array.</td><td>optional</td><td><a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema"><td><code>enum</code></td><td>Restricted set of values provided as an
@@ -1839,10 +1839,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
    </section>
    <section id="sec-default-values">
-      <h3 id="x5-4-default-value-definitions"><bdi class=
-      "secno">5.4</bdi> Default Value Definitions<a class=
-      "self-link" aria-label="§" href=
-      "#sec-default-values"></a></h3>
+      <h3>Default Value Definitions</h3>
       <p><span class="rfc2119-assertion" id=
       "td-vocabulary-defaults">When assignments in a TD are
       missing, a <a href="#dfn-td-processor" class="internalDFN"
@@ -1851,7 +1848,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       "#dfn-default-value" class="internalDFN" data-link-type=
       "dfn">Default Value</a> assignments expressed in the table of
       <a href="#sec-default-values" class=
-      "sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> Default Value
+      "sec-ref">Default Value
       Definitions</a>.</span></p>
       <p>The following table gives all <a href="#dfn-default-value"
       class="internalDFN" data-link-type="dfn">Default Values</a>

--- a/index.template.html
+++ b/index.template.html
@@ -1166,10 +1166,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
    </section>
    <section id="sec-default-values">
-      <h3 id="x5-4-default-value-definitions"><bdi class=
-      "secno">5.4</bdi> Default Value Definitions<a class=
-      "self-link" aria-label="§" href=
-      "#sec-default-values"></a></h3>
+      <h3>Default Value Definitions</h3>
       <p><span class="rfc2119-assertion" id=
       "td-vocabulary-defaults">When assignments in a TD are
       missing, a <a href="#dfn-td-processor" class="internalDFN"
@@ -1178,7 +1175,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       "#dfn-default-value" class="internalDFN" data-link-type=
       "dfn">Default Value</a> assignments expressed in the table of
       <a href="#sec-default-values" class=
-      "sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> Default Value
+      "sec-ref">Default Value
       Definitions</a>.</span></p>
       <p>The following table gives all <a href="#dfn-default-value"
       class="internalDFN" data-link-type="dfn">Default Values</a>


### PR DESCRIPTION
* removes self references and such


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1013.html" title="Last updated on Nov 26, 2020, 1:22 PM UTC (3d5cc8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1013/b8e1f9e...danielpeintner:3d5cc8b.html" title="Last updated on Nov 26, 2020, 1:22 PM UTC (3d5cc8b)">Diff</a>