### PR TITLE
fix: minor singular vs plural issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -5789,7 +5789,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
         <p>
             When <a>Thing Models</a> are updated and have a new version, it should be aware that this may affect 
-            other <a>Thing Models</a> that uses the extension and import features (see Section <a href="#thing-model-extension-import"></a>). 
+            other <a>Thing Models</a> that use the extension and import features (see Section <a href="#thing-model-extension-import"></a>). 
             In some cases it is useful to reflect a new version also in the file name and/or in a corresponding URL to identify the version.
           </p>
 

--- a/index.template.html
+++ b/index.template.html
@@ -4623,7 +4623,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
         <p>
             When <a>Thing Models</a> are updated and have a new version, it should be aware that this may affect 
-            other <a>Thing Models</a> that uses the extension and import features (see Section <a href="#thing-model-extension-import"></a>). 
+            other <a>Thing Models</a> that use the extension and import features (see Section <a href="#thing-model-extension-import"></a>). 
             In some cases it is useful to reflect a new version also in the file name and/or in a corresponding URL to identify the version.
           </p>
 


### PR DESCRIPTION
Note: the beginning of the text reads not right but this is already fixed by https://github.com/w3c/wot-thing-description/pull/1335


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1337.html" title="Last updated on Jan 12, 2022, 4:08 PM UTC (acb22fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1337/21ce84a...danielpeintner:acb22fa.html" title="Last updated on Jan 12, 2022, 4:08 PM UTC (acb22fa)">Diff</a>