### PR TITLE
fix titles and descriptions type problem + default value entries for security in

### DIFF
--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           for example, TLS.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
                parameters.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>uri</code>)</td></tr></tbody></table></section>
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>uri</code>)</td></tr></tbody></table></section>
 <section><h3><code>DigestSecurityScheme</code></h3><p>Digest Access Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication">RFC7616</a></cite>]
           security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>digest</code> (i.e.,
           <code>"scheme": "digest"</code>). This scheme is similar
@@ -1796,7 +1796,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           man-in-the-middle attacks.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
                parameters.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>uri</code>)</td></tr>
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>uri</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme"><td><code>qop</code></td><td>Quality of protection.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>auth</code>, or <code>auth-int</code>)</td></tr></tbody></table></section>
 <section><h3><code>APIKeySecurityScheme</code></h3><p>API key authentication security configuration
           identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
@@ -1810,7 +1810,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           of service requests using the mechanism indicated by the <code>"in"</code> field.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
                parameters.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>uri</code>)</td></tr></tbody></table></section>
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>uri</code>)</td></tr></tbody></table></section>
 <section><h3><code>BearerSecurityScheme</code></h3><p>Bearer Token [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6750" title="The OAuth 2.0 Authorization Framework: Bearer Token Usage">RFC6750</a></cite>]
           security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>bearer</code> (i.e.,
           <code>"scheme": "bearer"</code>) for situations where
@@ -1836,7 +1836,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 <tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme"><td><code>format</code></td><td>Specifies format of security authentication
                  information.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>uri</code>)</td></tr></tbody></table></section>
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>uri</code>)</td></tr></tbody></table></section>
 <section><h3><code>PSKSecurityScheme</code></h3><p>Pre-shared key authentication security configuration
           identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
           <code>psk</code> (i.e., <code>"scheme":

--- a/index.html
+++ b/index.html
@@ -1128,14 +1128,14 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           Description, whereas a virtual entity is the composition
           of one or more Things.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing"><td><code>@context</code></td><td>JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.</td><td>mandatory</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-id--Thing"><td><code>id</code></td><td>Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI, URI with local IP address, URN, etc.).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--Thing"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
                 a text for UI representation) based on a default
-                language.</td><td>mandatory</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                language.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing"><td><code>titles</code></td><td>Provides multi-language human-readable titles
                 (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-description--Thing"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-version--Thing"><td><code>version</code></td><td>Provides version information.</td><td>optional</td><td><a href="#versioninfo"><code>VersionInfo</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-created--Thing"><td><code>created</code></td><td>Provides information when the TD instance was
                 created.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
@@ -1358,14 +1358,14 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           defines three types of Interaction Affordances:
           Properties, Actions, and Events.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
                 a text for UI representation) based on a default
-                language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance"><td><code>titles</code></td><td>Provides multi-language human-readable titles
                 (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance"><td><code>forms</code></td><td>Set of form hypermedia controls that describe
                 how an operation can be performed. Forms are
                 serializations of Protocol Bindings.</td><td>mandatory</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
@@ -1457,8 +1457,12 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           minor version, and patch version, respectively. See
           [<cite><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0">SEMVER</a></cite>] for
           details.</p></section>
+<section><h3><code>MultiLanguage</code></h3><p><p>A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
+            <p><span class="rfc2119-assertion" id="td-multilanguage-language-tag">Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in [[!BCP47]].</span>
+            <span class="rfc2119-assertion" id="td-multilanguage-value"> Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>. </span> </p></p></section>
 
 
+    <!--
         <section><h3><code>MultiLanguage</code></h3><p>A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
         <p>
         <span class="rfc2119-assertion" id="td-multilanguage-language-tag"> 
@@ -1471,6 +1475,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         </span>
         </p>
         </section>
+    -->
       </section>
     
       <section id="sec-data-schema-vocabulary-definition">
@@ -1530,14 +1535,14 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       <section><h3><code>DataSchema</code></h3><p>Metadata that describes the data format used. It can
           be used for validation.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types)</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
                 a text for UI representation) based on a default
-                language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema"><td><code>titles</code></td><td>Provides multi-language human-readable titles
                 (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema"><td><code>const</code></td><td>Provides a constant value.</td><td>optional</td><td>any type</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema"><td><code>default</code></td><td>Supply a default value. The value should validate against the data schema in which it resides.</td><td>optional</td><td>any type</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema"><td><code>unit</code></td><td>Provides unit information that is used, e.g.,
@@ -1751,9 +1756,9 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           declared in a <code>SecurityScheme</code> 
           <em class="rfc2119" title="MUST">MUST</em> be distinct from all other URI variables 
           declared in the TD.</span></p></p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme"><td><code>proxy</code></td><td>URI of the proxy server this security
                 configuration provides access to. If not given, the
                 corresponding security configuration is for the
@@ -6717,7 +6722,7 @@ instance.
 		</pre>
         </aside>
 
-         <p>Please not that a TD can only be an instance of only one TM at a time. 
+         <p>Please note that a TD can only be an instance of only one TM at a time. 
              That means for Thing Descriptions:
          <span class="rfc2119-assertion" id="tm-rel-type-maximum">
             The <code>links</code> array can use the entry with <code>"rel" : "type"</code> maximum one.
@@ -7406,16 +7411,8 @@ instance.
             }
         },
         "multipleOfDefinition": {
-            "anyOf": [
-                {
-                    "type": "integer",
-                    "exclusiveMinimum": 0
-                },
-                {
-                    "type": "number",
-                    "exclusiveMinimum": 0
-                }
-            ]
+            "type": ["integer","number"],
+            "exclusiveMinimum": 0
         },
         "form_element_property": {
             "type": "object",

--- a/index.html
+++ b/index.html
@@ -4094,17 +4094,22 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
 <pre class="example">
 {
-    "@context": [
-        "http://www.w3.org/ns/td",
-        { "eg": "http://www.example.org/iot#" }
-    ],
+    "@context": "http://www.w3.org/ns/td",
     ...
     "properties": {
         "weather": {
             ...
             "uriVariables": {
-                "lat": { "type": "number", "minimum": 0, "maximum": 90, "description": "Latitude for the desired location in the world" },
-                "long": { "type": "number", "minimum": -180, "maximum": 180, "description": "Longitude for the desired location in the world" }
+                "lat": { 
+                    "type": "number", 
+                    "minimum": 0, 
+                    "maximum": 90, 
+                    "description": "Latitude for the desired location in the world" },
+                "long": { 
+                    "type": "number", 
+                    "minimum": -180, 
+                    "maximum": 180, 
+                    "description": "Longitude for the desired location in the world" }
             },
             "forms": [{
               "href": "http://example.org/weather/{?lat,long}",
@@ -4549,7 +4554,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   all required elements MUST be given explicitly, even if they have defaults
   and are assigned their default value.
   </span>
-  For example, the default value of <code>observable</code>
+  For example, the default value of <code>writeOnly</code>
   is <code>false</code>.  
   If an input TD omits <code>observable</code> where it is allowed,
   it must still explicitly appear in the canonical form with the value of <code>false</code>.

--- a/index.html
+++ b/index.html
@@ -1131,11 +1131,11 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                 language.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing"><td><code>titles</code></td><td>Provides multi-language human-readable titles
                 (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-description--Thing"><td><code>description</code></td><td>Provides additional (human-readable)
                       information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-version--Thing"><td><code>version</code></td><td>Provides version information.</td><td>optional</td><td><a href="#versioninfo"><code>VersionInfo</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-created--Thing"><td><code>created</code></td><td>Provides information when the TD instance was
                 created.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
@@ -1361,11 +1361,11 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                 language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance"><td><code>titles</code></td><td>Provides multi-language human-readable titles
                 (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance"><td><code>description</code></td><td>Provides additional (human-readable)
                       information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance"><td><code>forms</code></td><td>Set of form hypermedia controls that describe
                 how an operation can be performed. Forms are
                 serializations of Protocol Bindings.</td><td>mandatory</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
@@ -1538,11 +1538,11 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                 language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema"><td><code>titles</code></td><td>Provides multi-language human-readable titles
                 (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema"><td><code>description</code></td><td>Provides additional (human-readable)
                       information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema"><td><code>const</code></td><td>Provides a constant value.</td><td>optional</td><td>any type</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema"><td><code>default</code></td><td>Supply a default value. The value should validate against the data schema in which it resides.</td><td>optional</td><td>any type</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema"><td><code>unit</code></td><td>Provides unit information that is used, e.g.,
@@ -1758,7 +1758,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           declared in the TD.</span></p></p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable)
                       information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme"><td><code>proxy</code></td><td>URI of the proxy server this security
                 configuration provides access to. If not given, the
                 corresponding security configuration is for the
@@ -1797,7 +1797,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                parameters.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
             authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>uri</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme"><td><code>qop</code></td><td>Quality of protection.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>auth</code>, or <code>auth-int</code>)</td></tr></tbody></table></section>
+<tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme"><td><code>qop</code></td><td>Quality of protection.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>auth</code>, or <code>auth-int</code>)</td></tr></tbody></table></section>
 <section><h3><code>APIKeySecurityScheme</code></h3><p>API key authentication security configuration
           identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
           <code>apikey</code> (i.e., <code>"scheme":
@@ -1832,9 +1832,9 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           extensions</span>.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
                parameters.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme"><td><code>alg</code></td><td>Encoding, encryption, or digest algorithm.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>MD5</code>, <code>ES256</code>, or <code>ES512-256</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme"><td><code>alg</code></td><td>Encoding, encryption, or digest algorithm.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>MD5</code>, <code>ES256</code>, or <code>ES512-256</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme"><td><code>format</code></td><td>Specifies format of security authentication
-                 information.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)</td></tr>
+                 information.</td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)</td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
             authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>uri</code>)</td></tr></tbody></table></section>
 <section><h3><code>PSKSecurityScheme</code></h3><p>Pre-shared key authentication security configuration

--- a/index.template.html
+++ b/index.template.html
@@ -2951,8 +2951,16 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
         "weather": {
             ...
             "uriVariables": {
-                "lat": { "type": "number", "minimum": 0, "maximum": 90, "description": "Latitude for the desired location in the world" },
-                "long": { "type": "number", "minimum": -180, "maximum": 180, "description": "Longitude for the desired location in the world" }
+                "lat": { 
+                    "type": "number", 
+                    "minimum": 0, 
+                    "maximum": 90, 
+                    "description": "Latitude for the desired location in the world" },
+                "long": { 
+                    "type": "number", 
+                    "minimum": -180, 
+                    "maximum": 180, 
+                    "description": "Longitude for the desired location in the world" }
             },
             "forms": [{
               "href": "http://example.org/weather/{?lat,long}",
@@ -3397,7 +3405,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   all required elements MUST be given explicitly, even if they have defaults
   and are assigned their default value.
   </span>
-  For example, the default value of <code>observable</code>
+  For example, the default value of <code>writeOnly</code>
   is <code>false</code>.  
   If an input TD omits <code>observable</code> where it is allowed,
   it must still explicitly appear in the canonical form with the value of <code>false</code>.

--- a/index.template.html
+++ b/index.template.html
@@ -1126,6 +1126,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       %s
 
 
+    <!--
         <section><h3><code>MultiLanguage</code></h3><p>A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
         <p>
         <span class="rfc2119-assertion" id="td-multilanguage-language-tag"> 
@@ -1138,6 +1139,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         </span>
         </p>
         </section>
+    -->
       </section>
     
       <section id="sec-data-schema-vocabulary-definition">

--- a/index.template.html
+++ b/index.template.html
@@ -2945,10 +2945,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 
 <pre class="example">
 {
-    "@context": [
-        "http://www.w3.org/ns/td",
-        { "eg": "http://www.example.org/iot#" }
-    ],
+    "@context": "http://www.w3.org/ns/td",
     ...
     "properties": {
         "weather": {

--- a/templates.sparql
+++ b/templates.sparql
@@ -133,7 +133,9 @@ template :field(?class ?ns) {
         "<td>"
             format {
                 "%s"
-                if(?hasDefault || ?prop = <https://www.w3.org/2019/wot/hypermedia#forOperationType> || ?prop = <https://www.w3.org/2019/wot/security#in>,
+                 # work around only for forOperationType, in, qop etc.
+                if(?hasDefault || ?prop = <https://www.w3.org/2019/wot/hypermedia#forOperationType> || ?prop = <https://www.w3.org/2019/wot/security#in> 
+                || ?prop = <https://www.w3.org/2019/wot/security#qop> || ?prop = <https://www.w3.org/2019/wot/security#alg> || ?prop = <https://www.w3.org/2019/wot/security#format> ,
                    "<a href=\"#sec-default-values\">with default</a>",
                    if(?mandatory, "mandatory", "optional"))
             }
@@ -142,7 +144,7 @@ template :field(?class ?ns) {
 
             # work around only for description(s) and title(s) otherwise it returns 'string MultiLanguage' at the same time
              if ((?prop = <http://purl.org/dc/terms/description> || ?prop = <http://purl.org/dc/terms/title>),
-                if(?map, "<a>Map</a> of <a href=\"#multilanguage\"><code>MultiLanguage</code></a>", "<a href=\"https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a>"),
+                if(?map, "<a href=\"#multilanguage\"><code>MultiLanguage</code></a>", "<a href=\"https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a>"),
 
                     # start the normal processing 
                     concat(

--- a/templates.sparql
+++ b/templates.sparql
@@ -139,21 +139,25 @@ template :field(?class ?ns) {
             }
         "</td>"
         "<td>"
-            format {
-                "%s%s"
-                if(?array, "<a>Array</a> of ",
-                if(?map, "<a>Map</a> of ",
-                if(!?singleton && ?hasType,
-                   concat(st:call-template(:type, ?class, ?prop, ?ns), " or <a>Array</a> of "),
-                   "")))
-                if(?hasType, st:call-template(:type, ?class, ?prop, ?ns), "any type")
-            }
-            format {
-                "%s%s%s"
-                if(?hasEnum, " (", "")
-                st:call-template(:enum, ?class, ?prop, ?ns, 0)
-                if(?hasEnum, ")", "")
-            }
+
+            # work around only for description(s) and title(s) otherwise it returns 'string MultiLanguage' at the same time
+             if ((?prop = <http://purl.org/dc/terms/description> || ?prop = <http://purl.org/dc/terms/title>),
+                if(?map, "<a>Map</a> of <a href=\"#multilanguage\"><code>MultiLanguage</code></a>", "<a href=\"https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a>"),
+
+                    # start the normal processing 
+                    concat(
+                        if(?array, "<a>Array</a> of ",
+                            if(?map, "<a>Map</a> of ",
+                            if(!?singleton && ?hasType,
+                            concat(st:call-template(:type, ?class, ?prop, ?ns), " or <a>Array</a> of "),
+                            ""))),
+                        if(?hasType, st:call-template(:type, ?class, ?prop, ?ns), "any type"),                
+                        if(?hasEnum, " (", ""),
+                        st:call-template(:enum, ?class, ?prop, ?ns, 0),
+                        if(?hasEnum, ")", "")
+                    )
+                
+            )
         "</td>"
     "</tr>"
 } where {
@@ -349,15 +353,15 @@ template :default-label(?term) {
     format { "%s" strafter(str(?term), "#") }
 } where {}
 
-template :desc(?term) {
-    format {
-        "%s%s"
-        if(strends(?desc, "."), ?desc, concat(?desc, "."))
-        if(?term = <https://www.w3.org/2019/wot/td#MultiLanguage>, 
-            " See <a href=\"#titles-descriptions-serialization-json\"></a> for example usages of this container in a Thing Description instance.",
-            "")
-
-    } ; separator = " "
-} where {
-    ?term rdfs:comment ?desc .
-}
+#template :desc(?term) {
+#    format {
+#        "%s%s"
+#        if(strends(?desc, "."), ?desc, concat(?desc, "."))
+#        if(?term = <https://www.w3.org/2019/wot/td#MultiLanguage>, 
+#            " See <a href=\"#titles-descriptions-serialization-json\"></a> for example usages of this container in a Thing Description instance.",
+#            "")
+#
+#    } ; separator = " "
+#} where {
+#    ?term rdfs:comment ?desc .
+#}

--- a/templates.sparql
+++ b/templates.sparql
@@ -133,7 +133,7 @@ template :field(?class ?ns) {
         "<td>"
             format {
                 "%s"
-                if(?hasDefault || ?prop = <https://www.w3.org/2019/wot/hypermedia#forOperationType>,
+                if(?hasDefault || ?prop = <https://www.w3.org/2019/wot/hypermedia#forOperationType> || ?prop = <https://www.w3.org/2019/wot/security#in>,
                    "<a href=\"#sec-default-values\">with default</a>",
                    if(?mandatory, "mandatory", "optional"))
             }

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -516,6 +516,16 @@
 		  It is considered to be good practice that each <code>subscribeevent</code> has a corresponding <code>unsubscribeevent</code> unless the protocol
 		  supports implicit unsubscription mechanisms (e.g., heartbeat to detect connection loss).</p>"""^^rdf:HTML .
 
+:MultiLanguageShape a sh:NodeShape ;
+    sh:targetClass td:MultiLanguage ;
+    skos:definition """<p>A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
+            <p><span class="rfc2119-assertion" id="td-multilanguage-language-tag">Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in [[!BCP47]].</span>
+            <span class="rfc2119-assertion" id="td-multilanguage-value"> Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>. </span> </p>"""^^rdf:HTML ;
+    sh:closed false ;
+    sh:order 18 .
+
+
+
 :VersionInfoShape a sh:NodeShape ;
     sh:targetClass td:VersionInfo ;
     skos:definition """Metadata of a Thing that provides version information
@@ -1906,7 +1916,7 @@ _:titles sh:path dcterms:title ;
          skos:definition """Provides multi-language human-readable titles
                 (e.g., display a text for UI representation in
                 different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>."""^^rdf:HTML ;
-         sh:datatype xsd:string ;
+         sh:node :MultiLanguageShape ;
        	 sh:uniqueLang true ;
          sh:order 2 .
 
@@ -1920,7 +1930,7 @@ _:description sh:path dcterms:description ;
 _:descriptions sh:path dcterms:description ;
                skos:definition """Can be used to support (human-readable)
                        information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>."""^^rdf:HTML ;
-               sh:datatype xsd:string ;
+               sh:node :MultiLanguageShape ;
        		   sh:uniqueLang true ;
                sh:order 4 .
 

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -1938,6 +1938,7 @@ _:in sh:path wotsec:in ;
      skos:definition """Specifies the location of security
             authentication information.  """^^rdf:HTML ;
      sh:datatype xsd:string ;
+     sh:defaultValue "header"^^xsd:string ;
      sh:maxCount 1 ;
      sh:in (
         "header"
@@ -1946,7 +1947,6 @@ _:in sh:path wotsec:in ;
         "cookie"
         "uri"
     );
-    sh:defaultValue "header"^^xsd:string ;
     sh:order 100 .
 
 _:name sh:path wotsec:name ;


### PR DESCRIPTION
also see #1137


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1275.html" title="Last updated on Nov 17, 2021, 3:54 PM UTC (2ba9916)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1275/ce4cba4...2ba9916.html" title="Last updated on Nov 17, 2021, 3:54 PM UTC (2ba9916)">Diff</a>