### PR TITLE
fix: default op values for HTTP

### DIFF
--- a/index.html
+++ b/index.html
@@ -4787,8 +4787,10 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     "properties": {
         "status": {
             "type": "string",
+            "readOnly": true,
             "forms": [
                 {
+                    "op": "readproperty",
                     "href": "https://mylamp.example.com/status"
                 }
             ]
@@ -4833,16 +4835,12 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     "properties": {
         "status": {
             "type": "string",
+            "readOnly": true,
             "forms": [
                 {
                     "op": "readproperty",
                     "href": "https://mylamp.example.com/status",
                     "htv:methodName": "GET"
-                },
-                {
-                    "op": "writeproperty",
-                    "href": "https://mylamp.example.com/status",
-                    "htv:methodName": "PUT"
                 }
             ]
         }

--- a/index.template.html
+++ b/index.template.html
@@ -3821,8 +3821,10 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     "properties": {
         "status": {
             "type": "string",
+            "readOnly": true,
             "forms": [
                 {
+                    "op": "readproperty",
                     "href": "https://mylamp.example.com/status"
                 }
             ]
@@ -3867,16 +3869,12 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     "properties": {
         "status": {
             "type": "string",
+            "readOnly": true,
             "forms": [
                 {
                     "op": "readproperty",
                     "href": "https://mylamp.example.com/status",
                     "htv:methodName": "GET"
-                },
-                {
-                    "op": "writeproperty",
-                    "href": "https://mylamp.example.com/status",
-                    "htv:methodName": "PUT"
                 }
             ]
         }


### PR DESCRIPTION
fixes https://github.com/w3c/wot-thing-description/issues/1089


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1099.html" title="Last updated on Apr 20, 2021, 9:40 AM UTC (715b6dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1099/c51a957...danielpeintner:715b6dd.html" title="Last updated on Apr 20, 2021, 9:40 AM UTC (715b6dd)">Diff</a>