### PR TITLE
feat(context): use "@type" instead of "rdf:type"

### DIFF
--- a/context/json-schema-context.jsonld
+++ b/context/json-schema-context.jsonld
@@ -87,8 +87,7 @@
       "@container": "@set"
     },
     "type": {
-      "@id": "rdf:type",
-      "@type": "@vocab"
+      "@id": "@type"
     },
     "title" : {
       "@id" : "td:title"

--- a/context/td-context-1.1.jsonld
+++ b/context/td-context-1.1.jsonld
@@ -107,8 +107,7 @@
           "@container": "@set"
         },
         "type": {
-          "@id": "rdf:type",
-          "@type": "@vocab"
+          "@id": "@type"
         },
         "title": {
           "@id": "td:title"
@@ -673,8 +672,7 @@
           "@container": "@set"
         },
         "type": {
-          "@id": "rdf:type",
-          "@type": "@vocab"
+          "@id": "@type"
         },
         "title": {
           "@id": "td:title"
@@ -802,8 +800,7 @@
           "@container": "@set"
         },
         "type": {
-          "@id": "rdf:type",
-          "@type": "@vocab"
+          "@id": "@type"
         },
         "title": {
           "@id": "td:title"
@@ -931,8 +928,7 @@
           "@container": "@set"
         },
         "type": {
-          "@id": "rdf:type",
-          "@type": "@vocab"
+          "@id": "@type"
         },
         "title": {
           "@id": "td:title"
@@ -1060,8 +1056,7 @@
           "@container": "@set"
         },
         "type": {
-          "@id": "rdf:type",
-          "@type": "@vocab"
+          "@id": "@type"
         },
         "title": {
           "@id": "td:title"
@@ -1189,8 +1184,7 @@
           "@container": "@set"
         },
         "type": {
-          "@id": "rdf:type",
-          "@type": "@vocab"
+          "@id": "@type"
         },
         "title": {
           "@id": "td:title"
@@ -1318,8 +1312,7 @@
           "@container": "@set"
         },
         "type": {
-          "@id": "rdf:type",
-          "@type": "@vocab"
+          "@id": "@type"
         },
         "title": {
           "@id": "td:title"


### PR DESCRIPTION
Similarly to https://github.com/w3c/wot-thing-description/pull/1466

The input data of these examples was generated by transforming a TD into RDF and the RDF into json-ld with rdflib
(same result when uploading/downloading the RDF triples from a SPARQL endpoint)

`"type"` does not round trip on the TD properties type

[playground with original context](https://tinyurl.com/2n4xe7yc)
```
"properties": {
    "airpressure": {
      "@type": "number",
      }
 }
 ```
[playground with new context](https://tinyurl.com/4xxd6y6p)

```
"properties": {
    "airpressure": {
      "type": "number",
      }
 }
 ```