### PR TITLE
Add validation for icon links

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -766,12 +766,12 @@
                 },
                 {
                     "not": {
-                        "description": "A basic link element should not contain icon or extends",
+                        "description": "A basic link element should not contain icon or tm:extends",
                         "properties": {
                             "rel": {
                                 "enum": [
                                     "icon",
-                                    "extends"
+                                    "tm:extends"
                                 ]
                             }
                         },

--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -726,7 +726,7 @@
             ],
             "additionalProperties": true
         },
-        "link_element": {
+        "base_link_element": {
             "type": "object",
             "properties": {
                 "href": {
@@ -736,8 +736,7 @@
                     "type": "string"
                 },
                 "rel": {
-                    "type": "string",
-                    "not": {"const":"extends"}
+                    "type": "string"
                 },
                 "anchor": {
                     "$ref": "#/definitions/anyUri"
@@ -747,6 +746,59 @@
                 "href"
             ],
             "additionalProperties": true
+        },
+        "link_element": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/base_link_element"
+                },
+                {
+                    "not": {
+                        "description": "A basic link element should not contain sizes",
+                        "type": "object",
+                        "properties": {
+                            "sizes": {}
+                        },
+                        "required": [
+                            "sizes"
+                        ]
+                    }
+                },
+                {
+                    "not": {
+                        "description": "A basic link element should not contain icon or extends",
+                        "properties": {
+                            "rel": {
+                                "enum": [
+                                    "icon",
+                                    "extends"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "rel"
+                        ]
+                    }
+                }
+            ]
+        },
+        "icon_link_element": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/base_link_element"
+                },
+                {
+                    "properties": {
+                        "rel": {
+                            "const": "icon"
+                        },
+                        "sizes": {
+                            "type": "string",
+                            "pattern": "[0-9]*x[0-9]+"
+                        }
+                    }
+                }
+            ]
         },
         "securityScheme": {
             "oneOf": [{
@@ -1144,7 +1196,14 @@
         "links": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/link_element"
+                "oneOf": [
+                    {
+                        "$ref": "#/definitions/link_element"
+                    },
+                    {
+                        "$ref": "#/definitions/icon_link_element"
+                    }
+                ]
             }
         },
         "forms": {


### PR DESCRIPTION
#1103 introduced the icon relation type for TD links together with a new attribute called `sizes`. The current specs says that the `sizes` is only allowed for links that have ` "rel":"icon"` but the JSONSchema was not updated. This PR updates the JSON  Schema and validate the `sizes` field using the proposed format:
> The value pattern follows {Height}x{Width} (e.g., "16x16", "16x16 32x32").

Thanks, @egekorkan for reviewing the proposal 👍🏻 . 