### PR TITLE
Add social media icons to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
   
 [![Follow on Twitter](https://img.shields.io/twitter/follow/W3C_WoT.svg?label=follow+W3C_WoT)](https://twitter.com/W3C_WoT)
-<img alt="Stack Exchange questions" src="https://img.shields.io/stackexchange/stackoverflow/t/web-of-things?style=plastic">
+[![Stack Exchange questions](https://img.shields.io/stackexchange/stackoverflow/t/web-of-things?style=plastic)]( https://stackoverflow.com/questions/tagged/web-of-things)
   
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
-# Specification 'Web of Things (WoT) Thing Description'
+# Web of Things (WoT) Thing Description
 
-<div align="center">
-  
 [![Follow on Twitter](https://img.shields.io/twitter/follow/W3C_WoT.svg?label=follow+W3C_WoT)](https://twitter.com/W3C_WoT)
 [![Stack Exchange questions](https://img.shields.io/stackexchange/stackoverflow/t/web-of-things?style=plastic)]( https://stackoverflow.com/questions/tagged/web-of-things)
-  
-</div>
 
 General information about the Web of Things can be found on https://www.w3.org/WoT/.
-
+  
 ---
 
 Each commit here will sync it to the master, which will expose the content to http://w3c.github.io/wot-thing-description/.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Specification 'Web of Things (WoT) Thing Description'
 
+<div align="center">
+  
+[![Follow on Twitter](https://img.shields.io/twitter/follow/W3C_WoT.svg?label=follow+W3C_WoT)](https://twitter.com/W3C_WoT)
+<img alt="Stack Exchange questions" src="https://img.shields.io/stackexchange/stackoverflow/t/web-of-things?style=plastic">
+  
+</div>
+
 Each commit here will sync it to the master, which will expose the content to http://w3c.github.io/wot-thing-description/.
 
 For the draft TD specification for TAG review, please access this [URL](https://cdn.staticaly.com/gh/w3c/wot-thing-description/TD-TAG-review/index.html?env=dev).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
   
 </div>
 
+General information about the Web of Things can be found on https://www.w3.org/WoT/.
+
+---
+
 Each commit here will sync it to the master, which will expose the content to http://w3c.github.io/wot-thing-description/.
 
 For the draft TD specification for TAG review, please access this [URL](https://cdn.staticaly.com/gh/w3c/wot-thing-description/TD-TAG-review/index.html?env=dev).


### PR DESCRIPTION
Following https://github.com/w3c/wot-marketing/issues/188

Ideally, I would like to repeat this in our other repositories.