### PR TITLE
Add draft TD context URI

### DIFF
--- a/index.html
+++ b/index.html
@@ -5211,8 +5211,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         "thing-context-w3c-uri": {
             "type": "string",
             "enum": [
-                "https://www.w3.org/2019/wot/td/v1",
-                "http://www.w3.org/ns/td"
+                "https://www.w3.org/2019/wot/td/v1"
             ]
         },
         "thing-context": {

--- a/index.html
+++ b/index.html
@@ -5211,7 +5211,8 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         "thing-context-w3c-uri": {
             "type": "string",
             "enum": [
-                "https://www.w3.org/2019/wot/td/v1"
+                "https://www.w3.org/2019/wot/td/v1",
+                "http://www.w3.org/ns/td"
             ]
         },
         "thing-context": {

--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -60,7 +60,8 @@
         "thing-context-w3c-uri": {
             "type": "string",
             "enum": [
-                "https://www.w3.org/2019/wot/td/v1"
+                "https://www.w3.org/2019/wot/td/v1",
+                "http://www.w3.org/ns/td"
             ]
         },
         "thing-context": {


### PR DESCRIPTION
This adds the new context URI used in the latest draft. See the issue for details.

It closes #1036.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/farshidtz/wot-thing-description/pull/1038.html" title="Last updated on Jan 21, 2021, 10:39 PM UTC (01eac5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1038/091d6a0...farshidtz:01eac5e.html" title="Last updated on Jan 21, 2021, 10:39 PM UTC (01eac5e)">Diff</a>