### PR TITLE
fix: respec warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
             , previousPublishDate: "2020-11-24"
             , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report.html"
             //, processVersion: 2020
-            , wgPatentPolicy: "PP2017"
+            //, wgPatentPolicy: "PP2017" // deprecated, "group" option sets this automatically
             , shortName:      "wot-thing-description11"
             , copyrightStart: 2017
             , noLegacyStyle:  true
@@ -227,7 +227,7 @@ a[href].internalDFN {
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         // let ReSpec do syntax highlighting first
-        document.respecIsReady.then(() => {
+        document.respec.ready.then(() => {
             document.querySelectorAll('.with-default').forEach(n => {
                 let wo = n.querySelector('pre:nth-of-type(1)');
                 let w = n.querySelector('pre:nth-of-type(2)');

--- a/index.template.html
+++ b/index.template.html
@@ -12,7 +12,7 @@
             , previousPublishDate: "2020-11-24"
             , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report.html"
             //, processVersion: 2020
-            , wgPatentPolicy: "PP2017"
+            //, wgPatentPolicy: "PP2017" // deprecated, "group" option sets this automatically
             , shortName:      "wot-thing-description11"
             , copyrightStart: 2017
             , noLegacyStyle:  true
@@ -227,7 +227,7 @@ a[href].internalDFN {
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         // let ReSpec do syntax highlighting first
-        document.respecIsReady.then(() => {
+        document.respec.ready.then(() => {
             document.querySelectorAll('.with-default').forEach(n => {
                 let wo = n.querySelector('pre:nth-of-type(1)');
                 let w = n.querySelector('pre:nth-of-type(2)');


### PR DESCRIPTION
fixes https://github.com/w3c/wot-thing-description/issues/1029

* Configuration options wgPatentPolicy are superseded by group and will be overridden by ReSpec. Please remove them from respecConfig.
* document.respecIsReady is deprecated and will be removed in a future release. Use document.respec.ready instead.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 14, 2021, 8:50 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fdanielpeintner%2Fwot-thing-description%2Fadbec86ae1123f19957992e8357bdad739eea7be%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 29148 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/wot-thing-description%231030.)._
</details>
