### PR TITLE
fix: fix RDF triples example from Thing description json-ld 1.1

### DIFF
--- a/ontology/td.html
+++ b/ontology/td.html
@@ -348,7 +348,10 @@
               <button data-selects="ex-rdf">RDF</button>
             </div>
             <pre class="ex-original selected">{
-                "@context": "https://www.w3.org/2019/wot/td/v1",
+                "@context": [
+                    "https://www.w3.org/2019/wot/td/v1",
+                    { "@base": "urn:dev:ops:32473-WoTLamp-1234/" }
+                ],
                 "id": "urn:dev:ops:32473-WoTLamp-1234",
                 "title": "MyLampThing",
                 "securityDefinitions": {
@@ -380,7 +383,7 @@
             &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasEventAffordance&gt; _:b2 .
             &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasPropertyAffordance&gt; _:b5 .
             &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasSecurityConfiguration&gt; &lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; .
-            &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#securityDefinitions&gt; _:b7 .
+            &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#securityDefinitions&gt; &lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; .
             &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#title&gt; &quot;MyLampThing&quot; .
             _:b0 &lt;https://www.w3.org/2019/wot/td#name&gt; "toggle" .
             _:b0 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b1 .
@@ -395,6 +398,8 @@
             _:b5 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; "status" .
             _:b5 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b6 .
             _:b6 &lt;https://www.w3.org/2019/wot/hypermedia#hasTarget&gt; &quot;https://mylamp.example.com/status&quot; .
+            &lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; &lt;https://www.w3.org/2019/wot/security#in&gt; "header" .
+            &lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://www.w3.org/2019/wot/security#BasicSecurityScheme&gt; .
         </pre>
         </aside>
         

--- a/ontology/td.template.html
+++ b/ontology/td.template.html
@@ -316,7 +316,10 @@
               <button data-selects="ex-rdf">RDF</button>
             </div>
             <pre class="ex-original selected">{
-                "@context": "https://www.w3.org/2019/wot/td/v1",
+                "@context": [
+                    "https://www.w3.org/2019/wot/td/v1",
+                    { "@base": "urn:dev:ops:32473-WoTLamp-1234/" }
+                ],
                 "id": "urn:dev:ops:32473-WoTLamp-1234",
                 "title": "MyLampThing",
                 "securityDefinitions": {
@@ -348,7 +351,7 @@
             &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasEventAffordance&gt; _:b2 .
             &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasPropertyAffordance&gt; _:b5 .
             &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#hasSecurityConfiguration&gt; &lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; .
-            &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#securityDefinitions&gt; _:b7 .
+            &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#securityDefinitions&gt; &lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; .
             &lt;urn:dev:ops:32473-WoTLamp-1234&gt; &lt;https://www.w3.org/2019/wot/td#title&gt; &quot;MyLampThing&quot; .
             _:b0 &lt;https://www.w3.org/2019/wot/td#name&gt; "toggle" .
             _:b0 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b1 .
@@ -363,6 +366,8 @@
             _:b5 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; "status" .
             _:b5 &lt;https://www.w3.org/2019/wot/td#hasForm&gt; _:b6 .
             _:b6 &lt;https://www.w3.org/2019/wot/hypermedia#hasTarget&gt; &quot;https://mylamp.example.com/status&quot; .
+            &lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; &lt;https://www.w3.org/2019/wot/security#in&gt; "header" .
+            &lt;urn:dev:ops:32473-WoTLamp-1234/basic_sc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://www.w3.org/2019/wot/security#BasicSecurityScheme&gt; .
         </pre>
         </aside>
         


### PR DESCRIPTION
Hello,

We have noticed that the triples about the security definition were not present in the RDF example (https://www.w3.org/2019/wot/td#thing-description-json-ld-1-1-instance-to-rdf-dataset).

Using the https://www.w3.org/2019/wot/td/v1 context in the JSON-LD playground, we did not get exactly the same triples as our correction but the following:

```
<urn:dev:ops:32473-WoTLamp-1234> <https://www.w3.org/2019/wot/td#securityDefinitions> _:b0 .
_:b0 <https://www.w3.org/2019/wot/td#in> "header" .
_:b0 <https://www.w3.org/2019/wot/td#scheme> "basic" .
```

We figured there may be an issue with the context and we will try to propose a PR to fix it.