### PR TITLE
More fixes to canonicalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -4264,7 +4264,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   </p><p>
   Some of the choices leading to the efficient computation of a canonical form, 
   such as the suppression of white space and sorting of elements in objects 
-  do make the representation less human readable.
+  do make the representation less human readable, more verbose, and more redundant.
   In general, the canonical form presented here is optimized for machine-to-machine
   use cases such as signing.
   </p>
@@ -4303,6 +4303,17 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   Note that this also applies to extension vocabularies, e.g. for protocol bindings.
   If any such extension defines default values they must be given explicitly in the canonical form.
   </li>
+<!--
+  <li><span class="rfc2119-assertion" id="canonical-no-base">
+  In the <a>Canonical TD</a>,
+  <code>base</code> MUST NOT be used.</span>  
+  All URLs need to be given in absolute form.
+  </li>
+-->
+  <li><span class="rfc2119-assertion" id="canonical-prefix-mandatory">
+  In the Canonical TD, if a prefix is
+  defined it MUST be used in place of that URL.</span>
+  </li>
   <li><span class="rfc2119-assertion" id="canonical-singleton-arrays">
   In the <a>Canonical TD</a>,
   all values that can be expressed as either an array or as a single value 
@@ -4337,19 +4348,46 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   <span class="rfc2119-assertion" id="processors-preserve-prefixes">
   In order to support canonicalization, implementations 
   of TD Processors MUST preserve the prefixes used for extension vocabularies.</span>
-  This includes preserving and expressing a vocabulary term as a URL if no prefix was used.
+  This includes preserving and expressing a vocabulary term as a URL 
+  if no prefix is defined for that URL.
+  However, we need to
+  support stable reserialization in TD Processors that expand all
+  prefixes into URLs and then need to collapse them back to prefixes
+  when TDs are exported.
+  This is why if a prefix is defined, it is mandatory to use it in
+  place of the corresponding URL.
   </p><p>
   Some systems support different forms of URLs that are equivalent, for example,
   by mapping upper to lower case.  It is also legal to percent-encode
   unreserved characters, even though this is unnecessary and discouraged [[!RFC3986]]. 
   For canonicalization, however, such URL variants cannot be considered equivalent.
-  <span class="rfc2119-assertion" id="processors-preserve-prefixes">
+  <span class="rfc2119-assertion" id="processors-preserve-URLs">
   In order to support canonicalization, implementations 
-  of TD Processors MUST NOT modify input URLs.</span>
+  of TD Processors MUST NOT modify how input URLs are expressed.
+  </span>
   Of course some applications will need to modify URLs in TDs, 
   i.e. to express the result of protocol translation
   or to add entry points to a proxy.
+  Installation of a TD may also require modifying the base URL.
   The result should technically be considered a new TD related to the old one, but not equivalent.
+<!--
+  This is also why <code>base</code> is forbidden in Canonical TDs, since it
+  leads to multiple ways to express the same URLs.
+-->
+  Note that the use of <code>base</code> can also technically
+  lead to different ways to 
+  express the same URL.
+  However, the URLs that <code>base</code>
+  refers to are interaction endpoints, not semantic terms, and so 
+  should not be affected by semantic processing.  
+  Although it is just a special case of the above rule, we will
+  state this explicitly for clarity:
+  <span class="rfc2119-assertion" id="processors-preserve-base">
+  In order to support canonicalization, implementations 
+  of TD Processors MUST NOT modify how input URLs are expressed
+  as a combination of <code>base</code> and a relative URL in an
+  interaction.</span>
+  </p>
   </p><p>
   TDs should be validated before being canonicalized.  
   TD validation requires that URLs

--- a/index.html
+++ b/index.html
@@ -1913,7 +1913,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 <tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link"><td><code>sizes</code></td><td>Target attribute that specifies one or more sizes for the referenced icon. 
                     Only applicable for relation type "icon". The value pattern follows 
                     {Height}x{Width} (e.g., "16x16", "16x16 32x32").</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table> <p>Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description
-    is an instance of a specific Thing Model), or to further documentations information (e.g., device manuel of a Thing). It is recommended to reuse existing and established 
+    is an instance of a specific Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended to reuse existing and established 
     <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
     </p>
         <p>In the following a best practice relation type table is introduced that is recommended to use within WoT <a>Thing Description</a>

--- a/index.html
+++ b/index.html
@@ -4369,14 +4369,6 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   Note that this also applies to extension vocabularies, e.g. for protocol bindings.
   If any such extension defines default values they must be given explicitly in the canonical form.
   </li>
-  <li><span class="rfc2119-assertion" id="canonical-form-security">
-  In the <a>Canonical TD</a>,
-  <code>security</code> MUST NOT be used at the <code>Thing</code> level.</span>
-  Instead, assignment of <code>SecurityScheme</code> configuration objects
-  to interactions need to all take place at the <code>Form</code> level. 
-  This means that in a <a>Canonical TD</a> every <code>Form</code> must have 
-  a <code>security</code> entry (even if they are all the same).
-  </li>
   <li><span class="rfc2119-assertion" id="canonical-prefix-mandatory">
   In the Canonical TD, if a prefix is
   defined it MUST be used in place of that URL.</span>
@@ -4428,13 +4420,24 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   using different names for the <code>SecurityScheme</code> objects defined in 
   <code>securityDefinitions</code>, since these are just arbitrary strings 
   acting as internal references to definitions.
-  However, to avoid variants, these names should be preserved as well.
+  However, to avoid variants, these names should be preserved.
   <span class="rfc2119-assertion" id="processors-preserve-security-names">
   In order to support canonicalization, implementations 
   of TD Processors MUST preserve the strings used to identify <code>SecurityScheme</code>
   objects in <code>SecurityDefinitions</code> and referenced in <code>security</code>
   elements.</span>
   </p><p>
+  Another issue that arises with <code>security</code> is that the
+  same <code>SecurityScheme</code> could be redundantly applied at both the 
+  <code>Thing</code> and <code>Form</code> level.  
+  <span class="rfc2119-assertion" id="processors-preserve-security-instances">
+  In order to support canonicalization, implementations 
+  of TD Processors MUST preserve the presence (and absence) of 
+  <code>security</code> terms at the <code>Form</code> level.</span>
+  In other words, in order to avoid generating variant serializations,
+  a TD processor must not attempt to "optimize" a TD by removing such
+  redundant definitions.
+  <p>
   Some systems support different forms of URLs that are equivalent, for example,
   by mapping upper to lower case.  It is also legal to percent-encode
   unreserved characters, even though this is unnecessary and discouraged [[!RFC3986]]. 

--- a/index.html
+++ b/index.html
@@ -4303,13 +4303,14 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   Note that this also applies to extension vocabularies, e.g. for protocol bindings.
   If any such extension defines default values they must be given explicitly in the canonical form.
   </li>
-<!--
-  <li><span class="rfc2119-assertion" id="canonical-no-base">
+  <li><span class="rfc2119-assertion" id="canonical-form-security">
   In the <a>Canonical TD</a>,
-  <code>base</code> MUST NOT be used.</span>  
-  All URLs need to be given in absolute form.
+  <code>security</code> MUST NOT be used at the <code>Thing</code> level.</span>
+  Instead, assignment of <code>SecurityScheme</code> configuration objects
+  to interactions need to all take place at the <code>Form</code> level. 
+  This means that in a <a>Canonical TD</a> every <code>Form</code> must have 
+  a <code>security</code> entry (even if they are all the same).
   </li>
--->
   <li><span class="rfc2119-assertion" id="canonical-prefix-mandatory">
   In the Canonical TD, if a prefix is
   defined it MUST be used in place of that URL.</span>
@@ -4370,11 +4371,8 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   or to add entry points to a proxy.
   Installation of a TD may also require modifying the base URL.
   The result should technically be considered a new TD related to the old one, but not equivalent.
-<!--
-  This is also why <code>base</code> is forbidden in Canonical TDs, since it
-  leads to multiple ways to express the same URLs.
--->
-  Note that the use of <code>base</code> can also technically
+  </p><p>
+  The use of <code>base</code> can also technically
   lead to different ways to 
   express the same URL.
   However, the URLs that <code>base</code>
@@ -4409,13 +4407,15 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
                     "contentType": "application/json",
                     "href": "https://mylamp.example.com/status",
                     "htv:methodName": "GET",
-                    "op": "readproperty"
+                    "op": "readproperty",
+                    "security": "basic_sc"
                 },
                 {
                     "contentType": "application/json",
                     "href": "https://mylamp.example.com/status",
                     "htv:methodName": "PUT",
-                    "op": "writeproperty"
+                    "op": "writeproperty",
+                    "security": "basic_sc"
                 }
             ],
             "observable": false,
@@ -4424,7 +4424,6 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
             "writeOnly": false
         }
     },
-    "security": "basic_sc",
     "securityDefinitions": {
         "basic_sc": {
             "in": "header",
@@ -4437,7 +4436,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
 
 However, the actual true <a>Canonical TD</a> has all extra whitespace removed, and looks like the following:
 <aside class="example" id="canonical-thing-description-nows" title="Canonical Thing Description Example - No White Space">
-<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty"},{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"security":"basic_sc","securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"title":"MyLampThing"}</pre>
+<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty","security":"basic_sc"},{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty","security":"basic_sc"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"title":"MyLampThing"}</pre>
 </aside>
 
 </section>

--- a/index.html
+++ b/index.html
@@ -4358,6 +4358,17 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   This is why if a prefix is defined, it is mandatory to use it in
   place of the corresponding URL.
   </p><p>
+  Likewise, it would be in theory be possible to express the same information
+  using different names for the <code>SecurityScheme</code> objects defined in 
+  <code>securityDefinitions</code>, since these are just arbitrary strings 
+  acting as internal references to definitions.
+  However, to avoid variants, these names should be preserved as well.
+  <span class="rfc2119-assertion" id="processors-preserve-security-names">
+  In order to support canonicalization, implementations 
+  of TD Processors MUST preserve the strings used to identify <code>SecurityScheme</code>
+  objects in <code>SecurityDefinitions</code> and referenced in <code>security</code>
+  elements.</span>
+  </p><p>
   Some systems support different forms of URLs that are equivalent, for example,
   by mapping upper to lower case.  It is also legal to percent-encode
   unreserved characters, even though this is unnecessary and discouraged [[!RFC3986]]. 

--- a/index.html
+++ b/index.html
@@ -1847,7 +1847,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 <tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link"><td><code>sizes</code></td><td>Target attribute that specifies one or more sizes for the referenced icon. 
                     Only applicable for relation type "icon". The value pattern follows 
                     {Height}x{Width} (e.g., "16x16", "16x16 32x32").</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table> <p>Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description
-    is an instance of a specific Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended to reuse existing and established 
+    is an instance of a specific Thing Model), or to further documentations information (e.g., device manuel of a Thing). It is recommended to reuse existing and established 
     <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
     </p>
         <p>In the following a best practice relation type table is introduced that is recommended to use within WoT <a>Thing Description</a>

--- a/index.html
+++ b/index.html
@@ -4330,7 +4330,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   </p><p>
   Some of the choices leading to the efficient computation of a canonical form, 
   such as the suppression of white space and sorting of elements in objects 
-  do make the representation less human readable, more verbose, and more redundant.
+  do make the representation less human readable.
   In general, the canonical form presented here is optimized for machine-to-machine
   use cases such as signing.
   </p>

--- a/index.template.html
+++ b/index.template.html
@@ -3318,7 +3318,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   </p><p>
   Some of the choices leading to the efficient computation of a canonical form, 
   such as the suppression of white space and sorting of elements in objects 
-  do make the representation less human readable, more verbose, and more redundant.
+  do make the representation less human readable.
   In general, the canonical form presented here is optimized for machine-to-machine
   use cases such as signing.
   </p>

--- a/index.template.html
+++ b/index.template.html
@@ -3357,14 +3357,6 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   Note that this also applies to extension vocabularies, e.g. for protocol bindings.
   If any such extension defines default values they must be given explicitly in the canonical form.
   </li>
-  <li><span class="rfc2119-assertion" id="canonical-form-security">
-  In the <a>Canonical TD</a>,
-  <code>security</code> MUST NOT be used at the <code>Thing</code> level.</span>
-  Instead, assignment of <code>SecurityScheme</code> configuration objects
-  to interactions need to all take place at the <code>Form</code> level. 
-  This means that in a <a>Canonical TD</a> every <code>Form</code> must have 
-  a <code>security</code> entry (even if they are all the same).
-  </li>
   <li><span class="rfc2119-assertion" id="canonical-prefix-mandatory">
   In the Canonical TD, if a prefix is
   defined it MUST be used in place of that URL.</span>
@@ -3416,13 +3408,24 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   using different names for the <code>SecurityScheme</code> objects defined in 
   <code>securityDefinitions</code>, since these are just arbitrary strings 
   acting as internal references to definitions.
-  However, to avoid variants, these names should be preserved as well.
+  However, to avoid variants, these names should be preserved.
   <span class="rfc2119-assertion" id="processors-preserve-security-names">
   In order to support canonicalization, implementations 
   of TD Processors MUST preserve the strings used to identify <code>SecurityScheme</code>
   objects in <code>SecurityDefinitions</code> and referenced in <code>security</code>
   elements.</span>
   </p><p>
+  Another issue that arises with <code>security</code> is that the
+  same <code>SecurityScheme</code> could be redundantly applied at both the 
+  <code>Thing</code> and <code>Form</code> level.  
+  <span class="rfc2119-assertion" id="processors-preserve-security-instances">
+  In order to support canonicalization, implementations 
+  of TD Processors MUST preserve the presence (and absence) of 
+  <code>security</code> terms at the <code>Form</code> level.</span>
+  In other words, in order to avoid generating variant serializations,
+  a TD processor must not attempt to "optimize" a TD by removing such
+  redundant definitions.
+  <p>
   Some systems support different forms of URLs that are equivalent, for example,
   by mapping upper to lower case.  It is also legal to percent-encode
   unreserved characters, even though this is unnecessary and discouraged [[!RFC3986]]. 

--- a/index.template.html
+++ b/index.template.html
@@ -3291,13 +3291,14 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   Note that this also applies to extension vocabularies, e.g. for protocol bindings.
   If any such extension defines default values they must be given explicitly in the canonical form.
   </li>
-<!--
-  <li><span class="rfc2119-assertion" id="canonical-no-base">
+  <li><span class="rfc2119-assertion" id="canonical-form-security">
   In the <a>Canonical TD</a>,
-  <code>base</code> MUST NOT be used.</span>  
-  All URLs need to be given in absolute form.
+  <code>security</code> MUST NOT be used at the <code>Thing</code> level.</span>
+  Instead, assignment of <code>SecurityScheme</code> configuration objects
+  to interactions need to all take place at the <code>Form</code> level. 
+  This means that in a <a>Canonical TD</a> every <code>Form</code> must have 
+  a <code>security</code> entry (even if they are all the same).
   </li>
--->
   <li><span class="rfc2119-assertion" id="canonical-prefix-mandatory">
   In the Canonical TD, if a prefix is
   defined it MUST be used in place of that URL.</span>
@@ -3358,11 +3359,8 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   or to add entry points to a proxy.
   Installation of a TD may also require modifying the base URL.
   The result should technically be considered a new TD related to the old one, but not equivalent.
-<!--
-  This is also why <code>base</code> is forbidden in Canonical TDs, since it
-  leads to multiple ways to express the same URLs.
--->
-  Note that the use of <code>base</code> can also technically
+  </p><p>
+  The use of <code>base</code> can also technically
   lead to different ways to 
   express the same URL.
   However, the URLs that <code>base</code>
@@ -3397,13 +3395,15 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
                     "contentType": "application/json",
                     "href": "https://mylamp.example.com/status",
                     "htv:methodName": "GET",
-                    "op": "readproperty"
+                    "op": "readproperty",
+                    "security": "basic_sc"
                 },
                 {
                     "contentType": "application/json",
                     "href": "https://mylamp.example.com/status",
                     "htv:methodName": "PUT",
-                    "op": "writeproperty"
+                    "op": "writeproperty",
+                    "security": "basic_sc"
                 }
             ],
             "observable": false,
@@ -3412,7 +3412,6 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
             "writeOnly": false
         }
     },
-    "security": "basic_sc",
     "securityDefinitions": {
         "basic_sc": {
             "in": "header",
@@ -3425,7 +3424,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
 
 However, the actual true <a>Canonical TD</a> has all extra whitespace removed, and looks like the following:
 <aside class="example" id="canonical-thing-description-nows" title="Canonical Thing Description Example - No White Space">
-<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty"},{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"security":"basic_sc","securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"title":"MyLampThing"}</pre>
+<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty","security":"basic_sc"},{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty","security":"basic_sc"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"title":"MyLampThing"}</pre>
 </aside>
 
 </section>

--- a/index.template.html
+++ b/index.template.html
@@ -3346,6 +3346,17 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   This is why if a prefix is defined, it is mandatory to use it in
   place of the corresponding URL.
   </p><p>
+  Likewise, it would be in theory be possible to express the same information
+  using different names for the <code>SecurityScheme</code> objects defined in 
+  <code>securityDefinitions</code>, since these are just arbitrary strings 
+  acting as internal references to definitions.
+  However, to avoid variants, these names should be preserved as well.
+  <span class="rfc2119-assertion" id="processors-preserve-security-names">
+  In order to support canonicalization, implementations 
+  of TD Processors MUST preserve the strings used to identify <code>SecurityScheme</code>
+  objects in <code>SecurityDefinitions</code> and referenced in <code>security</code>
+  elements.</span>
+  </p><p>
   Some systems support different forms of URLs that are equivalent, for example,
   by mapping upper to lower case.  It is also legal to percent-encode
   unreserved characters, even though this is unnecessary and discouraged [[!RFC3986]]. 

--- a/index.template.html
+++ b/index.template.html
@@ -3252,7 +3252,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   </p><p>
   Some of the choices leading to the efficient computation of a canonical form, 
   such as the suppression of white space and sorting of elements in objects 
-  do make the representation less human readable.
+  do make the representation less human readable, more verbose, and more redundant.
   In general, the canonical form presented here is optimized for machine-to-machine
   use cases such as signing.
   </p>
@@ -3291,6 +3291,17 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   Note that this also applies to extension vocabularies, e.g. for protocol bindings.
   If any such extension defines default values they must be given explicitly in the canonical form.
   </li>
+<!--
+  <li><span class="rfc2119-assertion" id="canonical-no-base">
+  In the <a>Canonical TD</a>,
+  <code>base</code> MUST NOT be used.</span>  
+  All URLs need to be given in absolute form.
+  </li>
+-->
+  <li><span class="rfc2119-assertion" id="canonical-prefix-mandatory">
+  In the Canonical TD, if a prefix is
+  defined it MUST be used in place of that URL.</span>
+  </li>
   <li><span class="rfc2119-assertion" id="canonical-singleton-arrays">
   In the <a>Canonical TD</a>,
   all values that can be expressed as either an array or as a single value 
@@ -3325,19 +3336,46 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   <span class="rfc2119-assertion" id="processors-preserve-prefixes">
   In order to support canonicalization, implementations 
   of TD Processors MUST preserve the prefixes used for extension vocabularies.</span>
-  This includes preserving and expressing a vocabulary term as a URL if no prefix was used.
+  This includes preserving and expressing a vocabulary term as a URL 
+  if no prefix is defined for that URL.
+  However, we need to
+  support stable reserialization in TD Processors that expand all
+  prefixes into URLs and then need to collapse them back to prefixes
+  when TDs are exported.
+  This is why if a prefix is defined, it is mandatory to use it in
+  place of the corresponding URL.
   </p><p>
   Some systems support different forms of URLs that are equivalent, for example,
   by mapping upper to lower case.  It is also legal to percent-encode
   unreserved characters, even though this is unnecessary and discouraged [[!RFC3986]]. 
   For canonicalization, however, such URL variants cannot be considered equivalent.
-  <span class="rfc2119-assertion" id="processors-preserve-prefixes">
+  <span class="rfc2119-assertion" id="processors-preserve-URLs">
   In order to support canonicalization, implementations 
-  of TD Processors MUST NOT modify input URLs.</span>
+  of TD Processors MUST NOT modify how input URLs are expressed.
+  </span>
   Of course some applications will need to modify URLs in TDs, 
   i.e. to express the result of protocol translation
   or to add entry points to a proxy.
+  Installation of a TD may also require modifying the base URL.
   The result should technically be considered a new TD related to the old one, but not equivalent.
+<!--
+  This is also why <code>base</code> is forbidden in Canonical TDs, since it
+  leads to multiple ways to express the same URLs.
+-->
+  Note that the use of <code>base</code> can also technically
+  lead to different ways to 
+  express the same URL.
+  However, the URLs that <code>base</code>
+  refers to are interaction endpoints, not semantic terms, and so 
+  should not be affected by semantic processing.  
+  Although it is just a special case of the above rule, we will
+  state this explicitly for clarity:
+  <span class="rfc2119-assertion" id="processors-preserve-base">
+  In order to support canonicalization, implementations 
+  of TD Processors MUST NOT modify how input URLs are expressed
+  as a combination of <code>base</code> and a relative URL in an
+  interaction.</span>
+  </p>
   </p><p>
   TDs should be validated before being canonicalized.  
   TD validation requires that URLs


### PR DESCRIPTION
- Discuss use of base.  In particular, add a clarification that the previous assertion about not changing the expression of URLs *includes* not changing how URLs used for interaction endpoints are expressed as a combination of base and relative URLs.  This is also meant to address the point about base raised in https://github.com/w3c/wot-profile/pull/57
- Add an assertion stating that if a prefix is defined, it MUST be used in place of that URL.  This is to support stable round-tripping where we may expand prefixes into URLs and then on export have to "un-expand" them.  If a URL was used in place of a prefix in the input it would be a legal TD, but the unexpansion would replace it with the prefix, which would result in a serialization different than the input.
- <s>Update: No "security" at the Thing level, and added assertion that names of securityDefinitions must be preserved.  This avoids problems with "equivalent" TDs using different names for these definitions.  See comments below.</s> (REVERTED)

Note that some of these choices mean that there will be Canonical TDs defining the same "information" that are considered different.  For instance, "not changing the way URLs are expressed" means that TDs that split up base and (relative) interaction URLs differently will be considered different, even though they actually refer to the same endpoints.  Likewise not changing prefixes means we can have any number of TDs with different prefixes that refer to the same URLs for those vocabularies, and therefore technically have the same semantics.  Therefore the goal is not really to stably canonicalize the semantic information itself, but the *expression* (serialization) of a given set of information.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-thing-description/pull/1129.html" title="Last updated on May 28, 2021, 1:27 PM UTC (ec5c17b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1129/f95085b...mmccool:ec5c17b.html" title="Last updated on May 28, 2021, 1:27 PM UTC (ec5c17b)">Diff</a>