### PR TITLE
Cleanup Security Considerations

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,11 @@
                 }
               ]
             , localBiblio: {
+                "OWASP-Top-10": {
+                  title: "OWASP Top Ten"
+                , href: "https://owasp.org/www-project-top-ten"
+                , publisher: "OWASP"
+                },
                 "JSON-SCHEMA": {
                   title:    "JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
                 , href:     "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01"
@@ -5573,6 +5578,11 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
   A detailed discussion of security (and privacy) considerations for the Web of Things,
   including a threat model that can be adapted to various circumstances, is
   presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
+  Many WoT Things are similar to and use the same technologies as web services.
+  In addition to the specific security considerations below,
+  the security risks and mitigations discussed in
+  guides such as the OWASP Top 10 [[OWASP-Top-10]] for web services should be
+  evaluated and if applicable, addressed.
   This section discusses only security risks
   and possible mitigations directly relevant to the WoT Thing Description.
   </p>
@@ -5582,11 +5592,11 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
   security status of the network interface is to be expected.
   </p>
   <p>The use of a WoT Thing Description introduces  
-  the privacy risks given in the following sections.
+  the security risks given in the following sections.
   After each risk, we suggest some possible mitigations.
   </p>
    <section id="sec-security-consideration-TD-tampering">
-   <h5>TD Interception and Tampering Risk</h5>
+   <h5>TD Interception and Tampering</h5>
       <p>Intercepting and tampering with TDs can be used to launch man-in-the-middle attacks,
       for example by rewriting URLs in TDs to redirect accesses to a malicious 
       intermediary that can capture or manipulate data.
@@ -5600,7 +5610,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       </dd></dl>
    </section>
    <section id="sec-security-consideration-context-tampering">
-   <h5>Context Interception and Tampering Risk</h5>
+   <h5>Context Interception and Tampering</h5>
       <p>Intercepting and tampering with context files can be used to facilitate attacks
       by modifying the interpretation of vocabulary. 
       </p>
@@ -5616,6 +5626,33 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 	      even when only an HTTP URL is given.
       </dd></dl>
    </section>
+   <section id="security-consideration-access-duration">
+      <h2>Limited Duration Accesses</h2>
+      <p>
+      In peer-to-peer scenarios,
+      it may be desired by an "owner" to limit the scope and duration of
+      access to a Thing by a "guest."
+      For example, if a guest is visiting the owner's house, the owner may
+      want to provide the guest with access to the garage door opener and
+      car charger so the guest can use them.
+      The scope however may be limited so that the guest cannot access
+      certain functions of these Things (for example, to change how long
+      the garage door can remain open, or to change the charging rate).
+      In addition, the access should expire after the guest is expected to have left,
+      e.g. after one week.
+      </p>
+      <dl>
+	<dt>Mitigations:</dt>
+	<dd>
+	The owner should use security mechanisms such as OAuth2.
+	A token/auth provider (which could also be managed by the owner if
+	appropriate or desired for privacy) can then 
+	provide limited duration tokens and use scopes to limit access.
+	Scopes can limit access to specific interactions but
+	are not sufficient to limit duration.
+	</dd>
+     </dl>
+</section>
 </section>
 <section id="sec-privacy-consideration" class="informative">
   <h4>Privacy Considerations</h4>

--- a/index.template.html
+++ b/index.template.html
@@ -51,6 +51,11 @@
                 }
               ]
             , localBiblio: {
+                "OWASP-Top-10": {
+                  title: "OWASP Top Ten"
+                , href: "https://owasp.org/www-project-top-ten"
+                , publisher: "OWASP"
+                },
                 "JSON-SCHEMA": {
                   title:    "JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
                 , href:     "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01"
@@ -4396,6 +4401,11 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
   A detailed discussion of security (and privacy) considerations for the Web of Things,
   including a threat model that can be adapted to various circumstances, is
   presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
+  Many WoT Things are similar to and use the same technologies as web services.
+  In addition to the specific security considerations below,
+  the security risks and mitigations discussed in
+  guides such as the OWASP Top 10 [[OWASP-Top-10]] for web services should be
+  evaluated and if applicable, addressed.
   This section discusses only security risks
   and possible mitigations directly relevant to the WoT Thing Description.
   </p>
@@ -4405,11 +4415,11 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
   security status of the network interface is to be expected.
   </p>
   <p>The use of a WoT Thing Description introduces  
-  the privacy risks given in the following sections.
+  the security risks given in the following sections.
   After each risk, we suggest some possible mitigations.
   </p>
    <section id="sec-security-consideration-TD-tampering">
-   <h5>TD Interception and Tampering Risk</h5>
+   <h5>TD Interception and Tampering</h5>
       <p>Intercepting and tampering with TDs can be used to launch man-in-the-middle attacks,
       for example by rewriting URLs in TDs to redirect accesses to a malicious 
       intermediary that can capture or manipulate data.
@@ -4423,7 +4433,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
       </dd></dl>
    </section>
    <section id="sec-security-consideration-context-tampering">
-   <h5>Context Interception and Tampering Risk</h5>
+   <h5>Context Interception and Tampering</h5>
       <p>Intercepting and tampering with context files can be used to facilitate attacks
       by modifying the interpretation of vocabulary. 
       </p>
@@ -4439,6 +4449,33 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 	      even when only an HTTP URL is given.
       </dd></dl>
    </section>
+   <section id="security-consideration-access-duration">
+      <h2>Limited Duration Accesses</h2>
+      <p>
+      In peer-to-peer scenarios,
+      it may be desired by an "owner" to limit the scope and duration of
+      access to a Thing by a "guest."
+      For example, if a guest is visiting the owner's house, the owner may
+      want to provide the guest with access to the garage door opener and
+      car charger so the guest can use them.
+      The scope however may be limited so that the guest cannot access
+      certain functions of these Things (for example, to change how long
+      the garage door can remain open, or to change the charging rate).
+      In addition, the access should expire after the guest is expected to have left,
+      e.g. after one week.
+      </p>
+      <dl>
+	<dt>Mitigations:</dt>
+	<dd>
+	The owner should use security mechanisms such as OAuth2.
+	A token/auth provider (which could also be managed by the owner if
+	appropriate or desired for privacy) can then 
+	provide limited duration tokens and use scopes to limit access.
+	Scopes can limit access to specific interactions but
+	are not sufficient to limit duration.
+	</dd>
+     </dl>
+</section>
 </section>
 <section id="sec-privacy-consideration" class="informative">
   <h4>Privacy Considerations</h4>


### PR DESCRIPTION
WIP: will also use this PR to deal with IANA/Security Considerations overlap problem, making security considerations normative to be consistent.

Changes:
- Add OWASP Top 10 reference and citation
- Remove "Risk" from section headings (was used inconsistently)
- Add "Limited Duration Access" (moved from Discovery)