### PR TITLE
fix example 37 and its canonical form

### DIFF
--- a/index.html
+++ b/index.html
@@ -4519,13 +4519,14 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
             "scheme": "basic"
         }
     },
+    "security":["basic_sc"],
     "title": "MyLampThing"
 }</pre>
 </aside>
 
 However, the actual true <a>Canonical TD</a> has all extra whitespace removed, and looks like the following:
 <aside class="example" id="canonical-thing-description-nows" title="Canonical Thing Description Example - No White Space">
-<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty","security":"basic_sc"},{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty","security":"basic_sc"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"title":"MyLampThing"}</pre>
+<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty","security":"basic_sc"},{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty","security":"basic_sc"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"security":["basic_sc"],"title":"MyLampThing"}</pre>
 </aside>
 
 </section>

--- a/index.template.html
+++ b/index.template.html
@@ -3498,13 +3498,14 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
             "scheme": "basic"
         }
     },
+    "security":["basic_sc"],
     "title": "MyLampThing"
 }</pre>
 </aside>
 
 However, the actual true <a>Canonical TD</a> has all extra whitespace removed, and looks like the following:
 <aside class="example" id="canonical-thing-description-nows" title="Canonical Thing Description Example - No White Space">
-<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty","security":"basic_sc"},{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty","security":"basic_sc"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"title":"MyLampThing"}</pre>
+<pre>{"@context":"http://www.w3.org/ns/td","id":"urn:dev:ops:32473-WoTLamp-1234","properties":{"status":{"forms":[{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"GET","op":"readproperty","security":"basic_sc"},{"contentType":"application/json","href":"https://mylamp.example.com/status","htv:methodName":"PUT","op":"writeproperty","security":"basic_sc"}],"observable":false,"readOnly":false,"type":"string","writeOnly":false}},"securityDefinitions":{"basic_sc":{"in":"header","scheme":"basic"}},"security":["basic_sc"],"title":"MyLampThing"}</pre>
 </aside>
 
 </section>


### PR DESCRIPTION
Fixed #1178


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/egekorkan/wot-thing-description/pull/1197.html" title="Last updated on Jul 21, 2021, 11:15 PM UTC (0299144)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1197/5462680...egekorkan:0299144.html" title="Last updated on Jul 21, 2021, 11:15 PM UTC (0299144)">Diff</a>