### PR TITLE
add new context url to tm schema

### DIFF
--- a/validation/test.js
+++ b/validation/test.js
@@ -133,7 +133,7 @@ const validTMs = [
     },
     {
         "$comment":"example 56 of the spec. Valid Model 10",
-        "@context": ["http://www.w3.org/ns/td"], 
+        "@context": ["https://www.w3.org/2019/wot/td/v1"], 
         "@type" : "tm:ThingModel",
         "title": "Thermostate No. {{THERMOSTATE_NUMBER}}",
         "base": "mqtt://{{MQTT_BROKER_ADDRESS}}",
@@ -149,7 +149,7 @@ const validTMs = [
     },
     {
         "$comment":"example 57 of the spec",
-        "@context": ["http://www.w3.org/ns/td"], 
+        "@context": ["https://www.w3.org/2022/wot/td/v1.1"], 
         "@type" : "tm:ThingModel",
         "title": "Valid Model 11",
         "description": "Lamp Thing Description Model",
@@ -178,7 +178,7 @@ const validTMs = [
     },
     {
         "$comment":"example 59 of the spec",
-        "@context": ["http://www.w3.org/ns/td"], 
+        "@context": ["https://www.w3.org/2022/wot/td/v1.1"], 
         "@type" : "tm:ThingModel",
         "links" : [{
             "rel": "tm:extends",

--- a/validation/tm-json-schema-validation.json
+++ b/validation/tm-json-schema-validation.json
@@ -64,7 +64,8 @@
       "type": "string",
       "enum": [
         "https://www.w3.org/2019/wot/td/v1",
-        "http://www.w3.org/ns/td"
+        "http://www.w3.org/ns/td",
+        "https://www.w3.org/2022/wot/td/v1.1"
       ]
     },
     "thing-context": {

--- a/validation/tmSchemaGenerator.js
+++ b/validation/tmSchemaGenerator.js
@@ -69,7 +69,8 @@ tmSchema.definitions["thing-context-w3c-uri"] = {
     "type": "string",
     "enum": [
       "https://www.w3.org/2019/wot/td/v1",
-      "http://www.w3.org/ns/td"
+      "http://www.w3.org/ns/td",
+      "https://www.w3.org/2022/wot/td/v1.1"
     ]
   };
 


### PR DESCRIPTION
Our new context URL `"https://www.w3.org/2022/wot/td/v1.1"` was not allowed in TMs, fixing this.