### PR TITLE
Add contentType default to canonicalization examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -4240,11 +4240,13 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
         "status": {
             "forms": [
                 {
+                    "contentType": "application/json",
                     "href": "https://mylamp.example.com/status",
                     "htv:methodName": "GET",
                     "op": "readproperty"
                 },
                 {
+                    "contentType": "application/json",
                     "href": "https://mylamp.example.com/status",
                     "htv:methodName": "PUT",
                     "op": "writeproperty"
@@ -4269,7 +4271,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
 
 However, the actual true <a>Canonical TD</a> has all extra whitespace removed, and looks like the following:
 <aside class="example" id="canonical-thing-description-nows" title="Canonical Thing Description Example - No White Space">
-<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty"},{"href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"security":"basic_sc","securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"title":"MyLampThing"}</pre>
+<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty"},{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"security":"basic_sc","securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"title":"MyLampThing"}</pre>
 </aside>
 
 </section>

--- a/index.template.html
+++ b/index.template.html
@@ -3274,11 +3274,13 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
         "status": {
             "forms": [
                 {
+                    "contentType": "application/json",
                     "href": "https://mylamp.example.com/status",
                     "htv:methodName": "GET",
                     "op": "readproperty"
                 },
                 {
+                    "contentType": "application/json",
                     "href": "https://mylamp.example.com/status",
                     "htv:methodName": "PUT",
                     "op": "writeproperty"
@@ -3303,7 +3305,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
 
 However, the actual true <a>Canonical TD</a> has all extra whitespace removed, and looks like the following:
 <aside class="example" id="canonical-thing-description-nows" title="Canonical Thing Description Example - No White Space">
-<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty"},{"href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"security":"basic_sc","securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"title":"MyLampThing"}</pre>
+<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty"},{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"security":"basic_sc","securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"title":"MyLampThing"}</pre>
 </aside>
 
 </section>


### PR DESCRIPTION
resolves https://github.com/w3c/wot-thing-description/issues/1106


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-thing-description/pull/1110.html" title="Last updated on Apr 23, 2021, 10:41 PM UTC (5ab7391)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1110/2cceb3a...mmccool:5ab7391.html" title="Last updated on Apr 23, 2021, 10:41 PM UTC (5ab7391)">Diff</a>