### PR TITLE
add link to tm schema and ednote

### DIFF
--- a/index.html
+++ b/index.html
@@ -5821,7 +5821,11 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         <a>Thing Model</a> can be serialized in the same JSON-based format as a Thing Description which also allows JSON-LD processing. 
         Note that a <a>Thing Model</a> cannot be validated in the same way as <a>Thing Description</a> instances due to some missing 
         mandatory terms.
+        You can use <a href="https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/tm-json-schema-validation.json">the JSON Schema in the GitHub repository</a> to validate TM instances that are serialized as JSON.
     </p>
+    <p class="note">
+        The link for the TM needs to be updated to a permanent one before publication.
+      </p>
   </section>
     <section id="thing-model-declaration" class="normative">
         <h2>Thing Model Declaration</h2>

--- a/index.template.html
+++ b/index.template.html
@@ -4644,7 +4644,11 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         <a>Thing Model</a> can be serialized in the same JSON-based format as a Thing Description which also allows JSON-LD processing. 
         Note that a <a>Thing Model</a> cannot be validated in the same way as <a>Thing Description</a> instances due to some missing 
         mandatory terms.
+        You can use <a href="https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/tm-json-schema-validation.json">the JSON Schema in the GitHub repository</a> to validate TM instances that are serialized as JSON.
     </p>
+    <p class="note">
+        The link for the TM needs to be updated to a permanent one before publication.
+      </p>
   </section>
     <section id="thing-model-declaration" class="normative">
         <h2>Thing Model Declaration</h2>


### PR DESCRIPTION
fixes #1409


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1430.html" title="Last updated on Mar 14, 2022, 10:13 AM UTC (43de534)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1430/bafa33e...43de534.html" title="Last updated on Mar 14, 2022, 10:13 AM UTC (43de534)">Diff</a>