### PR TITLE
Use previously define uri for the `td:name` and "jsonschema:propertyName"

### DIFF
--- a/context/json-schema-context.jsonld
+++ b/context/json-schema-context.jsonld
@@ -114,10 +114,11 @@
     "number": "jsonschema:NumberSchema",
     "integer": "jsonschema:IntegerSchema",
     "null": "jsonschema:NullSchema",
+    "propertyName": "jsonschema:propertyName",
     "properties": {
       "@id": "jsonschema:properties",
       "@container": "@index",
-      "@index": "jsonschema:propertyName"
+      "@index": "propertyName"
     },
     "unit": {
       "@id" : "schema:unitCode",

--- a/context/td-context-1.1.jsonld
+++ b/context/td-context-1.1.jsonld
@@ -13,11 +13,14 @@
       "@id": "http://purl.org/dc/terms/license"
     },
     "id": "@id",
+    "name": {
+      "@id": "td:name"
+    },
     "properties": {
       "@id": "td:hasPropertyAffordance",
       "@type": "@id",
       "@container": "@index",
-      "@index": "td:name",
+      "@index": "name",
       "@context": {
         "td": "https://www.w3.org/2019/wot/td#",
         "jsonschema": "https://www.w3.org/2019/wot/json-schema#",
@@ -133,15 +136,16 @@
         "number": "jsonschema:NumberSchema",
         "integer": "jsonschema:IntegerSchema",
         "null": "jsonschema:NullSchema",
+        "propertyName": "jsonschema:propertyName",
         "properties": {
           "@id": "jsonschema:properties",
           "@container": "@index",
-          "@index": "td:name",
+          "@index": "name",
           "@context": {
             "properties": {
               "@id": "jsonschema:properties",
               "@container": "@index",
-              "@index": "jsonschema:propertyName"
+              "@index": "propertyName"
             }
           }
         },
@@ -155,13 +159,13 @@
       "@id": "td:hasActionAffordance",
       "@type": "@id",
       "@container": "@index",
-      "@index": "td:name"
+      "@index": "name"
     },
     "events": {
       "@id": "td:hasEventAffordance",
       "@type": "@id",
       "@container": "@index",
-      "@index": "td:name"
+      "@index": "name"
     },
     "security": {
       "@id": "td:hasSecurityConfiguration",
@@ -255,9 +259,6 @@
     },
     "EventAffordance": {
       "@id": "td:EventAffordance"
-    },
-    "name": {
-      "@id": "td:name"
     },
     "created": {
       "@id": "dct:created",
@@ -437,7 +438,7 @@
       "@id": "td:hasUriTemplateSchema",
       "@type": "@id",
       "@container": "@index",
-      "@index": "td:name"
+      "@index": "name"
     },
     "safe": {
       "@id": "td:isSafe"
@@ -575,10 +576,11 @@
         "number": "jsonschema:NumberSchema",
         "integer": "jsonschema:IntegerSchema",
         "null": "jsonschema:NullSchema",
+        "propertyName": "jsonschema:propertyName",
         "properties": {
           "@id": "jsonschema:properties",
           "@container": "@index",
-          "@index": "jsonschema:propertyName"
+          "@index": "propertyName"
         },
         "unit": {
           "@id": "schema:unitCode",
@@ -704,10 +706,11 @@
         "number": "jsonschema:NumberSchema",
         "integer": "jsonschema:IntegerSchema",
         "null": "jsonschema:NullSchema",
+        "propertyName": "jsonschema:propertyName",
         "properties": {
           "@id": "jsonschema:properties",
           "@container": "@index",
-          "@index": "jsonschema:propertyName"
+          "@index": "propertyName"
         },
         "unit": {
           "@id": "schema:unitCode",
@@ -833,10 +836,11 @@
         "number": "jsonschema:NumberSchema",
         "integer": "jsonschema:IntegerSchema",
         "null": "jsonschema:NullSchema",
+        "propertyName": "jsonschema:propertyName",
         "properties": {
           "@id": "jsonschema:properties",
           "@container": "@index",
-          "@index": "jsonschema:propertyName"
+          "@index": "propertyName"
         },
         "unit": {
           "@id": "schema:unitCode",
@@ -962,10 +966,11 @@
         "number": "jsonschema:NumberSchema",
         "integer": "jsonschema:IntegerSchema",
         "null": "jsonschema:NullSchema",
+        "propertyName": "jsonschema:propertyName",
         "properties": {
           "@id": "jsonschema:properties",
           "@container": "@index",
-          "@index": "jsonschema:propertyName"
+          "@index": "propertyName"
         },
         "unit": {
           "@id": "schema:unitCode",
@@ -1091,10 +1096,11 @@
         "number": "jsonschema:NumberSchema",
         "integer": "jsonschema:IntegerSchema",
         "null": "jsonschema:NullSchema",
+        "propertyName": "jsonschema:propertyName",
         "properties": {
           "@id": "jsonschema:properties",
           "@container": "@index",
-          "@index": "jsonschema:propertyName"
+          "@index": "propertyName"
         },
         "unit": {
           "@id": "schema:unitCode",

--- a/context/td-context.jsonld
+++ b/context/td-context.jsonld
@@ -13,23 +13,24 @@
       "@id" : "http://purl.org/dc/terms/license"
     },
     "id": "@id",
+    "name": "td:name",
     "properties" : {
       "@id" : "td:hasPropertyAffordance",
       "@type" : "@id",
       "@container": "@index",
-      "@index": "td:name"
+      "@index": "name"
     },
     "actions" : {
       "@id" : "td:hasActionAffordance",
       "@type" : "@id",
       "@container": "@index",
-      "@index": "td:name"
+      "@index": "name"
     },
     "events" : {
       "@id" : "td:hasEventAffordance",
       "@type" : "@id",
       "@container": "@index",
-      "@index": "td:name"
+      "@index": "name"
     },
     "security" : {
       "@id" : "td:hasSecurityConfiguration",
@@ -85,7 +86,7 @@
       "@id" : "td:hasUriTemplateSchema",
       "@type": "@id",
       "@container": "@index",
-      "@index": "td:name"
+     "@index": "name"
     },
     "safe" : {
       "@id" : "td:isSafe"


### PR DESCRIPTION
This is a temporary fix since there are ongoing issues in jsonld.js (https://github.com/digitalbazaar/jsonld.js/issues/453) and in the api itself (https://github.com/w3c/json-ld-api/issues/514).

The workaround here is to define properties "name" and "propertyName" because it is (for now) necessary for the "@index" property. The prefixed URI leads to an error and the full URI leads to a "@none" index.

c.f. https://github.com/w3c/wot-thing-description/issues/1161