### PR TITLE
fix: some HTML markup issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -2631,7 +2631,7 @@ In order to support interoperable internationalization,
 requirements defined in Section 8.1 of RFC8259 [[!RFC8259]] for open ecosystems.</span>
 In summary, this requires the following:
 <ul>
-<li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[!RFC3629]].</span</li>
+<li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[!RFC3629]].</span></li>
 <li><span class="rfc2119-assertion" id="td-json-open_no-byte-order">Implementations MUST NOT 
   add a byte order mark (U+FEFF) to the beginning of a TD document.</span></li>
 <li><span class="rfc2119-assertion" id="td-json-open_accept-byte-order"><a>TD Processors</a> MAY ignore
@@ -5679,7 +5679,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
           As a second example, if we consider a TD to contain personally
           identifiable information, then it should not be retained indefinitely
           or used for purposes other than those for which consent was given.
-      </dd></dt>
+      </dd></dl>
   </section>
 
   </section>
@@ -6606,7 +6606,7 @@ instance.
             following steps:
          <ul>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-imports">Copy all definitions from the input <a>Thing Model</a> to the resulting <a>Partial TD</a> instance. If used, the extension and imports
-            feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href=#thing-model-extension-import></a></span>.</li>
+            feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href="#thing-model-extension-import"></a>.</li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-extends"> If used, <code>links</code> element entry with <code>"rel":"tm:extends"</code> MUST be removed from the current <a>Partial TD</a></li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-type">The <code>tm:ThingModel</code> value of the top-level <code>@type</code> MUST to be replaced by the value <code>Thing</code> in the <a>Partial TD</a> instance.</li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-required">If the <code>tm:required</code> feature is used based on Section <a href=#thing-model-td-required></a>, the required interactions MUST definitely be taken over in the <a>Partial TD</a> instance.</li>
@@ -6866,6 +6866,7 @@ instance.
       <dd>432</dd>
       <dt>Reference:</dt>
       <dd>[<a href="https://w3c.github.io/wot-thing-description/">"Web of Things (WoT) Thing Description", May 2019</a>]</dd>
+    </dl>
     </section>
   </section>
 

--- a/index.template.html
+++ b/index.template.html
@@ -1466,7 +1466,7 @@ In order to support interoperable internationalization,
 requirements defined in Section 8.1 of RFC8259 [[!RFC8259]] for open ecosystems.</span>
 In summary, this requires the following:
 <ul>
-<li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[!RFC3629]].</span</li>
+<li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDs MUST be encoded using UTF-8 [[!RFC3629]].</span></li>
 <li><span class="rfc2119-assertion" id="td-json-open_no-byte-order">Implementations MUST NOT 
   add a byte order mark (U+FEFF) to the beginning of a TD document.</span></li>
 <li><span class="rfc2119-assertion" id="td-json-open_accept-byte-order"><a>TD Processors</a> MAY ignore
@@ -4513,7 +4513,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
           As a second example, if we consider a TD to contain personally
           identifiable information, then it should not be retained indefinitely
           or used for purposes other than those for which consent was given.
-      </dd></dt>
+      </dd></dl>
   </section>
 
   </section>
@@ -5440,7 +5440,7 @@ instance.
             following steps:
          <ul>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-imports">Copy all definitions from the input <a>Thing Model</a> to the resulting <a>Partial TD</a> instance. If used, the extension and imports
-            feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href=#thing-model-extension-import></a></span>.</li>
+            feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href="#thing-model-extension-import"></a>.</li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-extends"> If used, <code>links</code> element entry with <code>"rel":"tm:extends"</code> MUST be removed from the current <a>Partial TD</a></li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-type">The <code>tm:ThingModel</code> value of the top-level <code>@type</code> MUST to be replaced by the value <code>Thing</code> in the <a>Partial TD</a> instance.</li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-required">If the <code>tm:required</code> feature is used based on Section <a href=#thing-model-td-required></a>, the required interactions MUST definitely be taken over in the <a>Partial TD</a> instance.</li>
@@ -5700,6 +5700,7 @@ instance.
       <dd>432</dd>
       <dt>Reference:</dt>
       <dd>[<a href="https://w3c.github.io/wot-thing-description/">"Web of Things (WoT) Thing Description", May 2019</a>]</dd>
+    </dl>
     </section>
   </section>
 


### PR DESCRIPTION
fixes *some* issues reported by HTML checker, see https://github.com/w3c/wot-thing-description/issues/1314

Note: there are MANY issues where table or ul etc are not allowed under p tag. Not sure if we really want to deal with all of them


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1332.html" title="Last updated on Dec 20, 2021, 1:11 PM UTC (e22781c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1332/21ce84a...danielpeintner:e22781c.html" title="Last updated on Dec 20, 2021, 1:11 PM UTC (e22781c)">Diff</a>