### PR TITLE
fix: replace "name" with "title" in TM example

### DIFF
--- a/index.html
+++ b/index.html
@@ -6064,7 +6064,7 @@ instance.
 {
 	...
 	"@type": "tm:ThingModel",
-	"name": "Smart Pump",
+	"title": "Smart Pump",
 	"description": "Smart Pump live plant and simulator",
 	"id": "urn:smart:device:wot:pump",
 	"version" : {"model" : "1.0.0" },
@@ -6075,7 +6075,7 @@ instance.
 {
 	...
 	"@type": "Thing",
-	"name": "Smart Pump",
+	"title": "Smart Pump",
 	"description": "Smart Pump live plant and simulator",
 	"id": "urn:smart:device:wot:pump:instance:1",
 	"version" : {"instance": "1.0.0",

--- a/index.template.html
+++ b/index.template.html
@@ -5044,7 +5044,7 @@ instance.
 {
 	...
 	"@type": "tm:ThingModel",
-	"name": "Smart Pump",
+	"title": "Smart Pump",
 	"description": "Smart Pump live plant and simulator",
 	"id": "urn:smart:device:wot:pump",
 	"version" : {"model" : "1.0.0" },
@@ -5055,7 +5055,7 @@ instance.
 {
 	...
 	"@type": "Thing",
-	"name": "Smart Pump",
+	"title": "Smart Pump",
 	"description": "Smart Pump live plant and simulator",
 	"id": "urn:smart:device:wot:pump:instance:1",
 	"version" : {"instance": "1.0.0",


### PR DESCRIPTION
I noticed that in [Example 57](https://w3c.github.io/wot-thing-description/#example-57) of the current Editor's Draft `"name"` is used instead of `"title"`. This (minimalistic) PR provides a fix for that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-thing-description/pull/1175.html" title="Last updated on Jul 14, 2021, 3:50 PM UTC (8a17f56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1175/732c5f1...JKRhb:8a17f56.html" title="Last updated on Jul 14, 2021, 3:50 PM UTC (8a17f56)">Diff</a>