### PR TITLE
fix: some internal links

### DIFF
--- a/index.html
+++ b/index.html
@@ -4009,7 +4009,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     <a>Vocabulary Term</a> as name.
   </span></p>
 
-  <p>It is recommended to follow the link relation values as provided in Section <a href=#link></a>.
+  <p>It is recommended to follow the link relation values as provided in Section <a href="#link"></a>.
  In the following examples are provide that uses different link relation values.</p>
 
  <p>A reference can be provided that points to a <a>Thing</a> (e.g., a controller) that controls the underlying
@@ -5805,8 +5805,8 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </span>
     The <a>Thing Model</a> will inherit all definitions from the extended <a>Thing Model</a>. There is the opportunity 
     to extend the existing definition with further metadata by providing further JSON name-value pairs from existing 
-    TD information model (<a href=#sec-vocabulary-definition></a>) or using the context extension concept 
-    (<a href=#sec-context-extensions></a>). A <a>Thing Model</a> can also overwrite existing definitions such as <code>title(s)</code> 
+    TD information model (<a href="#sec-vocabulary-definition"></a>) or using the context extension concept 
+    (<a href="#sec-context-extensions"></a>). A <a>Thing Model</a> can also overwrite existing definitions such as <code>title(s)</code> 
     and <code>maximum</code> etc.. For this there exists two limitations: 
     <span class="rfc2119-assertion" id="tm-overwrite-interaction">
         A <a>Thing Model</a> SHOULD NOT overwrite the JSON names defined within the  
@@ -6606,15 +6606,15 @@ instance.
             following steps:
          <ul>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-imports">Copy all definitions from the input <a>Thing Model</a> to the resulting <a>Partial TD</a> instance. If used, the extension and imports
-            feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href=#thing-model-extension-import></a></span>.</li>
+            feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href="#thing-model-extension-import"></a></span>.</li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-extends"> If used, <code>links</code> element entry with <code>"rel":"tm:extends"</code> MUST be removed from the current <a>Partial TD</a></li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-type">The <code>tm:ThingModel</code> value of the top-level <code>@type</code> MUST to be replaced by the value <code>Thing</code> in the <a>Partial TD</a> instance.</li>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-required">If the <code>tm:required</code> feature is used based on Section <a href=#thing-model-td-required></a>, the required interactions MUST definitely be taken over in the <a>Partial TD</a> instance.</li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-required">If the <code>tm:required</code> feature is used based on Section <a href="#thing-model-td-required"></a>, the required interactions MUST definitely be taken over in the <a>Partial TD</a> instance.</li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-placeholder">If used, all placeholder (see Section <a href="#thing-model-td-placeholder"></a>) in the <a>Thing Model</a> MUST be replaced with a valid corresponding value in the <a>Partial TD</a>.</li>
         </ul>
         Finally, a TM-to-TD generator will take the resulting <a>Partial TD</a> and transform it into a <a>Thing Description</a> with this last step
         <ul>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-forms">Missing communication and/or security metadata details MUST be complemented in the <a>Thing Description</a> instance based on Section <a href=#security-serialization-json></a> and/or <a href=#form-serialization-json></a>.</li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-forms">Missing communication and/or security metadata details MUST be complemented in the <a>Thing Description</a> instance based on Section <a href="#security-serialization-json"></a> and/or <a href="#form-serialization-json"></a>.</li>
         </ul>
     </p>
   

--- a/index.template.html
+++ b/index.template.html
@@ -2843,7 +2843,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
     <a>Vocabulary Term</a> as name.
   </span></p>
 
-  <p>It is recommended to follow the link relation values as provided in Section <a href=#link></a>.
+  <p>It is recommended to follow the link relation values as provided in Section <a href="#link"></a>.
  In the following examples are provide that uses different link relation values.</p>
 
  <p>A reference can be provided that points to a <a>Thing</a> (e.g., a controller) that controls the underlying
@@ -4639,8 +4639,8 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
     </span>
     The <a>Thing Model</a> will inherit all definitions from the extended <a>Thing Model</a>. There is the opportunity 
     to extend the existing definition with further metadata by providing further JSON name-value pairs from existing 
-    TD information model (<a href=#sec-vocabulary-definition></a>) or using the context extension concept 
-    (<a href=#sec-context-extensions></a>). A <a>Thing Model</a> can also overwrite existing definitions such as <code>title(s)</code> 
+    TD information model (<a href="#sec-vocabulary-definition"></a>) or using the context extension concept 
+    (<a href="#sec-context-extensions"></a>). A <a>Thing Model</a> can also overwrite existing definitions such as <code>title(s)</code> 
     and <code>maximum</code> etc.. For this there exists two limitations: 
     <span class="rfc2119-assertion" id="tm-overwrite-interaction">
         A <a>Thing Model</a> SHOULD NOT overwrite the JSON names defined within the  
@@ -5440,15 +5440,15 @@ instance.
             following steps:
          <ul>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-imports">Copy all definitions from the input <a>Thing Model</a> to the resulting <a>Partial TD</a> instance. If used, the extension and imports
-            feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href=#thing-model-extension-import></a></span>.</li>
+            feature MUST be resolved and represented in the <a>Partial TD</a> instance according to <a href="#thing-model-extension-import"></a></span>.</li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-extends"> If used, <code>links</code> element entry with <code>"rel":"tm:extends"</code> MUST be removed from the current <a>Partial TD</a></li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-type">The <code>tm:ThingModel</code> value of the top-level <code>@type</code> MUST to be replaced by the value <code>Thing</code> in the <a>Partial TD</a> instance.</li>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-required">If the <code>tm:required</code> feature is used based on Section <a href=#thing-model-td-required></a>, the required interactions MUST definitely be taken over in the <a>Partial TD</a> instance.</li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-required">If the <code>tm:required</code> feature is used based on Section <a href="#thing-model-td-required"></a>, the required interactions MUST definitely be taken over in the <a>Partial TD</a> instance.</li>
             <li class="rfc2119-assertion" id="thing-model-td-generation-processor-placeholder">If used, all placeholder (see Section <a href="#thing-model-td-placeholder"></a>) in the <a>Thing Model</a> MUST be replaced with a valid corresponding value in the <a>Partial TD</a>.</li>
         </ul>
         Finally, a TM-to-TD generator will take the resulting <a>Partial TD</a> and transform it into a <a>Thing Description</a> with this last step
         <ul>
-            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-forms">Missing communication and/or security metadata details MUST be complemented in the <a>Thing Description</a> instance based on Section <a href=#security-serialization-json></a> and/or <a href=#form-serialization-json></a>.</li>
+            <li class="rfc2119-assertion" id="thing-model-td-generation-processor-forms">Missing communication and/or security metadata details MUST be complemented in the <a>Thing Description</a> instance based on Section <a href="#security-serialization-json"></a> and/or <a href="#form-serialization-json"></a>.</li>
         </ul>
     </p>
   


### PR DESCRIPTION
by changing
`<a href=#link></a>`
to
`<a href="#link"></a>`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1336.html" title="Last updated on Jan 12, 2022, 4:06 PM UTC (3eeeeca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1336/51a6d27...danielpeintner:3eeeeca.html" title="Last updated on Jan 12, 2022, 4:06 PM UTC (3eeeeca)">Diff</a>