### PR TITLE
Event consumer: Alternative 1 - event operation 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1434,13 +1434,15 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           containing a combination of these terms.
           </span></p></section>
 <section><h3><code>EventAffordance</code></h3><p>An Interaction Affordance that describes an event
-          source, which asynchronously pushes event data to
+          source and an event consumer, which asynchronously pushes event data to
           <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating
           alerts).</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance"><td><code>subscription</code></td><td>Defines data that needs to be passed upon
                 subscription, e.g., filters or message format for
                 setting up Webhooks.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance"><td><code>data</code></td><td>Defines the data schema of the Event instance
+<tr class="rfc2119-table-assertion" id="td-vocab-data-response--EventAffordance"><td><code>data</code></td><td>Defines the data schema of the Event 
                 messages pushed by the Thing.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-data-response--EventAffordance"><td><code>dataresponse</code></td><td>Defines the data schema of the Event response
+                    messages sent be the consumer in a response to a data message.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance"><td><code>cancellation</code></td><td>Defines any data that needs to be passed to
                 cancel a subscription, e.g., a specific message to
                 remove a Webhook.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p><code>EventAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
@@ -1449,9 +1451,10 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           a Form instance is within an <code>EventAffordance</code>
           instance, the value assigned to <code>op</code>
           <em class="rfc2119" title="MUST">MUST</em> be either
-          <code>subscribeevent</code>,
-          <code>unsubscribeevent</code>, or both terms within an
-          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span></p><p class="note">
+          <code>subscribeevent</code>, <code>notify</code>,
+          <code>unsubscribeevent</code>, or an 
+          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
+          containing a combination of these terms.</span></p><p class="note">
 		  It is considered to be good practice that each <code>subscribeevent</code> has a corresponding <code>unsubscribeevent</code> unless the protocol
 		  supports implicit unsubscription mechanisms (e.g., heartbeat to detect connection loss).</p></section>
 <section><h3><code>VersionInfo</code></h3><p>Metadata of a Thing that provides version information


### PR DESCRIPTION
Event consumer operation to enable describing a servient with an event listener notification interface in a TD.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1329.html" title="Last updated on Dec 15, 2021, 9:46 PM UTC (6a563db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1329/21ce84a...6a563db.html" title="Last updated on Dec 15, 2021, 9:46 PM UTC (6a563db)">Diff</a>