### PR TITLE
Add RFC9200 reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,21 @@
                 , publisher: "W3C"
                 }
               }
+              , "RFC9200": {
+                  "href": "https://www.rfc-editor.org/rfc/rfc9200",
+                  "title": "Authentication and Authorization for Constrained Environments (ACE) Using the OAuth 2.0 Framework (ACE-OAuth)",
+                  "authors": [
+                    "L. Seitz",
+                    "G. Selander",
+                    "E. Wahlstroem", 
+                    "S. Erdtman",
+                    "H. Tschofenig"
+                  ],
+                  "status": "publication in process",
+                  "publisher": "IETF",
+                  "id": "rfc9200",
+                  "date": "March 2022"
+              }
             , otherLinks: [
                 {
                   key: "Contributors"
@@ -5850,11 +5865,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 	provide limited duration tokens and use scopes to limit access.
 	Scopes can limit access to specific interactions but
 	are not sufficient to limit duration.
-	See [[?ACE-OAuth]].
-	<p class="ednote" title="RFC9200">
-	Upgrade informative ACE-OAuth citation to normative RFC9200 citation if it 
-	passes.
-	</p>
+	See [[?RFC9200]].
 	</dd>
      </dl>
    </section>

--- a/index.html
+++ b/index.html
@@ -175,21 +175,21 @@
                   ]
                 , publisher: "W3C"
                 }
-              }
-              , "RFC9200": {
-                  "href": "https://www.rfc-editor.org/rfc/rfc9200",
-                  "title": "Authentication and Authorization for Constrained Environments (ACE) Using the OAuth 2.0 Framework (ACE-OAuth)",
-                  "authors": [
-                    "L. Seitz",
-                    "G. Selander",
-                    "E. Wahlstroem", 
-                    "S. Erdtman",
-                    "H. Tschofenig"
-                  ],
-                  "status": "publication in process",
-                  "publisher": "IETF",
-                  "id": "rfc9200",
-                  "date": "March 2022"
+                , "RFC9200": {
+                    "href": "https://www.rfc-editor.org/rfc/rfc9200",
+                    "title": "Authentication and Authorization for Constrained Environments (ACE) Using the OAuth 2.0 Framework (ACE-OAuth)",
+                    "authors": [
+                      "L. Seitz",
+                      "G. Selander",
+                      "E. Wahlstroem", 
+                      "S. Erdtman",
+                      "H. Tschofenig"
+                    ],
+                    "status": "Publication in process",
+                    "publisher": "IETF",
+                    "id": "rfc9200",
+                    "date": "March 2022"
+                }
               }
             , otherLinks: [
                 {
@@ -5252,7 +5252,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   Finally, new security schemes that are not included in <a href="#sec-security-vocabulary-definition"></a>
   can be imported using the <a>TD Context Extension</a> mechanism.
   This example uses a fictional ACE security scheme
-  based on [[?ACE-OAuth]] that is, for this example,
+  based on [[?RFC9200]] that is, for this example,
   defined by the namespace at <code>http://www.example.org/ace-security#</code>.
     <span class="rfc2119-assertion" 
       id="td-security-extension">

--- a/index.template.html
+++ b/index.template.html
@@ -175,21 +175,21 @@
                   ]
                 , publisher: "W3C"
                 }
-              }
-              , "RFC9200": {
-                  "href": "https://www.rfc-editor.org/rfc/rfc9200",
-                  "title": "Authentication and Authorization for Constrained Environments (ACE) Using the OAuth 2.0 Framework (ACE-OAuth)",
-                  "authors": [
-                    "L. Seitz",
-                    "G. Selander",
-                    "E. Wahlstroem", 
-                    "S. Erdtman",
-                    "H. Tschofenig"
-                  ],
-                  "status": "publication in process",
-                  "publisher": "IETF",
-                  "id": "rfc9200",
-                  "date": "March 2022"
+                , "RFC9200": {
+                    "href": "https://www.rfc-editor.org/rfc/rfc9200",
+                    "title": "Authentication and Authorization for Constrained Environments (ACE) Using the OAuth 2.0 Framework (ACE-OAuth)",
+                    "authors": [
+                      "L. Seitz",
+                      "G. Selander",
+                      "E. Wahlstroem", 
+                      "S. Erdtman",
+                      "H. Tschofenig"
+                    ],
+                    "status": "Publication in process",
+                    "publisher": "IETF",
+                    "id": "rfc9200",
+                    "date": "March 2022"
+                }
               }
             , otherLinks: [
                 {
@@ -3989,7 +3989,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
   Finally, new security schemes that are not included in <a href="#sec-security-vocabulary-definition"></a>
   can be imported using the <a>TD Context Extension</a> mechanism.
   This example uses a fictional ACE security scheme
-  based on [[?ACE-OAuth]] that is, for this example,
+  based on [[?RFC9200]] that is, for this example,
   defined by the namespace at <code>http://www.example.org/ace-security#</code>.
     <span class="rfc2119-assertion" 
       id="td-security-extension">

--- a/index.template.html
+++ b/index.template.html
@@ -176,6 +176,21 @@
                 , publisher: "W3C"
                 }
               }
+              , "RFC9200": {
+                  "href": "https://www.rfc-editor.org/rfc/rfc9200",
+                  "title": "Authentication and Authorization for Constrained Environments (ACE) Using the OAuth 2.0 Framework (ACE-OAuth)",
+                  "authors": [
+                    "L. Seitz",
+                    "G. Selander",
+                    "E. Wahlstroem", 
+                    "S. Erdtman",
+                    "H. Tschofenig"
+                  ],
+                  "status": "publication in process",
+                  "publisher": "IETF",
+                  "id": "rfc9200",
+                  "date": "March 2022"
+              }
             , otherLinks: [
                 {
                   key: "Contributors"
@@ -4587,11 +4602,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 	provide limited duration tokens and use scopes to limit access.
 	Scopes can limit access to specific interactions but
 	are not sufficient to limit duration.
-	See [[?ACE-OAuth]].
-	<p class="ednote" title="RFC9200">
-	Upgrade informative ACE-OAuth citation to normative RFC9200 citation if it 
-	passes.
-	</p>
+	See [[?RFC9200]].
 	</dd>
      </dl>
    </section>


### PR DESCRIPTION
This is to replace the ACE-OAuth reference.  Note however that while the ACE OAuth spec has passed review, as of this moment RFC9200 has NOT been published: it is still in the queue.  Please see the status at https://www.rfc-editor.org/info/rfc9200.  I put in the "expected" URL in the reference; right now though it will not work, although if you google for it you can find a draft here: https://ftp.ripe.net/rfc/authors/rfc9200.pdf

As soon as this RFC is both published and in specref the local definition should be removed.  I expect this will happen prior to PR.

Let's leave the issue (#1520) open until this is fully resolved (e.g. we are using specref for this citation).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-thing-description/pull/1544.html" title="Last updated on Jun 16, 2022, 4:51 PM UTC (6c4cf86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1544/1d10392...mmccool:6c4cf86.html" title="Last updated on Jun 16, 2022, 4:51 PM UTC (6c4cf86)">Diff</a>