### PR TITLE
print *all* code parts  on print

### DIFF
--- a/index.html
+++ b/index.html
@@ -6113,7 +6113,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
          <button class="exampleTab1 Ventilation"         onclick="openTab('exampleTab1', 'Ventilation')">Ventilation TM</button>
          <button class="exampleTab1 LED"    onclick="openTab('exampleTab1', 'LED')">LED TM</button>
        </div>
-       <pre class="SmartVentilator exampleTab1 selected">
+       <pre class="SmartVentilator exampleTab1 selected ">
         {
             "@context": "http://www.w3.org/ns/td",
             "@type": "tm:ThingModel",

--- a/index.html
+++ b/index.html
@@ -223,7 +223,6 @@ a[href].internalDFN {
     height: 0;
 }
 
-
 /* Print parts that might be hidden */
 @media print {
 	.with-default pre {
@@ -320,7 +319,6 @@ a[href].internalDFN {
       display: inline;
     }
   }
-	
   .ds-selector-tabs pre.selected, .ds-selector-tabs table.selected {
     display: block;
   }

--- a/index.html
+++ b/index.html
@@ -6105,10 +6105,6 @@ a Ventilation <a>Thing Model</a> that provides <code>on/off</code> and <code>adj
 provides <code>dimmable</code> and <code>RGB</code> capabilities. 
 </p>
 
-<div class="a">Some text.</div>
-<div class="printMe">Only to be shown in print.</div>
-<div class="b">More characters.</div>
-
 <aside class="example ds-selector-tabs" ><div class="marker">
     <span class="example-title">Top level/parent Smart Ventilator Thing Model </span>
      </div>
@@ -6117,7 +6113,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
          <button class="exampleTab1 Ventilation"         onclick="openTab('exampleTab1', 'Ventilation')">Ventilation TM</button>
          <button class="exampleTab1 LED"    onclick="openTab('exampleTab1', 'LED')">LED TM</button>
        </div>
-       <pre class="SmartVentilator exampleTab1 selected printMe">
+       <pre class="SmartVentilator exampleTab1 selected">
         {
             "@context": "http://www.w3.org/ns/td",
             "@type": "tm:ThingModel",
@@ -6142,7 +6138,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
           }
        </pre>
-       <pre class="Ventilation exampleTab1 printMe">
+       <pre class="Ventilation exampleTab1">
         {
             "@context": "http://www.w3.org/ns/td",
             "@type": "tm:ThingModel",
@@ -6163,7 +6159,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
         }
        </pre>
-       <pre class="LED exampleTab1 printMe">
+       <pre class="LED exampleTab1">
         {
             "@context": "http://www.w3.org/ns/td",
             "@type": "tm:ThingModel",

--- a/index.html
+++ b/index.html
@@ -222,6 +222,16 @@ a[href].internalDFN {
     margin-bottom: 0;
     height: 0;
 }
+
+
+/* Print parts that might be hidden */
+@media print {
+	.with-default pre {
+		margin-top: 0;
+		margin-bottom: 1em;
+		height: auto;
+	}
+}
 </style>
 
 <script>
@@ -304,6 +314,13 @@ a[href].internalDFN {
   .ds-selector-tabs pre, .ds-selector-tabs table {
     display: none;
   }
+  /* Print parts that might be hidden */
+  @media print {
+    .ds-selector-tabs pre, .ds-selector-tabs table {
+      display: inline;
+    }
+  }
+	
   .ds-selector-tabs pre.selected, .ds-selector-tabs table.selected {
     display: block;
   }
@@ -6088,6 +6105,10 @@ a Ventilation <a>Thing Model</a> that provides <code>on/off</code> and <code>adj
 provides <code>dimmable</code> and <code>RGB</code> capabilities. 
 </p>
 
+<div class="a">Some text.</div>
+<div class="printMe">Only to be shown in print.</div>
+<div class="b">More characters.</div>
+
 <aside class="example ds-selector-tabs" ><div class="marker">
     <span class="example-title">Top level/parent Smart Ventilator Thing Model </span>
      </div>
@@ -6096,7 +6117,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
          <button class="exampleTab1 Ventilation"         onclick="openTab('exampleTab1', 'Ventilation')">Ventilation TM</button>
          <button class="exampleTab1 LED"    onclick="openTab('exampleTab1', 'LED')">LED TM</button>
        </div>
-       <pre class="SmartVentilator exampleTab1 selected ">
+       <pre class="SmartVentilator exampleTab1 selected printMe">
         {
             "@context": "http://www.w3.org/ns/td",
             "@type": "tm:ThingModel",
@@ -6121,7 +6142,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
           }
        </pre>
-       <pre class="Ventilation exampleTab1">
+       <pre class="Ventilation exampleTab1 printMe">
         {
             "@context": "http://www.w3.org/ns/td",
             "@type": "tm:ThingModel",
@@ -6142,7 +6163,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
         }
        </pre>
-       <pre class="LED exampleTab1">
+       <pre class="LED exampleTab1 printMe">
         {
             "@context": "http://www.w3.org/ns/td",
             "@type": "tm:ThingModel",

--- a/index.template.html
+++ b/index.template.html
@@ -222,6 +222,15 @@ a[href].internalDFN {
     margin-bottom: 0;
     height: 0;
 }
+
+/* Print parts that might be hidden */
+@media print {
+	.with-default pre {
+		margin-top: 0;
+		margin-bottom: 1em;
+		height: auto;
+	}
+}
 </style>
 
 <script>
@@ -303,6 +312,12 @@ a[href].internalDFN {
   }
   .ds-selector-tabs pre, .ds-selector-tabs table {
     display: none;
+  }
+  /* Print parts that might be hidden */
+  @media print {
+    .ds-selector-tabs pre, .ds-selector-tabs table {
+      display: inline;
+    }
   }
   .ds-selector-tabs pre.selected, .ds-selector-tabs table.selected {
     display: block;


### PR DESCRIPTION
fixes https://github.com/w3c/wot-thing-description/issues/1059

Note: at the moment only index.html is changed for testing purposes.

With this change
* JS tabs, like  https://w3c.github.io/wot-thing-description/#example-4 and 
* CSS tabs like https://w3c.github.io/wot-thing-description/#example-56
are no longer hidden on print.

A downside is that it does not show a proper title before each code part but instead in the beginning only.
Please try to print index.html and you should see what I mean.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1279.html" title="Last updated on Nov 18, 2021, 10:42 AM UTC (be95723)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1279/815fc8e...danielpeintner:be95723.html" title="Last updated on Nov 18, 2021, 10:42 AM UTC (be95723)">Diff</a>