### PR TITLE
chore: actually fix filename bug in assertion sync workflow

### DIFF
--- a/.github/workflows/assertion-sync.yml
+++ b/.github/workflows/assertion-sync.yml
@@ -27,13 +27,13 @@ jobs:
       # This is done so that it can be compared later on
         run: |
           mkdir .temp
-          cp testing/inputs/results/results-template.csv .temp/template.current.csv
+          cp testing/inputs/results-template.csv .temp/template.current.csv
           cat .temp/template.current.csv
       - name: generate template.csv
       # this generates other stuff as well but we are interested in template.csv
         run: node assertions.js
       - name: Look for changes
-        continue-on-error: true 
+        continue-on-error: true
         run: |
           cat testing/inputs/results/template.csv
           git diff --no-index testing/inputs/results/template.csv .temp/template.current.csv


### PR DESCRIPTION
Unfortunately, https://github.com/w3c/wot-thing-description/pull/1484 did not get the filename completely right. This PR should now actually fix the problem (I ran a [slightly modified version](https://github.com/JKRhb/wot-thing-description/runs/6293230402?check_suite_focus=true) of the workflow in my fork which also created a [PR](https://github.com/JKRhb/wot-thing-description/pull/2)).