### PR TITLE
fix: ReSpec rendering issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -5769,7 +5769,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     In such a case the placeholder labeling MAY be used in Thing Model that MUST be substituted with a concrete value when TD instance is created 
     from the Thing Model. 
     <span class="rfc2119-assertion" id="td-model-placeholder">
-        The string-based pattern of the placeholder MUST follow <code>{{PLACEHOLDER_IDENTIFIER}}</code>, 
+        The string-based pattern of the placeholder MUST follow <code>{{\PLACEHOLDER_IDENTIFIER}}</code>, 
         which should contain a placeholder identifier name. The identifier name can be used to identify the placeholder for the substitution process.
     </span>
     <span class="rfc2119-assertion" id="td-model-placeholder-value">

--- a/index.template.html
+++ b/index.template.html
@@ -4757,7 +4757,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     In such a case the placeholder labeling MAY be used in Thing Model that MUST be substituted with a concrete value when TD instance is created 
     from the Thing Model. 
     <span class="rfc2119-assertion" id="td-model-placeholder">
-        The string-based pattern of the placeholder MUST follow <code>{{PLACEHOLDER_IDENTIFIER}}</code>, 
+        The string-based pattern of the placeholder MUST follow <code>{{\PLACEHOLDER_IDENTIFIER}}</code>, 
         which should contain a placeholder identifier name. The identifier name can be used to identify the placeholder for the substitution process.
     </span>
     <span class="rfc2119-assertion" id="td-model-placeholder-value">


### PR DESCRIPTION
https://github.com/w3c/respec/wiki/ReSpec-Editor's-Guide#escaping-references


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1132.html" title="Last updated on May 10, 2021, 8:52 AM UTC (a4b7fe4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1132/6e6268f...danielpeintner:a4b7fe4.html" title="Last updated on May 10, 2021, 8:52 AM UTC (a4b7fe4)">Diff</a>