### PR TITLE
Two step generation of the TD from a TM 

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -4429,7 +4429,7 @@ instance.
     <p>
         <a>Thing Models</a> can be used as template to generate <a>Thing Description</a> based on the restriction defined in 
         Sections <a href="#sec-vocabulary-definition"></a> and <a href="#sec-td-serialization"></a>. During this process 
-        missing data such as communication and seceurity metadata have to be complemented to create valid <a>Thing Description</a> instances.
+        missing data such as communication and security metadata have to be complemented to create valid <a>Thing Description</a> instances.
         <span class="rfc2119-assertion" id="thing-model-td-generation-inconsistencies">
             A <a>Thing Model</a> MUST be defined in such a way that there are no inconsistencies that would result in a <a>Thing Description</a> not 
             being able to meet the requirements as described in Section <a href="#sec-vocabulary-definition"></a> and <a href="#sec-td-serialization"></a>.

--- a/index.template.html
+++ b/index.template.html
@@ -611,6 +611,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
   <dfn>Thing</dfn>,
   <dfn>Consumer</dfn>,
   <dfn>Thing Description</dfn> (<dfn>TD</dfn>),
+  <dfn>Partial TD</dfn>,
   <dfn>Interaction Model</dfn>,
   <dfn>Interaction Affordance</dfn>,
   <dfn>Property</dfn>,
@@ -4435,16 +4436,18 @@ instance.
             being able to meet the requirements as described in Section <a href="#sec-vocabulary-definition"></a> and <a href="#sec-td-serialization"></a>.
         </span>
         <span class="rfc2119-assertion" id="thing-model-td-generation-processor">
-            A TM-to-TD generation processor MUST at least address the following considerations:
-
+            A TM-to-TD generator to derive a <a>Thing Description</a> instance from a <a>Thing Model</a> MUST first transform it to a <a>Partial TD</a>:
          <ul>
-            <li>All definitions in the applied <a>Thing Model</a> have to taken over in the <a>Thing Description</a> instance. If used, the extension and imports feature according to Section <a href=#thing-model-extension-import></a> must be resolved 
-                and represented in the <a>Thing Description</a> instance as well. </li>
-            <li>The value <code>ThingModel</code> value of the top-level <code>@type</code> have to be replaced by the value <code>Thing</code> in the <a>Thing Description</a> instance.</li>
-            <li>If the <code>required</code> feature is used based on Section <a href=#thing-model-td-required></a>, the required interactions must definitly be taken over in the <a>Thing Description</a> instance.</li>
-            <li>If used, all placholder (see Section <a href="#thing-model-td-placeholder"></a>) in a <a>Thing Model</a> must be replaced with a valid corresponding value in the <a>Thing Description</a>.</li>
+            <li>Copy all definitions from the input <a>Thing Model</a> to the resulting <a>Partial TD</a> instance. If used, the extension and imports
+            feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href=#thing-model-extension-import></a>.</li>
+            <li>If used, remove from the current <a>Partial TD</a> <code>links</code> element the entry with <code>"rel":"extends"</code></li>
+            <li>The <code>ThingModel</code> value of the top-level <code>@type</code> MUST to be replaced by the value <code>Thing</code> in the <a>Partial TD</a> instance.</li>
+            <li>If the <code>required</code> feature is used based on Section <a href=#thing-model-td-required></a>, the required interactions MUST definitly be taken over in the <a>Partial TD</a> instance.</li>
+            <li>If used, all placholder (see Section <a href="#thing-model-td-placeholder"></a>) in the <a>Thing Model</a> MUST be replaced with a valid corresponding value in the <a>Partial TD</a>.</li>
+        </ul>
+        Finally, a TM-to-TD generator MUST take the resulting <a>Partial TD</a> and transform it into a <a>Thing Description</a> with this last step
+        <ul>
             <li>Missing communication and/or security metadata details have to be complemented in the <a>Thing Description</a> instance based on Section <a href=#security-serialization-json></a> and/or <a href=#form-serialization-json></a>.</li>
-            <li>If used, <code>links</code> entry with <code>"rel":"extends"</code> should not taken over in the <a>Thing Description</a> instance.
         </ul>
         </span>
 


### PR DESCRIPTION
This PR addresses the comments in #1047. In practice, it refactors the generation process of a Thing Description from a Thing Model in two distinct phases. In the first part, it creates a Partial TD. In other words, the process replaces every place holder and Thing Model specific keywords with the corresponding values. The resulting object is a Partial TD because it cannot be guaranteed that the original TM was fully complete (e.g., it did not have forms or security meta-data). Finally, the last phase describes how to take the resulting Partial TD (no extends, no place holders) and create a valid Thing Description. 

I consider this work as a first proposal and we might need to discuss a couple of points:
- Should we mandate a two-step generation process? I used the keyword MUST. We might need to consider if we just require the complete set of steps but not the fact that the processor MUST first have an intermediate Partial TD object. 
- The final step of the process is a little bit vague
- The algorithm does not mention any validation procedure, should we apply this process only to valid TMs?