### PR TITLE
update assertion td-context-ns-thing-mandatory

### DIFF
--- a/index.html
+++ b/index.html
@@ -1211,7 +1211,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           "td-context-ns-thing-optional">When <code>@context</code>
           is an <a href="#dfn-array" class="internalDFN"
           data-link-type="dfn">Array</a>, the anyURI
-          <code>https://www.w3.org/2019/wot/td/v1</code> <em class=
+          <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class=
           "rfc2119" title="MAY">MAY</em> be followed by elements of
           type <code>anyURI</code> or type <a href="#dfn-map"
           class="internalDFN" data-link-type="dfn">Map</a> in any

--- a/index.html
+++ b/index.html
@@ -1201,15 +1201,17 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           "td-context-ns-thing-mandatory">The <code>@context</code>
           name-value pair <em class="rfc2119" title=
           "MUST">MUST</em> contain the anyURI
-          <code>https://www.w3.org/2022/wot/td/v1.1</code> either
-          directly when of type <code>anyURI</code> or as first
-          element when of type <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a>.</span>
+          <code>https://www.w3.org/2022/wot/td/v1.1</code>
+          in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly introduced terms. When there are possibly TD 1.0 consumers the anyURI
+          <code>https://www.w3.org/2019/wot/td/v1</code>
+          <em class="rfc2119" title=
+          "MUST">MUST</em> be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class="rfc2119" title=
+          "MUST">MUST</em> be the second entry.</span>
           <span class="rfc2119-assertion" id=
           "td-context-ns-thing-optional">When <code>@context</code>
           is an <a href="#dfn-array" class="internalDFN"
           data-link-type="dfn">Array</a>, the anyURI
-          <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class=
+          <code>https://www.w3.org/2019/wot/td/v1</code> <em class=
           "rfc2119" title="MAY">MAY</em> be followed by elements of
           type <code>anyURI</code> or type <a href="#dfn-map"
           class="internalDFN" data-link-type="dfn">Map</a> in any
@@ -3528,7 +3530,6 @@ In summary, this requires the following:
 </section>
 <section id="security-apikey">
     <h3>API key usage</h3>
-
 
 <p>A Thing can require an onboarding process that results in the Consumer requiring an API key
     to interact with the Thing. This API key can be included in the request to the Thing in different ways 

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -181,10 +181,12 @@
           "td-context-ns-thing-mandatory">The <code>@context</code>
           name-value pair <em class="rfc2119" title=
           "MUST">MUST</em> contain the anyURI
-          <code>https://www.w3.org/2019/wot/td/v1</code> either
-          directly when of type <code>anyURI</code> or as first
-          element when of type <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a>.</span>
+          <code>https://www.w3.org/2022/wot/td/v1.1</code>
+          in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly introduced terms. When there are possibly TD 1.0 consumers the anyURI
+          <code>https://www.w3.org/2019/wot/td/v1</code>
+          <em class="rfc2119" title=
+          "MUST">MUST</em> be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class="rfc2119" title=
+          "MUST">MUST</em> be the second entry.</span>
           <span class="rfc2119-assertion" id=
           "td-context-ns-thing-optional">When <code>@context</code>
           is an <a href="#dfn-array" class="internalDFN"

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -191,7 +191,7 @@
           "td-context-ns-thing-optional">When <code>@context</code>
           is an <a href="#dfn-array" class="internalDFN"
           data-link-type="dfn">Array</a>, the anyURI
-          <code>https://www.w3.org/2019/wot/td/v1</code> <em class=
+          <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class=
           "rfc2119" title="MAY">MAY</em> be followed by elements of
           type <code>anyURI</code> or type <a href="#dfn-map"
           class="internalDFN" data-link-type="dfn">Map</a> in any


### PR DESCRIPTION
with the option that can also carry the TD 1.0 namespace

also see https://github.com/w3c/wot-thing-description/issues/1324


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1339.html" title="Last updated on Jan 12, 2022, 4:32 PM UTC (0efbfd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1339/7d14b4c...0efbfd0.html" title="Last updated on Jan 12, 2022, 4:32 PM UTC (0efbfd0)">Diff</a>