### PR TITLE
fix: typos and grammatical errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -4010,7 +4010,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   </span></p>
 
   <p>It is recommended to follow the link relation values as provided in Section <a href=#link></a>.
- In the following examples are provide that uses different link relation values.</p>
+ The examples provided below demonstrate the use of different link relation types.</p>
 
  <p>A reference can be provided that points to a <a>Thing</a> (e.g., a controller) that controls the underlying
     unit (e.g., a lamp). For this <code>controlledBy</code> can be used:</p>
@@ -4481,10 +4481,10 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
 </aside>
 
   <p>
-  The terms <code>readOnly</code> and <code>writeOnly</code> can be used signal
+  The terms <code>readOnly</code> and <code>writeOnly</code> can be used to signal
   which data items are exchanged in read interactions (i.e., when reading a Property)
   and which in write interactions (i.e., when writing a Property).
-  This can be used as workaround when Properties of an unconventional <a>Thing</a>
+  This can be used as a workaround when Properties of an unconventional <a>Thing</a>
   exhibit different data for reading and writing, which can be the case when
   augmenting an existing device or service with a Thing Description.
   </p>
@@ -4675,7 +4675,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
 <h3>Semantic Annotations</h3>
 
     <p>
-    <a>TD Context Extensions</a> allow for additional <a>Vocabulary Terms</a> to a Thing Description instance.
+    <a>TD Context Extensions</a> allow for the use of additional <a>Vocabulary Terms</a> in a Thing Description instance.
     If the included namespaces are based on <a>Class</a> definitions
     such as those provided by the RDF Schema or OWL,
     they can be used to annotate any <a>Class</a> instance of a Thing Description semantically
@@ -4683,7 +4683,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
     This is done by assigning a <a>Class</a> name to the <code>@type</code> name-value pair or
     including <a>Class</a> name in its <a>Array</a> value for multiple associations/annotations.
     Following the serialization rules in <a href="#td-basic-types-mapping"></a>,
-    <code>@type</code> is either serialized as JSON string or as JSON array.
+    <code>@type</code> is either serialized as a JSON string or as a JSON array.
     <code>@type</code> is the JSON-LD keyword [[?json-ld11]] used to set the type of a node.
     </p>
 
@@ -4698,7 +4698,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
     </p>
 
     <p>
-    Next subsections show some sample usage of different kind of ontologies in Thing Descriptions.
+    The next subsections show some sample usage of different kind of ontologies in Thing Descriptions.
     </p>
 
     <section id="semantic-annotations-example-version-units">
@@ -5193,7 +5193,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         <li>
             <span class="rfc2119-assertion" id="bindings-requirements-scheme">
                 Every form in a WoT Thing Description MUST follow the requirements
-                of the <a>Protocol Binding</a> indicated by the URI scheme [[!RFC3986]] of its
+                of the <a>Protocol Binding</a> Template indicated by the URI scheme [[!RFC3986]] of its
                 <code>href</code> member as indicated by the Binding Templates specification at <a href="https://w3c.github.io/wot-binding-templates/#creating-a-new-protocol-binding">Creating a New Protocol Binding</a>.
 
             </span>
@@ -5745,7 +5745,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     A <a>Thing Model</a> MAY NOT contain instance specific <a>Protocol Binding</a> and security information such as endpoint addresses.
     </span>
 
-    As consequent, <a>Thing Model</a> definitions will be also valid if there are no JSON members like <em>forms</em>, <em>base</em>, 
+    Consequently, <a>Thing Model</a> definitions will also be valid if there are no JSON members like <em>forms</em>, <em>base</em>, 
     <em>securityDefinitions</em>, and <em>security</em>. <a>Thing Models</a> are also valid even if these JSON members are used (e.g., as template), however,
     the nested mandatory members like <em>href</em> are omitted.
     </p>
@@ -5760,7 +5760,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     <section id="thing-model-tools" class="normative">
         <h2>Modeling Tools</h2>
 
-        <p>In the context of <a>Thing Model</a> definitions specifics features are introduced that can be used for <a>Thing</a> modelling.</p>
+        <p>In the context of <a>Thing Model</a> definitions specific features are introduced that can be used for <a>Thing</a> modelling.</p>
 
     <section id="thing-model-versioning" class="normative">
         <h3>Versioning</h3>
@@ -5788,9 +5788,9 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         </p>
 
         <p>
-            When <a>Thing Models</a> are updated and have a new version, it should be aware that this may affect 
+            When <a>Thing Models</a> are updated and have a new version, this may affect 
             other <a>Thing Models</a> that uses the extension and import features (see Section <a href="#thing-model-extension-import"></a>). 
-            In some cases it is useful to reflect a new version also in the file name and/or in a corresponding URL to identify the version.
+            In some cases it is also useful to reflect a new version in the file name and/or in a corresponding URL to identify the version.
           </p>
 
     </section>
@@ -5801,13 +5801,13 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         A <a>Thing Model</a> can extend an existing <a>Thing Model</a> by using the <code>tm:extends</code> mechanism announced in the <code>links</code> definition: 
      <span class="rfc2119-assertion" id="tm-extend">
         A <a>Thing Model</a> MUST use at least one <code>links</code> entry with <code>"rel":"tm:extends"</code> 
-        that targets to a <a>Thing Model</a> that is be extended.
+        that targets a <a>Thing Model</a> that is be extended.
     </span>
     The <a>Thing Model</a> will inherit all definitions from the extended <a>Thing Model</a>. There is the opportunity 
-    to extend the existing definition with further metadata by providing further JSON name-value pairs from existing 
+    to extend the existing definition with further metadata by providing further JSON name-value pairs from the existing 
     TD information model (<a href=#sec-vocabulary-definition></a>) or using the context extension concept 
     (<a href=#sec-context-extensions></a>). A <a>Thing Model</a> can also overwrite existing definitions such as <code>title(s)</code> 
-    and <code>maximum</code> etc.. For this there exists two limitations: 
+    and <code>maximum</code> etc.. For this there exist two limitations: 
     <span class="rfc2119-assertion" id="tm-overwrite-interaction">
         A <a>Thing Model</a> SHOULD NOT overwrite the JSON names defined within the  
         <code>properties</code>, <code>actions</code>, and/or <code>events</code> <a>Map</a> of the extended <a>Thing Model</a>.
@@ -5815,7 +5815,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     <span class="rfc2119-assertion" id="tm-overwrite-types">
         Definitions SHOULD NOT be overwritten in such a way that possible instance values are no longer valid compared to the origin extended definitions.
     </span>
-    Those assertations preserve the semantics throughout of the extended <a>Thing Model</a>. 
+    Those assertions preserve the semantics throughout of the extended <a>Thing Model</a>. 
     E.g., it is not allowed that a <code>"minimum":2 </code>  from a extended <a>Thing Model</a> can be overwritten with <code>"minimum":0</code>. 
     Meanwhile, overwriting with <code>"minimum":5 </code> would work since all instances values will always fulfill the restrictions of the extended <a>Thing Model</a> 
     (also see Figure <a href="#thing-model-overwriting"></a> for further explanation).
@@ -5869,7 +5869,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </p>
 
     <p>
-    The <code>tm:extends</code> feature only allows to inherit all definitions of one <a>Thing Model</a>. In many use cases, however,
+    The <code>tm:extends</code> feature only permits inheriting all definitions of one <a>Thing Model</a>. In many use cases, however,
      it is desired only to import pieces of definitions of one or more existing <a>Thing Models</a>. 
      For doing this, the <code>tm:ref</code> term is introduced that provides the location of an existing (sub-)definition that should be reused.
      <span class="rfc2119-assertion" id="tm-tmRef1">
@@ -5908,10 +5908,10 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
     <p>
       At the place the "tm:ref" is defined, additional name-value pairs can be added. 
-      It is also allowed to override name-value pairs from the referenced definition.  
+      It is also permitted to override name-value pairs from the referenced definition.  
       <span class="rfc2119-assertion" id="tm-tmRef-overwrite">
-        If it is intended to override an existing JSON name-value pair definition from <code>tm:ref</code>, the same JSON name MUST be used
-        at the same level of the <code>tm:ref</code> declearation that provides a new value. This process MUST follow the 
+        If the intention is to override an existing JSON name-value pair definition from <code>tm:ref</code>, the same JSON name MUST be used
+        at the same level of the <code>tm:ref</code> declaration that provides a new value. This process MUST follow the 
         JSON Merge Patch algorithm as defined in [RFC7396] where the content of the referenced definition is patched with the new provided JSON name-value 
         pairs.
        </span>
@@ -5928,7 +5928,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </p>
 
     <p>
-        The following example shows a new TM definition that overwrite (<code>maximum</code>), enhanced (<code>unit</code>), and removes (<code>title</code>) existing definitions from
+        The following example shows a new TM definition that overwrites (<code>maximum</code>), enhances (<code>unit</code>), and removes (<code>title</code>) existing definitions from
          <a href="#td-model-example-smart-lamp-control"></a>. 
     </p>
 
@@ -5953,7 +5953,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </p>
  
     <p>
-        The <code>tm:extends</code> and the import mechanism based on <code>tm:ref</code> can be also used at the same time in 
+        The <code>tm:extends</code> and the import mechanism based on <code>tm:ref</code> can also be used at the same time in 
         a TM definition. The following example extends the TM from <a href="#td-model-example-basic-on-off"></a> and imports
         the <code>status</code> and <code>dim</code> definitions from <a href="#td-model-example-lamp"></a> and 
         <a href="#td-model-example-smart-lamp-control"></a> respectively.
@@ -5983,13 +5983,13 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     <p>
 
 
-    The following figure summarizes the allowable override behavior of the extension and import TM functions presented in this section.
-    Three <a>Thing Models</a> using the <code>tm:ref</code> or <code>tm:extends</code> feature to reuse TM definitions of the Smart Lamp Control <a>Thing Model</a>.
-    The first <a>Thing Model</a> imports and overwrite the <code>maximum</code> value to <code>120</code> within the <code>dimmer</code> property. However, this results 
+    The following figure summarizes the allowable override behaviour of the extension and imports TM functions presented in this section.
+    Three <a>Thing Models</a> use the <code>tm:ref</code> or <code>tm:extends</code> feature to reuse TM definitions of the Smart Lamp Control <a>Thing Model</a>.
+    The first <a>Thing Model</a> imports and overwrites the <code>maximum</code> value to <code>120</code> within the <code>dimmer</code> property. However, this results 
     in possible instance values (at runtime) that may not be in the range of the original <code>dim</code> definition between <code>0</code> and <code>100</code> of the dim definition of the Smart Lamp Control 
-    Thing Model. Thus, such kind of <a>Thing Model</a> definition is not allowed.  
+    Thing Model. Thus, such a <a>Thing Model</a> definition is not allowed.  
      
-     The second model overwrites the property <code>type</code> value by <code>number</code>. Again, this will potential result to numeric <code>dim</code> values that are not
+     The second model overwrites the property <code>type</code> value by <code>number</code>. Again, this will potentially result in numeric <code>dim</code> values that are not
      accepted by the definition of the origin <code>dim</code> type definition (integer) of the Smart Lamp Control <a>Thing Model</a>.  
 
      The last model is defined in a correct way. The new ranges of <code>dim</code> produce potential instance values that are also fulfilled by the 
@@ -6008,8 +6008,8 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 <section id="thing-model-composition" class="normative">
     <h3>Composition</h3>
 <p>
-In some applications, it is beneficial to reuse existing <a>Thing Model</a> definitions and compose them to a new IoT system. 
-An example can be that a new Smart Ventilator should be designed which consist of two sub/child <a>Thing Model</a> definitions such as 
+In some applications, it is beneficial to reuse existing <a>Thing Model</a> definitions and compose them into a new IoT system. 
+An example would be that a new Smart Ventilator is designed to consist of two sub/child <a>Thing Model</a> definitions such as 
 a Ventilation <a>Thing Model</a> that provides <code>on/off</code> and <code>adjustRpm</code> capabilities, and an LED <a>Thing Model</a> that 
 provides <code>dimmable</code> and <code>RGB</code> capabilities. 
 </p>
@@ -6118,9 +6118,9 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
         that targets to the (sub-) <a>Thing Models</a>.
     </span>
     <span class="rfc2119-assertion" id="tm-compose-instanceName">
-        Optional an <code>instanceName</code> can be provided to associate an individual name to the composed (sub-) <a>Thing Model</a>.
+        Optionally an <code>instanceName</code> can be provided to associate an individual name to the composed (sub-) <a>Thing Model</a>.
     </span> 
-    This is useful when multiple same <a>Thing Model</a> definitions are composed and needs to be distinguished. 
+    This is useful when multiple similar <a>Thing Model</a> definitions are composed and needs to be distinguished. 
 </p>
 
 
@@ -6317,7 +6317,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
 
 
 <p>
-    A single TD can be also generated which contains the interaction definitions of the top level/parent
+    A single TD can also be generated which contains the interaction definitions of the top level/parent
     <a>Thing Model</a> and all interaction definitions of all sub/child <a>Thing Models</a>. 
     <span class="rfc2119-assertion" id="tm-compose-name-collision">
        To avoid name collisions of the sub/child interaction names it is recommended to rename the JSON name to the <code>instanceName</code> followed with <code>'_'</code> and the interaction name of the sub/child <a>Thing Model</a>.
@@ -6440,11 +6440,10 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
 
 
   <p>    
-    In some cases it is desirable to force the information which interaction model is mandatory 
-    and has to be definitely implemented in a <a>Thing Description</a> instance or can be always expected 
+    In some cases it is desirable to enforce which interaction affordances are mandatory and have to be implemented in a <a>Thing Description</a> instance or can be always expected 
     by the <a>Thing Model</a>.
     <span class="rfc2119-assertion" id="tm-tmRequired">
-        To guarantee the implementation of particular kind of interaction models, Thing Model definitions MUST use 
+        To guarantee the implementation of particular kinds of interaction models, Thing Model definitions MUST use 
         the JSON member name <code>tm:required</code>. 
     </span>
     <span class="rfc2119-assertion" id="tm-tmRequired-array">
@@ -6497,7 +6496,7 @@ and <a>Action</a> interaction <code>toggle</code>.
 </pre>
     
 <p>
-Since the <a>Event</a> <code>overheating</code> is not mandatory it may be not available in a <a>Thing Description</a> 
+Since the <a>Event</a> <code>overheating</code> is not mandatory it may not be available in a <a>Thing Description</a> 
 instance.
 </p>
 
@@ -6507,7 +6506,7 @@ instance.
     <h3>Placeholder</h3>
 
 <p>
-    <a>Thing Model</a> can specify which terms should be taken in a TD instance, but their values are unspecific and are first known during TD instantiation. 
+    A <a>Thing Model</a> can specify which terms should be used in a TD instance, but their values are unspecific and are first known during TD instantiation. 
     In such a case the placeholder labeling MAY be used in Thing Model that MUST be substituted with a concrete value when TD instance is created 
     from the Thing Model. 
     <span class="rfc2119-assertion" id="tm-placeholder">
@@ -6515,11 +6514,10 @@ instance.
         The characters between <code>{{</code> and <code>}}</code> are used as identifier name of the placeholder. The identifier name can be used to identify the placeholder for the substitution process.
     </span>
     <span class="rfc2119-assertion" id="tm-placeholder-value">
-        Placeholder can be only applied within the value of the JSON name-value pair and the value have to be typed as JSON string. 
+        A placeholder can only be applied within the value of the JSON name-value pair and the value has to be a JSON string. 
     </span>  
     <span class="rfc2119-assertion" id="tm-placeholder-retyping">
-    In the case a non string-based value of a JSON name-value pair should have a placeholder the value must be (temporary) typed 
-    as string. After replacing the placeholder, e.g. when creating a Thing Description instance, the original type can be applied with the 
+    In the case that a non string-based value of a JSON name-value pair should have a placeholder, the value must be (temporarily) typed as string. After replacing the placeholder, e.g. when creating a Thing Description instance, the original type can be applied with the 
     corresponding replaced value.  
     </span>
           
@@ -6592,10 +6590,10 @@ instance.
   </section>
 
   <section id="thing-model-td-generation" class="normative">
-    <h2>Derivation to Thing Description Instances</h2>
+    <h2>Derivation of Thing Description Instances</h2>
 
     <p>
-        <a>Thing Models</a> can be used as template to generate <a>Thing Description</a> based on the restriction defined in 
+        <a>Thing Models</a> can be used as templates to generate a <a>Thing Description</a> based on the restrictions defined in 
         Sections <a href="#sec-vocabulary-definition"></a> and <a href="#sec-td-serialization"></a>. During this process 
         missing data such as communication and security metadata have to be complemented to create valid <a>Thing Description</a> instances.
         <span class="rfc2119-assertion" id="tm-td-generation-inconsistencies">
@@ -6607,20 +6605,19 @@ instance.
          <ul>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-imports">Copy all definitions from the input <a>Thing Model</a> to the resulting <a>Partial TD</a> instance. If used, the extension and imports
             feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href=#thing-model-extension-import></a></span>.</li>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-extends"> If used, <code>links</code> element entry with <code>"rel":"tm:extends"</code> MUST be removed from the current <a>Partial TD</a></li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-extends"> If used, a <code>links</code> element entry with <code>"rel":"tm:extends"</code> MUST be removed from the current <a>Partial TD</a></li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-type">The <code>tm:ThingModel</code> value of the top-level <code>@type</code> MUST to be replaced by the value <code>Thing</code> in the <a>Partial TD</a> instance.</li>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-required">If the <code>tm:required</code> feature is used based on Section <a href=#thing-model-td-required></a>, the required interactions MUST definitely be taken over in the <a>Partial TD</a> instance.</li>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-placeholder">If used, all placeholder (see Section <a href="#thing-model-td-placeholder"></a>) in the <a>Thing Model</a> MUST be replaced with a valid corresponding value in the <a>Partial TD</a>.</li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-required">If the <code>tm:required</code> feature is used based on Section <a href=#thing-model-td-required></a>, the required interactions MUST be taken over to the <a>Partial TD</a> instance.</li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-placeholder">If used, all placeholders (see Section <a href="#thing-model-td-placeholder"></a>) in the <a>Thing Model</a> MUST be replaced with a valid corresponding value in the <a>Partial TD</a>.</li>
         </ul>
         Finally, a TM-to-TD generator will take the resulting <a>Partial TD</a> and transform it into a <a>Thing Description</a> with this last step
         <ul>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-forms">Missing communication and/or security metadata details MUST be complemented in the <a>Thing Description</a> instance based on Section <a href=#security-serialization-json></a> and/or <a href=#form-serialization-json></a>.</li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-forms">Missing communication and/or security metadata details MUST be completed in the <a>Thing Description</a> instance based on Section <a href=#security-serialization-json></a> and/or <a href=#form-serialization-json></a>.</li>
         </ul>
     </p>
   
 
-      <p>Thing description instances that follow a Thing Model can carry the information which type 
-          of Thing Model is derived. In this context, the linking concept can be used with <code>"rel" : "type"</code> (also see
+      <p>Thing description instances that follow a Thing Model can carry the information regarding which type of Thing Model is derived. In this context, the linking concept can be used with <code>"rel" : "type"</code> (also see
           Section <a href="#link"></a>), as shown in the following example: 
       </p>
 
@@ -6661,10 +6658,10 @@ instance.
 		</pre>
         </aside>
 
-         <p>Please note that a TD can only be an instance of only one TM at a time. 
+         <p>Please note that a TD can only be an instance of one TM at a time. 
              That means for Thing Descriptions:
          <span class="rfc2119-assertion" id="tm-rel-type-maximum">
-            The <code>links</code> array can use the entry with <code>"rel" : "type"</code> maximum one.
+            The <code>links</code> array can use the entry with <code>"rel" : "type"</code> a maximum of once.
         </span> 
     </p>
 

--- a/index.template.html
+++ b/index.template.html
@@ -2844,7 +2844,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
   </span></p>
 
   <p>It is recommended to follow the link relation values as provided in Section <a href=#link></a>.
- In the following examples are provide that uses different link relation values.</p>
+ The examples provided below demonstrate the use of different link relation types.</p>
 
  <p>A reference can be provided that points to a <a>Thing</a> (e.g., a controller) that controls the underlying
     unit (e.g., a lamp). For this <code>controlledBy</code> can be used:</p>
@@ -3315,10 +3315,10 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
 </aside>
 
   <p>
-  The terms <code>readOnly</code> and <code>writeOnly</code> can be used signal
+  The terms <code>readOnly</code> and <code>writeOnly</code> can be used to signal
   which data items are exchanged in read interactions (i.e., when reading a Property)
   and which in write interactions (i.e., when writing a Property).
-  This can be used as workaround when Properties of an unconventional <a>Thing</a>
+  This can be used as a workaround when Properties of an unconventional <a>Thing</a>
   exhibit different data for reading and writing, which can be the case when
   augmenting an existing device or service with a Thing Description.
   </p>
@@ -3509,7 +3509,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
 <h3>Semantic Annotations</h3>
 
     <p>
-    <a>TD Context Extensions</a> allow for additional <a>Vocabulary Terms</a> to a Thing Description instance.
+    <a>TD Context Extensions</a> allow for the use of additional <a>Vocabulary Terms</a> in a Thing Description instance.
     If the included namespaces are based on <a>Class</a> definitions
     such as those provided by the RDF Schema or OWL,
     they can be used to annotate any <a>Class</a> instance of a Thing Description semantically
@@ -3517,7 +3517,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
     This is done by assigning a <a>Class</a> name to the <code>@type</code> name-value pair or
     including <a>Class</a> name in its <a>Array</a> value for multiple associations/annotations.
     Following the serialization rules in <a href="#td-basic-types-mapping"></a>,
-    <code>@type</code> is either serialized as JSON string or as JSON array.
+    <code>@type</code> is either serialized as a JSON string or as a JSON array.
     <code>@type</code> is the JSON-LD keyword [[?json-ld11]] used to set the type of a node.
     </p>
 
@@ -3532,7 +3532,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
     </p>
 
     <p>
-    Next subsections show some sample usage of different kind of ontologies in Thing Descriptions.
+    The next subsections show some sample usage of different kind of ontologies in Thing Descriptions.
     </p>
 
     <section id="semantic-annotations-example-version-units">
@@ -4027,7 +4027,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         <li>
             <span class="rfc2119-assertion" id="bindings-requirements-scheme">
                 Every form in a WoT Thing Description MUST follow the requirements
-                of the <a>Protocol Binding</a> indicated by the URI scheme [[!RFC3986]] of its
+                of the <a>Protocol Binding</a> Template indicated by the URI scheme [[!RFC3986]] of its
                 <code>href</code> member as indicated by the Binding Templates specification at <a href="https://w3c.github.io/wot-binding-templates/#creating-a-new-protocol-binding">Creating a New Protocol Binding</a>.
 
             </span>
@@ -4579,7 +4579,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     A <a>Thing Model</a> MAY NOT contain instance specific <a>Protocol Binding</a> and security information such as endpoint addresses.
     </span>
 
-    As consequent, <a>Thing Model</a> definitions will be also valid if there are no JSON members like <em>forms</em>, <em>base</em>, 
+    Consequently, <a>Thing Model</a> definitions will also be valid if there are no JSON members like <em>forms</em>, <em>base</em>, 
     <em>securityDefinitions</em>, and <em>security</em>. <a>Thing Models</a> are also valid even if these JSON members are used (e.g., as template), however,
     the nested mandatory members like <em>href</em> are omitted.
     </p>
@@ -4594,7 +4594,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     <section id="thing-model-tools" class="normative">
         <h2>Modeling Tools</h2>
 
-        <p>In the context of <a>Thing Model</a> definitions specifics features are introduced that can be used for <a>Thing</a> modelling.</p>
+        <p>In the context of <a>Thing Model</a> definitions specific features are introduced that can be used for <a>Thing</a> modelling.</p>
 
     <section id="thing-model-versioning" class="normative">
         <h3>Versioning</h3>
@@ -4622,9 +4622,9 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         </p>
 
         <p>
-            When <a>Thing Models</a> are updated and have a new version, it should be aware that this may affect 
+            When <a>Thing Models</a> are updated and have a new version, this may affect 
             other <a>Thing Models</a> that uses the extension and import features (see Section <a href="#thing-model-extension-import"></a>). 
-            In some cases it is useful to reflect a new version also in the file name and/or in a corresponding URL to identify the version.
+            In some cases it is also useful to reflect a new version in the file name and/or in a corresponding URL to identify the version.
           </p>
 
     </section>
@@ -4635,13 +4635,13 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         A <a>Thing Model</a> can extend an existing <a>Thing Model</a> by using the <code>tm:extends</code> mechanism announced in the <code>links</code> definition: 
      <span class="rfc2119-assertion" id="tm-extend">
         A <a>Thing Model</a> MUST use at least one <code>links</code> entry with <code>"rel":"tm:extends"</code> 
-        that targets to a <a>Thing Model</a> that is be extended.
+        that targets a <a>Thing Model</a> that is be extended.
     </span>
     The <a>Thing Model</a> will inherit all definitions from the extended <a>Thing Model</a>. There is the opportunity 
-    to extend the existing definition with further metadata by providing further JSON name-value pairs from existing 
+    to extend the existing definition with further metadata by providing further JSON name-value pairs from the existing 
     TD information model (<a href=#sec-vocabulary-definition></a>) or using the context extension concept 
     (<a href=#sec-context-extensions></a>). A <a>Thing Model</a> can also overwrite existing definitions such as <code>title(s)</code> 
-    and <code>maximum</code> etc.. For this there exists two limitations: 
+    and <code>maximum</code> etc.. For this there exist two limitations: 
     <span class="rfc2119-assertion" id="tm-overwrite-interaction">
         A <a>Thing Model</a> SHOULD NOT overwrite the JSON names defined within the  
         <code>properties</code>, <code>actions</code>, and/or <code>events</code> <a>Map</a> of the extended <a>Thing Model</a>.
@@ -4649,7 +4649,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     <span class="rfc2119-assertion" id="tm-overwrite-types">
         Definitions SHOULD NOT be overwritten in such a way that possible instance values are no longer valid compared to the origin extended definitions.
     </span>
-    Those assertations preserve the semantics throughout of the extended <a>Thing Model</a>. 
+    Those assertions preserve the semantics throughout of the extended <a>Thing Model</a>. 
     E.g., it is not allowed that a <code>"minimum":2 </code>  from a extended <a>Thing Model</a> can be overwritten with <code>"minimum":0</code>. 
     Meanwhile, overwriting with <code>"minimum":5 </code> would work since all instances values will always fulfill the restrictions of the extended <a>Thing Model</a> 
     (also see Figure <a href="#thing-model-overwriting"></a> for further explanation).
@@ -4703,7 +4703,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </p>
 
     <p>
-    The <code>tm:extends</code> feature only allows to inherit all definitions of one <a>Thing Model</a>. In many use cases, however,
+    The <code>tm:extends</code> feature only permits inheriting all definitions of one <a>Thing Model</a>. In many use cases, however,
      it is desired only to import pieces of definitions of one or more existing <a>Thing Models</a>. 
      For doing this, the <code>tm:ref</code> term is introduced that provides the location of an existing (sub-)definition that should be reused.
      <span class="rfc2119-assertion" id="tm-tmRef1">
@@ -4742,10 +4742,10 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
     <p>
       At the place the "tm:ref" is defined, additional name-value pairs can be added. 
-      It is also allowed to override name-value pairs from the referenced definition.  
+      It is also permitted to override name-value pairs from the referenced definition.  
       <span class="rfc2119-assertion" id="tm-tmRef-overwrite">
-        If it is intended to override an existing JSON name-value pair definition from <code>tm:ref</code>, the same JSON name MUST be used
-        at the same level of the <code>tm:ref</code> declearation that provides a new value. This process MUST follow the 
+        If the intention is to override an existing JSON name-value pair definition from <code>tm:ref</code>, the same JSON name MUST be used
+        at the same level of the <code>tm:ref</code> declaration that provides a new value. This process MUST follow the 
         JSON Merge Patch algorithm as defined in [RFC7396] where the content of the referenced definition is patched with the new provided JSON name-value 
         pairs.
        </span>
@@ -4762,7 +4762,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </p>
 
     <p>
-        The following example shows a new TM definition that overwrite (<code>maximum</code>), enhanced (<code>unit</code>), and removes (<code>title</code>) existing definitions from
+        The following example shows a new TM definition that overwrites (<code>maximum</code>), enhances (<code>unit</code>), and removes (<code>title</code>) existing definitions from
          <a href="#td-model-example-smart-lamp-control"></a>. 
     </p>
 
@@ -4787,7 +4787,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </p>
  
     <p>
-        The <code>tm:extends</code> and the import mechanism based on <code>tm:ref</code> can be also used at the same time in 
+        The <code>tm:extends</code> and the import mechanism based on <code>tm:ref</code> can also be used at the same time in 
         a TM definition. The following example extends the TM from <a href="#td-model-example-basic-on-off"></a> and imports
         the <code>status</code> and <code>dim</code> definitions from <a href="#td-model-example-lamp"></a> and 
         <a href="#td-model-example-smart-lamp-control"></a> respectively.
@@ -4817,13 +4817,13 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     <p>
 
 
-    The following figure summarizes the allowable override behavior of the extension and import TM functions presented in this section.
-    Three <a>Thing Models</a> using the <code>tm:ref</code> or <code>tm:extends</code> feature to reuse TM definitions of the Smart Lamp Control <a>Thing Model</a>.
-    The first <a>Thing Model</a> imports and overwrite the <code>maximum</code> value to <code>120</code> within the <code>dimmer</code> property. However, this results 
+    The following figure summarizes the allowable override behaviour of the extension and imports TM functions presented in this section.
+    Three <a>Thing Models</a> use the <code>tm:ref</code> or <code>tm:extends</code> feature to reuse TM definitions of the Smart Lamp Control <a>Thing Model</a>.
+    The first <a>Thing Model</a> imports and overwrites the <code>maximum</code> value to <code>120</code> within the <code>dimmer</code> property. However, this results 
     in possible instance values (at runtime) that may not be in the range of the original <code>dim</code> definition between <code>0</code> and <code>100</code> of the dim definition of the Smart Lamp Control 
-    Thing Model. Thus, such kind of <a>Thing Model</a> definition is not allowed.  
+    Thing Model. Thus, such a <a>Thing Model</a> definition is not allowed.  
      
-     The second model overwrites the property <code>type</code> value by <code>number</code>. Again, this will potential result to numeric <code>dim</code> values that are not
+     The second model overwrites the property <code>type</code> value by <code>number</code>. Again, this will potentially result in numeric <code>dim</code> values that are not
      accepted by the definition of the origin <code>dim</code> type definition (integer) of the Smart Lamp Control <a>Thing Model</a>.  
 
      The last model is defined in a correct way. The new ranges of <code>dim</code> produce potential instance values that are also fulfilled by the 
@@ -4842,8 +4842,8 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 <section id="thing-model-composition" class="normative">
     <h3>Composition</h3>
 <p>
-In some applications, it is beneficial to reuse existing <a>Thing Model</a> definitions and compose them to a new IoT system. 
-An example can be that a new Smart Ventilator should be designed which consist of two sub/child <a>Thing Model</a> definitions such as 
+In some applications, it is beneficial to reuse existing <a>Thing Model</a> definitions and compose them into a new IoT system. 
+An example would be that a new Smart Ventilator is designed to consist of two sub/child <a>Thing Model</a> definitions such as 
 a Ventilation <a>Thing Model</a> that provides <code>on/off</code> and <code>adjustRpm</code> capabilities, and an LED <a>Thing Model</a> that 
 provides <code>dimmable</code> and <code>RGB</code> capabilities. 
 </p>
@@ -4952,9 +4952,9 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
         that targets to the (sub-) <a>Thing Models</a>.
     </span>
     <span class="rfc2119-assertion" id="tm-compose-instanceName">
-        Optional an <code>instanceName</code> can be provided to associate an individual name to the composed (sub-) <a>Thing Model</a>.
+        Optionally an <code>instanceName</code> can be provided to associate an individual name to the composed (sub-) <a>Thing Model</a>.
     </span> 
-    This is useful when multiple same <a>Thing Model</a> definitions are composed and needs to be distinguished. 
+    This is useful when multiple similar <a>Thing Model</a> definitions are composed and needs to be distinguished. 
 </p>
 
 
@@ -5151,7 +5151,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
 
 
 <p>
-    A single TD can be also generated which contains the interaction definitions of the top level/parent
+    A single TD can also be generated which contains the interaction definitions of the top level/parent
     <a>Thing Model</a> and all interaction definitions of all sub/child <a>Thing Models</a>. 
     <span class="rfc2119-assertion" id="tm-compose-name-collision">
        To avoid name collisions of the sub/child interaction names it is recommended to rename the JSON name to the <code>instanceName</code> followed with <code>'_'</code> and the interaction name of the sub/child <a>Thing Model</a>.
@@ -5274,11 +5274,10 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
 
 
   <p>    
-    In some cases it is desirable to force the information which interaction model is mandatory 
-    and has to be definitely implemented in a <a>Thing Description</a> instance or can be always expected 
+    In some cases it is desirable to enforce which interaction affordances are mandatory and have to be implemented in a <a>Thing Description</a> instance or can be always expected 
     by the <a>Thing Model</a>.
     <span class="rfc2119-assertion" id="tm-tmRequired">
-        To guarantee the implementation of particular kind of interaction models, Thing Model definitions MUST use 
+        To guarantee the implementation of particular kinds of interaction models, Thing Model definitions MUST use 
         the JSON member name <code>tm:required</code>. 
     </span>
     <span class="rfc2119-assertion" id="tm-tmRequired-array">
@@ -5331,7 +5330,7 @@ and <a>Action</a> interaction <code>toggle</code>.
 </pre>
     
 <p>
-Since the <a>Event</a> <code>overheating</code> is not mandatory it may be not available in a <a>Thing Description</a> 
+Since the <a>Event</a> <code>overheating</code> is not mandatory it may not be available in a <a>Thing Description</a> 
 instance.
 </p>
 
@@ -5341,7 +5340,7 @@ instance.
     <h3>Placeholder</h3>
 
 <p>
-    <a>Thing Model</a> can specify which terms should be taken in a TD instance, but their values are unspecific and are first known during TD instantiation. 
+    A <a>Thing Model</a> can specify which terms should be used in a TD instance, but their values are unspecific and are first known during TD instantiation. 
     In such a case the placeholder labeling MAY be used in Thing Model that MUST be substituted with a concrete value when TD instance is created 
     from the Thing Model. 
     <span class="rfc2119-assertion" id="tm-placeholder">
@@ -5349,11 +5348,10 @@ instance.
         The characters between <code>{{</code> and <code>}}</code> are used as identifier name of the placeholder. The identifier name can be used to identify the placeholder for the substitution process.
     </span>
     <span class="rfc2119-assertion" id="tm-placeholder-value">
-        Placeholder can be only applied within the value of the JSON name-value pair and the value have to be typed as JSON string. 
+        A placeholder can only be applied within the value of the JSON name-value pair and the value has to be a JSON string. 
     </span>  
     <span class="rfc2119-assertion" id="tm-placeholder-retyping">
-    In the case a non string-based value of a JSON name-value pair should have a placeholder the value must be (temporary) typed 
-    as string. After replacing the placeholder, e.g. when creating a Thing Description instance, the original type can be applied with the 
+    In the case that a non string-based value of a JSON name-value pair should have a placeholder, the value must be (temporarily) typed as string. After replacing the placeholder, e.g. when creating a Thing Description instance, the original type can be applied with the 
     corresponding replaced value.  
     </span>
           
@@ -5426,10 +5424,10 @@ instance.
   </section>
 
   <section id="thing-model-td-generation" class="normative">
-    <h2>Derivation to Thing Description Instances</h2>
+    <h2>Derivation of Thing Description Instances</h2>
 
     <p>
-        <a>Thing Models</a> can be used as template to generate <a>Thing Description</a> based on the restriction defined in 
+        <a>Thing Models</a> can be used as templates to generate a <a>Thing Description</a> based on the restrictions defined in 
         Sections <a href="#sec-vocabulary-definition"></a> and <a href="#sec-td-serialization"></a>. During this process 
         missing data such as communication and security metadata have to be complemented to create valid <a>Thing Description</a> instances.
         <span class="rfc2119-assertion" id="tm-td-generation-inconsistencies">
@@ -5441,20 +5439,19 @@ instance.
          <ul>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-imports">Copy all definitions from the input <a>Thing Model</a> to the resulting <a>Partial TD</a> instance. If used, the extension and imports
             feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href=#thing-model-extension-import></a></span>.</li>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-extends"> If used, <code>links</code> element entry with <code>"rel":"tm:extends"</code> MUST be removed from the current <a>Partial TD</a></li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-extends"> If used, a <code>links</code> element entry with <code>"rel":"tm:extends"</code> MUST be removed from the current <a>Partial TD</a></li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-type">The <code>tm:ThingModel</code> value of the top-level <code>@type</code> MUST to be replaced by the value <code>Thing</code> in the <a>Partial TD</a> instance.</li>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-required">If the <code>tm:required</code> feature is used based on Section <a href=#thing-model-td-required></a>, the required interactions MUST definitely be taken over in the <a>Partial TD</a> instance.</li>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-placeholder">If used, all placeholder (see Section <a href="#thing-model-td-placeholder"></a>) in the <a>Thing Model</a> MUST be replaced with a valid corresponding value in the <a>Partial TD</a>.</li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-required">If the <code>tm:required</code> feature is used based on Section <a href=#thing-model-td-required></a>, the required interactions MUST be taken over to the <a>Partial TD</a> instance.</li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-placeholder">If used, all placeholders (see Section <a href="#thing-model-td-placeholder"></a>) in the <a>Thing Model</a> MUST be replaced with a valid corresponding value in the <a>Partial TD</a>.</li>
         </ul>
         Finally, a TM-to-TD generator will take the resulting <a>Partial TD</a> and transform it into a <a>Thing Description</a> with this last step
         <ul>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-forms">Missing communication and/or security metadata details MUST be complemented in the <a>Thing Description</a> instance based on Section <a href=#security-serialization-json></a> and/or <a href=#form-serialization-json></a>.</li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-forms">Missing communication and/or security metadata details MUST be completed in the <a>Thing Description</a> instance based on Section <a href=#security-serialization-json></a> and/or <a href=#form-serialization-json></a>.</li>
         </ul>
     </p>
   
 
-      <p>Thing description instances that follow a Thing Model can carry the information which type 
-          of Thing Model is derived. In this context, the linking concept can be used with <code>"rel" : "type"</code> (also see
+      <p>Thing description instances that follow a Thing Model can carry the information regarding which type of Thing Model is derived. In this context, the linking concept can be used with <code>"rel" : "type"</code> (also see
           Section <a href="#link"></a>), as shown in the following example: 
       </p>
 
@@ -5495,10 +5492,10 @@ instance.
 		</pre>
         </aside>
 
-         <p>Please note that a TD can only be an instance of only one TM at a time. 
+         <p>Please note that a TD can only be an instance of one TM at a time. 
              That means for Thing Descriptions:
          <span class="rfc2119-assertion" id="tm-rel-type-maximum">
-            The <code>links</code> array can use the entry with <code>"rel" : "type"</code> maximum one.
+            The <code>links</code> array can use the entry with <code>"rel" : "type"</code> a maximum of once.
         </span> 
     </p>
 


### PR DESCRIPTION
reported in https://github.com/w3c/wot-thing-description/issues/1324#issuecomment-993730711 by "->"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1335.html" title="Last updated on Jan 12, 2022, 3:58 PM UTC (dd51d6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1335/7472e2a...danielpeintner:dd51d6c.html" title="Last updated on Jan 12, 2022, 3:58 PM UTC (dd51d6c)">Diff</a>