### PR TITLE
chore: fix filename bug in assertion sync workflow

### DIFF
--- a/.github/workflows/assertion-sync.yml
+++ b/.github/workflows/assertion-sync.yml
@@ -27,7 +27,7 @@ jobs:
       # This is done so that it can be compared later on
         run: |
           mkdir .temp
-          cp testing/inputs/results/template.csv .temp/template.current.csv
+          cp testing/inputs/results/results-template.csv .temp/template.current.csv
           cat .temp/template.current.csv
       - name: generate template.csv
       # this generates other stuff as well but we are interested in template.csv


### PR DESCRIPTION
I noticed that the assertion sync is currently failing due to an incorrect file name. I think this PR should fix the issue.