### PR TITLE
use "@type" instead of rdf:type

### DIFF
--- a/context/td-context-1.1.jsonld
+++ b/context/td-context-1.1.jsonld
@@ -222,8 +222,7 @@
           "@id": "wotsec:oneOf"
         },
         "scheme": {
-          "@id": "rdf:type",
-          "@type": "@vocab"
+          "@id": "@type"
         },
         "description": {
           "@id": "td:description"
@@ -311,8 +310,7 @@
           "@id": "wotsec:oneOf"
         },
         "scheme": {
-          "@id": "rdf:type",
-          "@type": "@vocab"
+          "@id": "@type"
         },
         "description": {
           "@id": "td:description"

--- a/context/wot-security-context.jsonld
+++ b/context/wot-security-context.jsonld
@@ -54,8 +54,7 @@
       "@id": "wotsec:oneOf"
     },
     "scheme": {
-      "@id": "rdf:type",
-      "@type": "@vocab"
+      "@id": "@type"
     },
     "description" : {
       "@id" : "td:description"


### PR DESCRIPTION
This is necessary for JSON-LD framing of the TD.
The security triples are not framed back correctly with "rdf:type" instead of "@type" in the context.
The input data in these examples is a set of security RDF triples which have been transformed into JSON-LD with rdflib (python library for rdf).
The same output is obtained after uploading and retrieving the triples from a SPARQL endpoint.
```
<urn:uuid:55f01138-5c96-4b3d-a5d0-81319a2db677> a td:Thing .
<urn:uuid:55f01138-5c96-4b3d-a5d0-81319a2db677> td:definesSecurityScheme _:b0 .
<urn:uuid:55f01138-5c96-4b3d-a5d0-81319a2db677> td:hasSecurityConfiguration> <https://json-ld.org/playground/nosec_sc> .
_:b0 a wotsec:NoSecurityScheme .
_:b0 td:hasInstanceConfiguration <https://json-ld.org/playground/nosec_sc> .
```

Framing with the original context gives [playground with original context](https://tinyurl.com/34w9529x)
```json
"securityDefinitions": {
    "nosec_sc": {
      "@type": "nosec"
    }
  }
```
Framing with the new context gives [playground with this MR context](https://tinyurl.com/3v2axww4)
```json
"securityDefinitions": {
    "nosec_sc": {
      "scheme": "nosec"
    }
  }
```
