### PR TITLE
replaces 'well-formed language tag' with 'valid language tag' (new)

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,7 +563,7 @@ a[href].internalDFN {
         <a href="#thing-description-full-serialization">Example 2</a> extends the TD sample from
         Example 1 by introducing a second definition in the <code>@context</code> to declare the
         prefix <code>saref</code> as referring to <a href="https://w3id.org/saref">SAREF</a>, the
-        Smart Appliance Reference Ontology [[SMARTM2M]]. This IoT ontology includes terms interpreted
+        Smart Appliance Reference Ontology [[SMARTM2M]]. This IoT ontology includes terms interpreted
         as semantic labels that can be set as values of the
         <code>@type</code> field, giving the semantics of <a>Things</a> and their
         <a>Interaction Affordances</a>. In the example below, the <a>Thing</a> is labelled with
@@ -742,7 +742,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         Set of <a>Class</a> definitions constructed from pre-defined <a>Vocabularies</a>
         on which constraints apply, thus defining the semantics of these <a>Vocabularies</a>.
         Class definitions are typically expressed in terms of a <a>Signature</a> (a set of
-        <a>Vocabulary Terms</a>) and functions over that <a>Signature</a>. The <a>TD
+        <a>Vocabulary Terms</a>) and functions over that <a>Signature</a>. The <a>TD
         Information Model</a> also includes <a>Default Values</a>, defined as a global
         function over <a>Classes</a>.
     </dd>
@@ -750,20 +750,20 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
     <dfn id="dfn-td-processor">TD Processor</dfn>
     </dt>
     <dd>
-        A system that can serialize some internal representation of a <a>Thing Description</a>
+        A system that can serialize some internal representation of a <a>Thing Description</a>
         in a given format and/or deserialize it from that format. A <a>TD Processor</a> must detect
         semantically inconsistent <a>Thing Descriptions</a>, that is, <a>Thing Descriptions</a>
         that cannot satisfy constraints on the <a>Instance Relation</a> of the <code>Thing</code>
-        class. For that purpose, a <a>TD Processor</a> may compute forms of <a>Thing
+        class. For that purpose, a <a>TD Processor</a> may compute forms of <a>Thing
         Descriptions</a> in which all possible <a>Default Values</a> are assigned. A <a>TD Processor</a>
         is typically a sub-system of a <a>WoT Runtime</a>.
         Implementations of a TD Processor may be a TD producer only (able to serialize to TD Documents)
         or a TD consumer only (able to deserialize from TD Documents).
     </dd>
     <dt>
-        <dfn id="dfn-td-serialization">TD Serialization</dfn>
+        <dfn id="dfn-td-serialization">TD Serialization</dfn>
         or
-        <dfn id="dfn-td-document">TD Document</dfn>
+        <dfn id="dfn-td-document">TD Document</dfn>
     </dt>
     <dd>
         Textual or binary representation of <a>Thing Descriptions</a> that can be stored and
@@ -795,7 +795,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       <a href="https://www.w3.org/2022/wot/td/v1.1">JSON-LD context file</a> [[?json-ld11]],
       allowing the compact strings in <a>TD Documents</a> to be expanded to full IRI-based
       <a>Vocabulary Terms</a>. However, this processing is only required when transforming
-      JSON-based <a>TD Documents</a> to RDF, an optional feature of <a>TD Processor</a>
+      JSON-based <a>TD Documents</a> to RDF, an optional feature of <a>TD Processor</a>
       implementations.
   </p>
 
@@ -805,7 +805,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         In the present specification, <a>Vocabulary Terms</a> are always presented in their compact form.
         Their expanded form can be accessed under the namespace IRI of the <a>Vocabulary</a> they
         belong to. These namespaces follow the structure of <a href="#class-definitions"></a>.
-        Each <a>Vocabulary</a> used in the <a>TD Information Model</a> has its own namespace IRI,
+        Each <a>Vocabulary</a> used in the <a>TD Information Model</a> has its own namespace IRI,
         as follows:
     </p>
   
@@ -943,28 +943,28 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       </p>
 
     <figure id="td-core-model">
-      <img src="visualization/td.svg" alt="UML diagram of the TD information model for the TD core vocabulary"/>
+      <img src="visualization/td.svg" alt="UML diagram of the TD information model for the TD core vocabulary"/>
       <figcaption>TD core vocabulary (<a href="visualization/td.svg">SVG file</a>)</figcaption>
     </figure>
     
     <hr>
 
     <figure id="td-data-schema-model">
-      <img src="visualization/jsonschema.svg" alt="UML diagram of the TD information model for the Data schema vocabulary"/>
+      <img src="visualization/jsonschema.svg" alt="UML diagram of the TD information model for the Data schema vocabulary"/>
       <figcaption>Data schema vocabulary (<a href="visualization/jsonschema.svg">SVG file</a>)</figcaption>
     </figure>
     
     <hr>
     
     <figure id="td-security-model">
-      <img src="visualization/wotsec.svg" alt="UML diagram of the TD information model for the WoT security vocabulary"/>
+      <img src="visualization/wotsec.svg" alt="UML diagram of the TD information model for the WoT security vocabulary"/>
       <figcaption>WoT security vocabulary (<a href="visualization/wotsec.svg">SVG file</a>)</figcaption>
     </figure>
     
     <hr>
     
     <figure id="hypermedia-model">
-      <img src="visualization/hctl.svg" alt="UML diagram of the TD information model for the hypermedia controls vocabulary"/>
+      <img src="visualization/hctl.svg" alt="UML diagram of the TD information model for the hypermedia controls vocabulary"/>
       <figcaption>Hypermedia controls vocabulary (<a href="visualization/hctl.svg">SVG file</a>)</figcaption>
     </figure>
 
@@ -1089,7 +1089,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
         <p>
             By convention, <a>Simple Types</a> are denoted by names starting with lowercase.
-            The <a>TD Information Model</a> references the following <a>Simple Types</a> 
+            The <a>TD Information Model</a> references the following <a>Simple Types</a> 
             defined in XML Schema [[XMLSCHEMA11-2-20120405]]:
             <code>string</code>,
             <code>anyURI</code>,
@@ -2903,7 +2903,7 @@ In summary, this requires the following:
   </p>
 
   <p><span class="rfc2119-assertion" id="td-context">
-  The root element of a <a>TD Serialization</a> MUST be a JSON object that
+  The root element of a <a>TD Serialization</a> MUST be a JSON object that
   includes a member with the name <code>@context</code> and a value of type
   string or array that equals or respectively contains <code>https://www.w3.org/2022/wot/td/v1.1</code>.
   </span></p>
@@ -2974,7 +2974,7 @@ In summary, this requires the following:
   in an instance of the <a>Class</a> <code>Thing</code>
   MUST be serialized as JSON arrays containing JSON objects
   as defined in <a href="#link-serialization-json"></a>
-  and <a href="#form-serialization-json"></a>, respectively.
+  and <a href="#form-serialization-json"></a>, respectively.
   </span></p>
 
   <p>
@@ -2982,7 +2982,7 @@ In summary, this requires the following:
   The value assigned to
   <code>security</code>
   in an instance of <a>Class</a> <code>Thing</code>
-  MUST be serialized as JSON string or as JSON array whose elements are JSON strings.
+  MUST be serialized as JSON string or as JSON array whose elements are JSON strings.
   </span>
   </p>
 
@@ -3063,8 +3063,8 @@ In summary, this requires the following:
   in multiple languages within a single TD document.
   <span class="rfc2119-assertion" id="td-multi-languages">
     All name-value pairs of a <code>MultiLanguage</code> <a>Map</a>
-    MUST be serialized as members of a JSON object,
-    where the name is a well-formed language tag as defined by [[!BCP47]]
+    MUST be serialized as members of a JSON object,
+    where the name is a valid language tag as defined by [[!BCP47]] (also see <a href="https://w3c.github.io/i18n-glossary/#def_valid">W3C I18N Glossary</a>)
     and the value is a human-readable string in the language indicated by the tag.
   </span>
   See <a href="#multilanguage"></a> for details.
@@ -3260,8 +3260,8 @@ In summary, this requires the following:
     <code>SecurityScheme</code>.
     <span class="rfc2119-assertion" id="td-security">
     All name-value pairs of a <a>Map</a> of <code>SecurityScheme</code> instances
-    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
-    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
     instance of <code>SecurityScheme</code>, MUST be serialized as a JSON object.
   </span></p>
 
@@ -3847,8 +3847,8 @@ a data schema will effectively be <em>created</em> for the actions <code>on</cod
   is a <a>Map</a> of instances of <code>PropertyAffordance</code>.
   <span class="rfc2119-assertion" id="td-properties">
     All name-value pairs of a <a>Map</a> of <code>PropertyAffordance</code> instances
-    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
-    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
     instance of <code>PropertyAffordance</code>, MUST be serialized as a JSON object.
   </span></p>
 
@@ -3920,8 +3920,8 @@ a data schema will effectively be <em>created</em> for the actions <code>on</cod
     is a <a>Map</a> of instances of <code>ActionAffordance</code>.
     <span class="rfc2119-assertion" id="td-actions">
     All name-value pairs of a <a>Map</a> of <code>ActionAffordance</code> instances
-    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
-    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
     instance of <code>ActionAffordance</code>, MUST be serialized as a JSON object.
   </span></p>
 
@@ -3997,8 +3997,8 @@ a data schema will effectively be <em>created</em> for the actions <code>on</cod
     is a map of instances of <code>EventAffordance</code>.
     <span class="rfc2119-assertion" id="td-events">
     All name-value pairs of a <a>Map</a> of <code>EventAffordance</code> instances
-    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
-    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
+    MUST be serialized as members of the JSON object that results from serializing the <a>Map</a>;
+    the name of a pair MUST be serialized as a JSON string and the value of the pair, an
     instance of <code>EventAffordance</code>, MUST be serialized as a JSON object.
   </span></p>
 
@@ -4700,7 +4700,12 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   In practice, these assertions can be validated using a JSON Schema 
   in combination with a few spot checks, for example to check that 
   security schema names have matching definitions.
-  </p><p> 
+  </p>
+  <p> 
+    In the case <code>titles</code> and/or <code>descriptions</code> are used in the Thing Description,
+    the consumer only needs to check if the language tags are well-formed (also see <a href="https://w3c.github.io/i18n-glossary/#def_well_formed">W3C I18N Glossary</a>).   
+    </p>
+  <p> 
   This level of validation includes all assertions implied by 
   normative tables in this document as well as all assertions marked
   with the "Minimal" tag.
@@ -4903,7 +4908,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
     "@type": "saref:LightSwitch",
     "saref:hasState": {
         "@id": "urn:dev:ops:32473-WoTLamp-1234/state",
-        "@type": "saref:OnOffState"
+        "@type": "saref:OnOffState"
     },
     ...
     "properties": {

--- a/index.html
+++ b/index.html
@@ -4702,10 +4702,6 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   security schema names have matching definitions.
   </p>
   <p> 
-    In the case <code>titles</code> and/or <code>descriptions</code> are used in the Thing Description,
-    the consumer only needs to check if the language tags are well-formed (also see <a href="https://w3c.github.io/i18n-glossary/#def_well_formed">W3C I18N Glossary</a>).   
-    </p>
-  <p> 
   This level of validation includes all assertions implied by 
   normative tables in this document as well as all assertions marked
   with the "Minimal" tag.

--- a/index.template.html
+++ b/index.template.html
@@ -1885,7 +1885,7 @@ In summary, this requires the following:
   <span class="rfc2119-assertion" id="td-multi-languages">
     All name-value pairs of a <code>MultiLanguage</code> <a>Map</a>
     MUST be serialized as members of a JSON object,
-    where the name is a well-formed language tag as defined by [[!BCP47]]
+    where the name is a valid language tag as defined by [[!BCP47]] (also see <a href="https://w3c.github.io/i18n-glossary/#def_valid">W3C I18N Glossary</a>)
     and the value is a human-readable string in the language indicated by the tag.
   </span>
   See <a href="#multilanguage"></a> for details.
@@ -3521,7 +3521,12 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   In practice, these assertions can be validated using a JSON Schema 
   in combination with a few spot checks, for example to check that 
   security schema names have matching definitions.
-  </p><p> 
+  </p>
+  <p> 
+    In the case <code>titles</code> and/or <code>descriptions</code> are used in the Thing Description,
+    the consumer only needs to check if the language tags are well-formed (also see <a href="https://w3c.github.io/i18n-glossary/#def_well_formed">W3C I18N Glossary</a>).   
+    </p>
+  <p> 
   This level of validation includes all assertions implied by 
   normative tables in this document as well as all assertions marked
   with the "Minimal" tag.

--- a/index.template.html
+++ b/index.template.html
@@ -3523,10 +3523,6 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   security schema names have matching definitions.
   </p>
   <p> 
-    In the case <code>titles</code> and/or <code>descriptions</code> are used in the Thing Description,
-    the consumer only needs to check if the language tags are well-formed (also see <a href="https://w3c.github.io/i18n-glossary/#def_well_formed">W3C I18N Glossary</a>).   
-    </p>
-  <p> 
   This level of validation includes all assertions implied by 
   normative tables in this document as well as all assertions marked
   with the "Minimal" tag.


### PR DESCRIPTION
solves #1415

there was a prevision PR which was closed https://github.com/w3c/wot-thing-description/pull/1456


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1465.html" title="Last updated on Apr 13, 2022, 3:31 PM UTC (6d0f9e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1465/a2262b1...6d0f9e8.html" title="Last updated on Apr 13, 2022, 3:31 PM UTC (6d0f9e8)">Diff</a>