### PR TITLE
Add fracsec rule to dateTime in Canonical TD

### DIFF
--- a/index.html
+++ b/index.html
@@ -4158,12 +4158,19 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   the JSON serialization of a TD.  
   The following sequence of transformations and constraints are then applied: 
   <ol>
-  <li><span class="rfc2119-assertion" id="canonical-datetime">
+  <li><span class="rfc2119-assertion" id="canonical-datetime-timezone">
   In the <a>Canonical TD</a>, 
   values that are of type <code>dateTime</code>
-  MUST use the literal <code>Z</code> 
+  MUST use the literal "<code>Z</code>" 
   representing the UTC time zone instead 
-  of an offset.
+  of an offset.</span>
+  </li>
+  <li><span class="rfc2119-assertion" id="canonical-datetime-fracsec">
+  In the <a>Canonical TD</a>, 
+  values that are of type <code>dateTime</code>
+  will serialize the fractional part of the seconds field as other numbers under the JSON Canonicalization Scheme, 
+  except that negative numbers and exponents are not permitted.</span>
+  Note that trailing zeros and zero fractional seconds are not permitted under this serialization.
   </li>
   <li><span class="rfc2119-assertion" id="canonical-defaults">
   In the <a>Canonical TD</a>,

--- a/index.template.html
+++ b/index.template.html
@@ -3192,12 +3192,19 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   the JSON serialization of a TD.  
   The following sequence of transformations and constraints are then applied: 
   <ol>
-  <li><span class="rfc2119-assertion" id="canonical-datetime">
+  <li><span class="rfc2119-assertion" id="canonical-datetime-timezone">
   In the <a>Canonical TD</a>, 
   values that are of type <code>dateTime</code>
-  MUST use the literal <code>Z</code> 
+  MUST use the literal "<code>Z</code>" 
   representing the UTC time zone instead 
-  of an offset.
+  of an offset.</span>
+  </li>
+  <li><span class="rfc2119-assertion" id="canonical-datetime-fracsec">
+  In the <a>Canonical TD</a>, 
+  values that are of type <code>dateTime</code>
+  will serialize the fractional part of the seconds field as other numbers under the JSON Canonicalization Scheme, 
+  except that negative numbers and exponents are not permitted.</span>
+  Note that trailing zeros and zero fractional seconds are not permitted under this serialization.
   </li>
   <li><span class="rfc2119-assertion" id="canonical-defaults">
   In the <a>Canonical TD</a>,


### PR DESCRIPTION
resolves https://github.com/w3c/wot-thing-description/issues/1105


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-thing-description/pull/1111.html" title="Last updated on Apr 23, 2021, 11:21 PM UTC (17fdf29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1111/2cceb3a...mmccool:17fdf29.html" title="Last updated on Apr 23, 2021, 11:21 PM UTC (17fdf29)">Diff</a>