### PR TITLE
fix: move CBOR content types their own table row in section 5.3.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -1537,6 +1537,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                      <code>application/xml</code> <br />
                      <code>application/senml+xml</code> <br />
                      <code>application/exi</code> <br />
+                     <code>application/senml-exi</code> <br />
                   </td>
                </tr>
             </tbody>

--- a/index.html
+++ b/index.html
@@ -1522,7 +1522,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             </thead>
             <tbody>
                <tr>
-                  <td>JSON</td>
+                  <td>JSON/CBOR</td>
                   <td>
                      <code>application/json</code> <br />
                      <code>application/ld+json</code> <br />
@@ -1532,7 +1532,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                   </td>
                </tr>
                <tr>
-                  <td>XML</td>
+                  <td>XML/EXI</td>
                   <td>
                      <code>application/xml</code> <br />
                      <code>application/senml+xml</code> <br />

--- a/index.template.html
+++ b/index.template.html
@@ -1201,6 +1201,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                      <code>application/xml</code> <br />
                      <code>application/senml+xml</code> <br />
                      <code>application/exi</code> <br />
+                     <code>application/senml-exi</code> <br />
                   </td>
                </tr>
             </tbody>

--- a/index.template.html
+++ b/index.template.html
@@ -1186,7 +1186,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             </thead>
             <tbody>
                <tr>
-                  <td>JSON</td>
+                  <td>JSON/CBOR</td>
                   <td>
                      <code>application/json</code> <br />
                      <code>application/ld+json</code> <br />
@@ -1196,7 +1196,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                   </td>
                </tr>
                <tr>
-                  <td>XML</td>
+                  <td>XML/EXI</td>
                   <td>
                      <code>application/xml</code> <br />
                      <code>application/senml+xml</code> <br />


### PR DESCRIPTION
In the table in section 5.3.2 the CBOR content types are listed in a row labelled "JSON" which is probably incorrect. This PR provides a fix for this issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-thing-description/pull/1331.html" title="Last updated on Feb 16, 2022, 4:53 PM UTC (44ee6e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1331/21ce84a...JKRhb:44ee6e3.html" title="Last updated on Feb 16, 2022, 4:53 PM UTC (44ee6e3)">Diff</a>