### PR TITLE
Create Automatic Issue Labeling Action

### DIFF
--- a/.github/workflows/labeling-workflow.yml
+++ b/.github/workflows/labeling-workflow.yml
@@ -1,0 +1,15 @@
+name: Add Label
+
+# based on https://github.com/actions-ecosystem/action-add-labels
+
+on:
+  issues:
+    types: opened
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: needs-triage


### PR DESCRIPTION
This PR triggers a very small job that adds `needs-triage` label to each issue that is opened. We can then use this to filter issues that we did not have time to discuss in a meeting or for an editor to categorize.