### PR TITLE
Update IR with new Ditto results

### DIFF
--- a/testing/atrisk.csv
+++ b/testing/atrisk.csv
@@ -112,7 +112,7 @@
 "tm-compose-name-collision","HELP, pass undefined"
 "tm-compose-submodel","HELP, pass=1"
 "tm-context-requirement","HELP, pass=1"
-"tm-extend","HELP, pass undefined"
+"tm-extend","HELP, pass=1"
 "tm-placeholder","HELP, pass=1"
 "tm-placeholder-replacement","HELP, pass=1"
 "tm-placeholder-usecase","HELP, pass=1"

--- a/testing/inputs/atrisk.csv
+++ b/testing/inputs/atrisk.csv
@@ -112,7 +112,7 @@
 "tm-compose-name-collision","HELP, pass undefined"
 "tm-compose-submodel","HELP, pass=1"
 "tm-context-requirement","HELP, pass=1"
-"tm-extend","HELP, pass undefined"
+"tm-extend","HELP, pass=1"
 "tm-placeholder","HELP, pass=1"
 "tm-placeholder-replacement","HELP, pass=1"
 "tm-placeholder-usecase","HELP, pass=1"

--- a/testing/inputs/results/Ditto.csv
+++ b/testing/inputs/results/Ditto.csv
@@ -1,5 +1,5 @@
 "ID","Status","Comment","Assertion"
-"tm-extend","fail","data/links/0/rel must be equal to constant, data/links/1/rel must be equal to constant, data/links/2/rel must be equal to constant, data/links/3/rel must be equal to constant, data/links/4/rel must be equal to constant, data/links/5/rel must be equal to constant, data/links/6/rel must be equal to constant, data/links must contain at least 1 valid item(s)",
+"tm-extend","pass","",
 "tm-identification","pass","",
 "tm-placeholder","not-impl","",
 "tm-placeholder-value","pass","",

--- a/testing/report11.html
+++ b/testing/report11.html
@@ -6699,8 +6699,8 @@ Type: boolean.</td>
         that targets a Thing Model that is be extended MUST be used.
     </td>
 	<td class="baseassertion"></td>
-	<td class="result missing">0</td>
-	<td class="result failed">2</td>
+	<td class="result failed">1</td>
+	<td class="result failed">1</td>
 	<td class="result baseassertion">0</td>
 	<td class="result baseassertion">2</td></tr>
 <tr id="tm-identification" class="baseassertion">

--- a/testing/todo.csv
+++ b/testing/todo.csv
@@ -112,7 +112,7 @@
 "tm-compose-name-collision","HELP, pass undefined"
 "tm-compose-submodel","HELP, pass=1"
 "tm-context-requirement","HELP, pass=1"
-"tm-extend","HELP, pass undefined; WHY?"
+"tm-extend","HELP, pass=1"
 "tm-placeholder","HELP, pass=1"
 "tm-placeholder-replacement","HELP, pass=1"
 "tm-placeholder-usecase","HELP, pass=1"


### PR DESCRIPTION
fixes tm:extend so result now shows as "1" rather than "0" after a fix to the assertion tester that changed the results for "Ditto".