### PR TITLE
Event consumer: Alternative 2 - event consumer affordance 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1454,7 +1454,25 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span></p><p class="note">
 		  It is considered to be good practice that each <code>subscribeevent</code> has a corresponding <code>unsubscribeevent</code> unless the protocol
 		  supports implicit unsubscription mechanisms (e.g., heartbeat to detect connection loss).</p></section>
-<section><h3><code>VersionInfo</code></h3><p>Metadata of a Thing that provides version information
+
+
+
+          <section><h3><code>EventConsumerAffordance</code></h3><p>An Interaction Affordance that describes an event
+            destination, which asynchronously receives event data from
+            <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating
+            alerts).</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-notification--EventAffordance"><td><code>notification</code></td><td>Defines the data schema of the Event 
+                message pushed by the Thing to the event consumer.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+  <tr class="rfc2119-table-assertion" id="td-vocab-notification-response--EventAffordance"><td><code>notification-response</code></td><td>Defines the data schema of the response message that is sent after reception of a message pushed by the Thing.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+  </tbody></table><p><code>EventAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+            <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+            <span class="rfc2119-assertion" id="td-op-for-event">When
+            a Form instance is within an <code>EventConsumerAffordance</code>
+            instance, the value assigned to <code>op</code>
+            <em class="rfc2119" title="MUST">MUST</em> be
+            <code>notify</code>.</span></p></section>
+  
+
+          <section><h3><code>VersionInfo</code></h3><p>Metadata of a Thing that provides version information
           about the TD document. If required, additional version
           information such as firmware and hardware version (term
           definitions outside of the TD namespace) can be extended


### PR DESCRIPTION
Event consumer affordance to enable describing a servient with an event listener notification interface in a TD.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1330.html" title="Last updated on Dec 15, 2021, 9:45 PM UTC (015c3a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1330/21ce84a...015c3a1.html" title="Last updated on Dec 15, 2021, 9:45 PM UTC (015c3a1)">Diff</a>