### PR TITLE
fix: tweak minor example bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2854,7 +2854,7 @@ In summary, this requires the following:
     ],
     "title": "MeinDing",
     "titles": {
-        "en":"MyThing",
+        "en": "MyThing",
         "de": "MeinDing",
         "ja": "私の物",
         "zh-Hans": "我的东西", 
@@ -2862,7 +2862,7 @@ In summary, this requires the following:
     },
     "description": "Menschenlesbare Informationen.",
     "descriptions": {
-        "en":"Human readable information.",
+        "en": "Human readable information.",
         "de": "Menschenlesbare Informationen.",
         "ja": "人間が読むことができる情報",
         "zh-Hans": "人们可阅读的信息", 
@@ -3045,7 +3045,7 @@ In summary, this requires the following:
         },
         "combo_sc": {
             "scheme": "combo",
-            "allOf": ["proxy_sc", "bearer_sc"],
+            "allOf": ["proxy_sc", "bearer_sc"]
         }
     },
     "security": "combo_sc",
@@ -3954,7 +3954,7 @@ is shown below:
 			    "op": "readproperty", 
 			    "href": "coaps://mylamp.example.com/lastPicture", 
 			    "cov:methodName": "GET",
-                "contentType": "application/json" 
+			    "contentType": "application/json" 
 		    }] 
         }
     },
@@ -4676,10 +4676,12 @@ However, the actual true <a>Canonical TD</a> has all extra whitespace removed, a
 
 <pre class="example" id="saref-geolocation-annotation-example-3">
 {
-    "@context": "http://www.w3.org/ns/td",
+    "@context": [
+        "http://www.w3.org/ns/td",
         {
             "schema": "http://schema.org#"
         }
+    ],
     ...
     "properties": {
         "position": {

--- a/index.template.html
+++ b/index.template.html
@@ -1842,7 +1842,7 @@ In summary, this requires the following:
     ],
     "title": "MeinDing",
     "titles": {
-        "en":"MyThing",
+        "en": "MyThing",
         "de": "MeinDing",
         "ja": "私の物",
         "zh-Hans": "我的东西", 
@@ -1850,7 +1850,7 @@ In summary, this requires the following:
     },
     "description": "Menschenlesbare Informationen.",
     "descriptions": {
-        "en":"Human readable information.",
+        "en": "Human readable information.",
         "de": "Menschenlesbare Informationen.",
         "ja": "人間が読むことができる情報",
         "zh-Hans": "人们可阅读的信息", 
@@ -2033,7 +2033,7 @@ In summary, this requires the following:
         },
         "combo_sc": {
             "scheme": "combo",
-            "allOf": ["proxy_sc", "bearer_sc"],
+            "allOf": ["proxy_sc", "bearer_sc"]
         }
     },
     "security": "combo_sc",
@@ -2942,7 +2942,7 @@ is shown below:
 			    "op": "readproperty", 
 			    "href": "coaps://mylamp.example.com/lastPicture", 
 			    "cov:methodName": "GET",
-                "contentType": "application/json" 
+			    "contentType": "application/json" 
 		    }] 
         }
     },
@@ -3664,10 +3664,12 @@ However, the actual true <a>Canonical TD</a> has all extra whitespace removed, a
 
 <pre class="example" id="saref-geolocation-annotation-example-3">
 {
-    "@context": "http://www.w3.org/ns/td",
+    "@context": [
+        "http://www.w3.org/ns/td",
         {
             "schema": "http://schema.org#"
         }
+    ],
     ...
     "properties": {
         "position": {


### PR DESCRIPTION
### Example 8
https://w3c.github.io/wot-thing-description/#example-8
spaces in 
* `"en":"MyThing",`
* `"en":"Human readable information.",`

### Example 12
https://w3c.github.io/wot-thing-description/#security-digest-example2
trailing `,` in

```
    "combo_sc": {
        "scheme": "combo",
        "allOf": ["proxy_sc", "bearer_sc"],
    }
```

### Example 32
https://w3c.github.io/wot-thing-description/#example-32
.. proper nesting `contentType`


###  Example 43
https://w3c.github.io/wot-thing-description/#saref-geolocation-annotation-example-3

proper `@context`

```
    "@context": "http://www.w3.org/ns/td",
        {
            "schema": "http://schema.org#"
        }
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1136.html" title="Last updated on May 12, 2021, 8:19 AM UTC (a70e567)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1136/6e6268f...danielpeintner:a70e567.html" title="Last updated on May 12, 2021, 8:19 AM UTC (a70e567)">Diff</a>