### PR TITLE
Fix definition of multipleOf in TD schema

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -207,16 +207,7 @@
                     "minimum": 0
                 },
                 "multipleOf": {
-                    "anyOf": [
-                        {
-                            "type": "integer",
-                            "exclusiveMinimum": 0
-                        },
-                        {
-                            "type": "number",
-                            "exclusiveMinimum": 0
-                        }
-                    ]
+                    "$ref": "#/definitions/multipleOfDefinition"
                 },
                 "properties": {
                     "additionalProperties": {
@@ -247,6 +238,18 @@
                     }
                 }
             }
+        },
+        "multipleOfDefinition": {
+            "anyOf": [
+                {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                },
+                {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                }
+            ]
         },
         "form_element_property": {
             "type": "object",
@@ -604,16 +607,7 @@
                     "minimum": 0
                 },
                 "multipleOf": {
-                    "anyOf": [
-                        {
-                            "type": "integer",
-                            "exclusiveMinimum": 0
-                        },
-                        {
-                            "type": "number",
-                            "exclusiveMinimum": 0
-                        }
-                    ]
+                    "$ref": "#/definitions/multipleOfDefinition"
                 },
                 "properties": {
                     "additionalProperties": {

--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -207,12 +207,14 @@
                     "minimum": 0
                 },
                 "multipleOf": {
-                    "oneOf": [
+                    "anyOf": [
                         {
-                            "type": "integer"
+                            "type": "integer",
+                            "exclusiveMinimum": 0
                         },
                         {
-                            "type": "number"
+                            "type": "number",
+                            "exclusiveMinimum": 0
                         }
                     ]
                 },
@@ -602,12 +604,14 @@
                     "minimum": 0
                 },
                 "multipleOf": {
-                    "oneOf": [
+                    "anyOf": [
                         {
-                            "type": "integer"
+                            "type": "integer",
+                            "exclusiveMinimum": 0
                         },
                         {
-                            "type": "number"
+                            "type": "number",
+                            "exclusiveMinimum": 0
                         }
                     ]
                 },

--- a/validation/tm-json-schema-validation.json
+++ b/validation/tm-json-schema-validation.json
@@ -247,12 +247,14 @@
           ]
         },
         "multipleOf": {
-          "oneOf": [
+          "anyOf": [
             {
-              "type": "integer"
+              "type": "integer",
+              "exclusiveMinimum": 0
             },
             {
-              "type": "number"
+              "type": "number",
+              "exclusiveMinimum": 0
             }
           ]
         },
@@ -680,12 +682,14 @@
           ]
         },
         "multipleOf": {
-          "oneOf": [
+          "anyOf": [
             {
-              "type": "integer"
+              "type": "integer",
+              "exclusiveMinimum": 0
             },
             {
-              "type": "number"
+              "type": "number",
+              "exclusiveMinimum": 0
             }
           ]
         },

--- a/validation/tm-json-schema-validation.json
+++ b/validation/tm-json-schema-validation.json
@@ -274,6 +274,23 @@
         }
       }
     },
+    "additionalResponsesDefinition": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "contentType": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "success": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
     "form_element_property": {
       "type": "object",
       "properties": {
@@ -317,18 +334,7 @@
           }
         },
         "additionalResponses": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "contentType": {
-                "type": "string"
-              },
-              "schema": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/additionalResponsesDefinition"
         },
         "tm:ref": {
           "$ref": "#/definitions/tm_ref"
@@ -379,18 +385,7 @@
           }
         },
         "additionalResponses": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "contentType": {
-                "type": "string"
-              },
-              "schema": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/additionalResponsesDefinition"
         },
         "tm:ref": {
           "$ref": "#/definitions/tm_ref"
@@ -441,18 +436,7 @@
           }
         },
         "additionalResponses": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "contentType": {
-                "type": "string"
-              },
-              "schema": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/additionalResponsesDefinition"
         },
         "tm:ref": {
           "$ref": "#/definitions/tm_ref"
@@ -503,18 +487,7 @@
           }
         },
         "additionalResponses": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "contentType": {
-                "type": "string"
-              },
-              "schema": {
-                "type": "string"
-              }
-            }
-          }
+          "$ref": "#/definitions/additionalResponsesDefinition"
         },
         "tm:ref": {
           "$ref": "#/definitions/tm_ref"

--- a/validation/tm-json-schema-validation.json
+++ b/validation/tm-json-schema-validation.json
@@ -247,16 +247,7 @@
           ]
         },
         "multipleOf": {
-          "anyOf": [
-            {
-              "type": "integer",
-              "exclusiveMinimum": 0
-            },
-            {
-              "type": "number",
-              "exclusiveMinimum": 0
-            }
-          ]
+          "$ref": "#/definitions/multipleOfDefinition"
         },
         "properties": {
           "additionalProperties": {
@@ -290,6 +281,18 @@
           }
         }
       }
+    },
+    "multipleOfDefinition": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        {
+          "type": "number",
+          "exclusiveMinimum": 0
+        }
+      ]
     },
     "form_element_property": {
       "type": "object",
@@ -655,16 +658,7 @@
           ]
         },
         "multipleOf": {
-          "anyOf": [
-            {
-              "type": "integer",
-              "exclusiveMinimum": 0
-            },
-            {
-              "type": "number",
-              "exclusiveMinimum": 0
-            }
-          ]
+          "$ref": "#/definitions/multipleOfDefinition"
         },
         "properties": {
           "additionalProperties": {


### PR DESCRIPTION
In #1186 I noticed (among other issues) that the current definition of multipleOf in the JSON schemas does not work as expected. So far the following (TM) definition would be invalid:

```json
{
    "@context": ["http://www.w3.org/ns/td"],
    "@type": "tm:ThingModel",
    "properties": {
        "foo": {
            "title": "Invalid",
            "multipleOf": 1
        },
        "bar": {
            "title": "Invalid",
            "multipleOf": 2.0
        },
        "baz": {
            "title": "Valid, because not an integer",
            "multipleOf": 2.2
        }
    }
}
```

This PR replaces the `oneOf` in the definitions of `multipleOf` with an `anyOf` and adds an `exclusiveMinimum` of 0 to align the schema more closely to the [specification](https://w3c.github.io/wot-thing-description/#td-vocab-multipleOf--NumberSchema) that states:

> The value must [be] strictly greater than 0.