### PR TITLE
fix: the "required" keyword was placed incorrectly in the TM schema

### DIFF
--- a/validation/tm-json-schema-validation.json
+++ b/validation/tm-json-schema-validation.json
@@ -94,6 +94,12 @@
         }
       ]
     },
+    "required_element": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "dataSchema": {
       "type": "object",
       "properties": {
@@ -249,12 +255,6 @@
         "properties": {
           "additionalProperties": {
             "$ref": "#/definitions/dataSchema"
-          }
-        },
-        "required": {
-          "type": "array",
-          "items": {
-            "type": "string"
           }
         }
       }
@@ -611,12 +611,6 @@
         "properties": {
           "additionalProperties": {
             "$ref": "#/definitions/dataSchema"
-          }
-        },
-        "required": {
-          "type": "array",
-          "items": {
-            "type": "string"
           }
         }
       },
@@ -1019,18 +1013,33 @@
     },
     "properties": {
       "type": "object",
+      "properties": {
+        "required": {
+          "$ref": "#/definitions/required_element"
+        }
+      },
       "additionalProperties": {
         "$ref": "#/definitions/property_element"
       }
     },
     "actions": {
       "type": "object",
+      "properties": {
+        "required": {
+          "$ref": "#/definitions/required_element"
+        }
+      },
       "additionalProperties": {
         "$ref": "#/definitions/action_element"
       }
     },
     "events": {
       "type": "object",
+      "properties": {
+        "required": {
+          "$ref": "#/definitions/required_element"
+        }
+      },
       "additionalProperties": {
         "$ref": "#/definitions/event_element"
       }


### PR DESCRIPTION
The current TM schema handles the "required" keyword not like the Thing Model draft describes.  https://w3c.github.io/wot-thing-description/#thing-model-td-required <br>

Currently the "required" keyword is placed inside the interactions when instead it should be placed on the interaction-level next to properties, actions and events. <br>

This PR updates the TM Schema to work correctly by creating a new "required_element" in the definitions and referencing it in the properties, actions and events sections.


