### PR TITLE
Remove left over merge conflict seperators

### DIFF
--- a/index.html
+++ b/index.html
@@ -4400,8 +4400,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   representing the UTC time zone instead 
   of an offset.</span>
   </li>
-<<<<<<< HEAD
-=======
+
   <li><span class="rfc2119-assertion" id="canonical-datetime-fracsec">
   In the <a>Canonical TD</a>, 
   values that are of type <code>dateTime</code>
@@ -4414,7 +4413,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   values that are of type <code>dateTime</code>
   MUST NOT use '24' in the hours field.</span>
   </li>
->>>>>>> upstream/main
+
   <li><span class="rfc2119-assertion" id="canonical-defaults">
   In the <a>Canonical TD</a>,
   all required elements MUST be given explicitly, even if they have defaults

--- a/index.template.html
+++ b/index.template.html
@@ -3379,8 +3379,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   representing the UTC time zone instead 
   of an offset.</span>
   </li>
-<<<<<<< HEAD
-=======
+
   <li><span class="rfc2119-assertion" id="canonical-datetime-fracsec">
   In the <a>Canonical TD</a>, 
   values that are of type <code>dateTime</code>
@@ -3393,7 +3392,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   values that are of type <code>dateTime</code>
   MUST NOT use '24' in the hours field.</span>
   </li>
->>>>>>> upstream/main
+
   <li><span class="rfc2119-assertion" id="canonical-defaults">
   In the <a>Canonical TD</a>,
   all required elements MUST be given explicitly, even if they have defaults


### PR DESCRIPTION
I took the freedom of opening this PR to fix #1225. I hope I "resolved" the conflict correctly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-thing-description/pull/1227.html" title="Last updated on Sep 15, 2021, 10:55 AM UTC (402dd66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1227/ce539d4...JKRhb:402dd66.html" title="Last updated on Sep 15, 2021, 10:55 AM UTC (402dd66)">Diff</a>