### PR TITLE
Move Thing Model section before Considerations sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -5745,476 +5745,6 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
 </section> <!-- end of id="behavior"-->
 
-
-<section id="sec-security-consideration">
-  <h4>Security Considerations</h4>
-  <p>
-  In general the security measures taken to protect a WoT 
-  system will depend on the threats and attackers that system
-  may face and the value of the assets that need to be protected.
-  A detailed discussion of security (and privacy) considerations for the Web of Things,
-  including a threat model that can be adapted to various circumstances, is
-  presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
-  Many WoT Things are similar to and use the same technologies as web services.
-  In addition to the specific security considerations below,
-  the security risks and mitigations discussed in
-  guides such as the OWASP Top 10 [[OWASP-Top-10]] for web services should be
-  evaluated, and if applicable, addressed.
-  This section discusses only security risks
-  and possible mitigations directly relevant to the WoT Thing Description.
-  </p>
-  <p>A WoT Thing Description can describe both secure and 
-  insecure network interfaces.  When a Thing Description is 
-  retro-fitted to an existing network interface, no change in the 
-  security status of the network interface is to be expected.
-  </p>
-  <p>The use of a WoT Thing Description introduces  
-  the security risks given in the following sections.
-  After each risk, we suggest some possible mitigations.
-  </p>
-   <section id="sec-security-consideration-TD-tampering">
-   <h5>TD Interception and Tampering</h5>
-      <p>Intercepting and tampering with TDs can be used to launch man-in-the-middle attacks,
-      for example by rewriting URLs in TDs to redirect accesses to a malicious 
-      intermediary that can capture or manipulate data.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="security-mutual-auth-td">
-          Thing Descriptions SHOULD be obtained only through
-          mutually authenticated secure channels.
-	  </span>
-          Mutual authentication
-	  ensures that the <a>Consumer</a> and the TD provider are both sure of the
-          identity of the other party to the communication.
-	  However, mutual authentication also can be used to identify the 
-	  Consumer, which may be undesirable in some cases (privacy risk).
-	  <span class="rfc2119-assertion" id="security-server-auth-td">
-	  In cases where the Consumer is associated
-	  with a person, e.g. browsers, TDs MAY be obtained
-	  through a channel where only the TD provider is authenticated.
-	  </span>
-      </dd></dl>
-   </section>
-   <section id="sec-security-consideration-context-tampering">
-   <h5>Context Interception and Tampering</h5>
-      <p>Intercepting and tampering with context definition
-      files can be used to facilitate attacks
-      by modifying the interpretation of vocabulary. 
-      Context extensions 
-      (see <a href="#sec-context-extensions"></a>)
-      that are loaded from the Web over non-secure connections,
-      such as HTTP, run the risk of being altered by an attacker, and
-      may modify the <a>TD Information Model</a> in ways that could
-      compromise security.
-      </p>
-      <p>
-      As recommended in 
-      <a href="#sec-privacy-consideration-context"></a>, 
-      on constrained implementations 
-      context definition files should be pre-installed and managed
-      using a secure software
-      update process and the context URLs only used to identify
-      known contexts, not to fetch them.
-      This consideration therefore applies only when fetching context definition
-      files dynamically is otherwise unavoidable, for example in a directory
-      service supporting general semantic processing.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	      Ideally context definition files would only be obtained through secure
-	      channels established by mutual authentication
-	      but it is notable (and unfortunate) that many contexts are indicated using
-	      "plain" HTTP URLs.  
-	      However, the HTTP protocol is vulnerable to interception and modification if 
-	      used without first establishing a secure transport channel using TLS. 
-	      <span class="rfc2119-assertion" id="security-context-secure-fetch">
-	      If it is necessary to fetch a context definition file,
-	      an implementation SHOULD first attempt to use HTTP over TLS 
-	      even when only an HTTP URL is given.
-	      </span>
-      </dd></dl>
-   </section>
-   <section id="security-consideration-access-duration">
-      <h5>Limited Duration Accesses</h5>
-      <p>
-      In some scenarios,
-      it may be desirable to limit the scope and duration of
-      access to a set of Things by some users.
-      For example, if A is visiting B's house, B may
-      want to provide A with temporary and limited access to the garage door opener and
-      car charger so A can use them.
-      The scope however may be limited so that A cannot access
-      certain administrative functions of these Things (for example, to change how long
-      the garage door can remain open, or to change the charging rate).
-      In addition, the access should expire after A is expected to have left,
-      e.g. after one week.
-      </p>
-      <dl>
-	<dt>Mitigations:</dt>
-	<dd>
-	<span class="rfc2119-assertion" id="security-oauth-limits">
-	To limit the scope and duration of access to Things, tokens SHOULD
-	be used to manage access.
-	</span>
-	Note that this includes mechanisms such as OAuth2, which provide
-	for token generation flows where verifying the authentication and 
-	authorization of a user is handled by a separate token provider 
-	service.
-	Token provider services (which could be managed directly 
-	by the Thing's administrator if
-	appropriate or desired for privacy) can
-	provide limited duration tokens and use scopes to limit access.
-	Scopes can limit access to specific interactions but
-	are not sufficient to limit duration.
-	See [[?RFC9200]].
-	</dd>
-     </dl>
-   </section>
-   <section id="sec-security-consideration-vulnerability-auditing">
-   <h5>Vulnerability Auditing</h5>
-      <p>An attacker with access to a set of TDs, for example those returned by
-      WoT Discovery, may be able to use this information to identify vulnerable devices
-      and plan attacks on them.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	      Deployers of IoT systems can use the same information to audit their IoT systems
-	      and ensure that vulnerable systems are adequately protected (if necessary
-	      by external means such as transport security and/or segmented networks) or hardened.
-	      It is also possible to not make the TDs for known-vulnerable systems available
-	      via discovery.  This is, however, not a recommended
-	      approach since security by obscurity is a poor defence: an attacker can still
-	      discover the system by other means, even if the TD has limited distribution.
-	      The definition of "vulnerable" however depends on the context 
-	      in which the information is made available, and to whom it is made available to.
-	      Ideally, only those with the rights to access the Things
-	      described by TDs should get access to those TDs.
-	      <span class="rfc2119-assertion" id="sec-vuln-auto">
-	      The <code>auto</code> security scheme MAY be used if vulnerability
-	      scanning is a concern.</span>
-      </dd></dl>
-   </section>
-   <section id="sec-security-consideration-script-injection">
-   <h5>Script Injection</h5>
-   <p>Many strings given in TDs, in particular the values carried in 
-      <code>title</code>/<code>titles</code>
-      and 
-      <code>description</code>/<code>descriptions</code>, 
-      are meant to be human-readable.  
-      An application may take
-      such strings and use them to generate a user interface, 
-      for example, a web dashboard listing a set of
-      available Things with their titles and descriptions. 
-      If such an interface is naively generated using
-      string substitution, for example inserting the values of these strings into
-      marked places in a HTML template to create final HTML, any HTML 
-      markup in the original string will be interpreted in the context
-      of the browser displaying the dashboard.  
-      It is possible for an attacker to embed scripts in HTML in
-      various ways and have these scripts executed upon user interaction or even automatically (e.g. upon
-      page load, or upon an error, which can be done intentionally).  
-      Since the string will be 
-      generated by the TD producer and the dashboard will be generated by a different origin,
-      this is a form of cross-site-scripting (XSS) attack.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	      Strings sourced from TDs should be treated like any other source of external string
-	      when generating HTML: with care. 
-	      <span class="rfc2119-assertion" id="sec-inj-sanitize">
-		      Strings sourced from TDs MUST either be sanitized using a carefully vetted HTML
-	      sanitizer that disables any markup or should be inserted into an HTML template using
-	      DOM node manipulation APIs that will escape any markup.
-	      </span>
-	      It is also possible that strings sourced from TDs could be used to generate documents
-	      in other markup languages, such as MD files or XML.  
-	      Such usages should take equivalent
-	      precautions to ensure that string values are sanitized before insertion in a template.
-	      Unfortunately such sanitization also will disable any HTML markup included for
-	      internationalization purposes, 
-	      for example to set the initial direction of text rendering in 
-	      bidirectional text.  
-	      <span class="rfc2119-assertion" id="sec-inj-no-intl-markup">
-	      HTML markup SHOULD NOT be used for internationalization purposes in TD strings.
-	      </span>
-
-      </dd></dl>
-   </section>
-   <section id="sec-security-consideration-execution">
-      <h5>JSON Parsing</h5>
-      <p>
-      See <a href="https://tools.ietf.org/html/rfc8259#section-12">RFC&nbsp;8259, section 12</a>: JSON should not be parsed as JavaScript using <code>eval()</code>.
-      A WoT Thing Description is intended to be a pure data exchange format for
-      <a>Thing</a> metadata, not for holding executable content.
-      An (invalid) TD may, however, contain JavaScript code that,
-      when executed, could have side effects compromising the security of a system.
-      <dl>
-	<dt>Mitigation:</dt>
-	<dd><span class="rfc2119-assertion" id="security-no-execution">
-        A WoT Thing Description JSON-LD serialization MUST NOT be passed through a
-        code execution mechanism such as JavaScript's <code>eval()</code>
-        function to be parsed.
-	</span></dd>
-     </dl>
-     <p class="ednote" title="Other Injection Risks">
-     There are additional code injection risks discussed in
-     [[WOT-DISCOVERY]]. Other strings in TDs, such as the values given for
-     <code>title</code> and <code>description</code>, should be sanitized before being
-     used in templates for SQL, HTML, or other executable contexts.
-     This risk, however, is specifically about the Javascript injection risk
-     when parsing JSON.
-     </p>
-  </section>
-   <section id="sec-security-consideration-jsonld-expansion">
-      <h5>JSON-LD Expansion</h5>
-      <p>
-      JSON-LD processing usually includes the replacement of short terms with
-      longer IRIs [[RFC3987]].
-      For this reason, WoT Thing Descriptions may expand considerably when processed using
-      a JSON-LD 1.1 processor and, in the worst case, the resulting data
-      might consume all of the recipient's resources or cause an exploitable
-      buffer overflow.
-      <dl>
-	<dt>Mitigation:</dt>
-	<dd>
-          <span class="rfc2119-assertion" id="security-jsonld-expansion">
-          <a>Consumers</a> SHOULD 
-	  set and enforce limits on
-	  memory usage to prevent buffer overflow and resource exhaustion
-	  during JSON-LD processing.
-          </span>
-        </dd>
-     </dl>
-  </section>
-</section>
-<section id="sec-privacy-consideration">
-  <h4>Privacy Considerations</h4>
-  <p>
-  Privacy risks will depend on the association of 
-  Things with identifiable people and both the direct information and 
-  the inferred information available from such an association.
-  A detailed discussion of privacy (and security) considerations for the Web of Things,
-  including a threat model that can be adapted to various circumstances, is
-  presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
-  This section discusses only privacy risks
-  and possible mitigations directly relevant to the WoT Thing Description.
-  </p>
-  <p>The use of a WoT Thing Description introduces  
-  the privacy risks given in the following sections.
-  After each risk, we suggest some possible mitigations.
-  </p>
-  <section id="sec-privacy-consideration-context">
-  <h5>Context Fetching</h5>
-        <p>
-          WoT Thing Descriptions can be evaluated with a 
-	  JSON-LD 1.1 processor [[json-ld11]],
-          which typically follows links to remote contexts (i.e., TD context
-          extensions, see <a href="#sec-context-extensions"></a>)
-          automatically, resulting in the transfer of files
-          without the explicit request of the <a>Consumer</a> for each one. 
-	  If remote
-          contexts are served by third parties, it may allow them to gather
-          usage patterns or similar information leading to disclosure
-	  of private information, or information that can be used to infer
-	  private information.
-          In the case of the WoT, an attacker can also observe the network
-          traffic produced by such fetches and can use the metadata
-          of the fetch, such as the destination IP address,
-          to infer information about the device, 
-	  especially if domain-specific vocabularies are used.  
-	  This is a risk even if the connection
-          is encrypted, and is related to DNS privacy leaks.
-	  See also <a href="#sec-security-consideration-context-tampering"></a>,
-	  which is a related security risk which can also be avoided with the
-	  following mitigations.
-      <dl>
-	<dt>Mitigation:</dt>
-	<dd>
-          Implementations on resource-constrained devices are expected
-          to perform raw JSON processing (as opposed to JSON-LD processing)
-	  and support only a limited set of domain-specific extensions.
-	  The set of supported extensions can be established by a 
-	  WoT Profile [[WOT-PROFILE]], for example.
-	  <span class="rfc2119-assertion" id="security-static-context">
-          Constrained implementations SHOULD use statically managed and vetted
-          versions of their supported context extensions. 
-          </span>
-	  <span class="rfc2119-assertion" id="security-remote-context">
-          Constrained implementations SHOULD NOT follow links to remote contexts.
-	  </span>
-	  In this case the URLs are used only to identify extensions,
-	  not to fetch their definitions.
-	  <span class="rfc2119-assertion" id="security-update-contexts">
-          Supported context extensions on constrained implementations MAY be managed
-          through secure software update mechanisms.
-	  </span>
-        </dd>
-     </dl>
-   </section>
-   <section id="sec-privacy-consideration-id">
-   <h5>Immutable Identifiers</h5>
-      <p>A Thing Description containing an identifier (<code>id</code>) may
-         describe a Thing that is associated with an identifiable
-         person.  Such identifiers pose various risks including tracking.
-         However, if the identifier is also immutable, then the 
-         tracking risk is amplified, since a device
-         may be sold or given to another person and the known ID used to 
-         track that person.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-mutable-identifiers">
-          All identifiers used in a TD SHOULD be mutable,
-          and in particular there should be a mechanism to update the <code>id</code>
-          of a <a>Thing</a> when necessary.
-	  </span>
-          Specifically,
-          the <code>id</code> of a <a>Thing</a> should not be fixed in hardware.
-          This does, however, conflict with the Linked Data ideal that
-          identifiers are fixed URIs.  
-	  In many circumstances it
-          will be acceptable to only allow updates to identifiers if
-          a <a>Thing</a> is reinitialized.  In this case as a software entity the
-          old <a>Thing</a> ceases to exist and a new <a>Thing</a> is created.
-          This can be sufficient to break a tracking chain when, for
-          example, a device is sold to a new owner.
-          Alternatively, if more frequent changes are desired during 
-          the operational phase of a device,
-          a mechanism can be put into place to notify only authorized users
-          of the change in identifier when a change is made.
-          Note however that some classes of devices, e.g., medical devices,
-          may require immutable IDs by law in some jurisdictions.
-          In this case extra attention should be paid to secure 
-          access to files, such as Thing Descriptions, containing such
-          immutable identifiers.  
-	  It may also be desirable to not share
-          the "true" immutable identifier in such a case in the TD whenever possible.
-          </dd></dl>
-      </p>
-   </section>
-   <section id="sec-privacy-consideration-fingerprint">
-   <h5>Fingerprinting</h5>
-      <p>As noted above, the <code>id</code> member in a TD can pose a privacy risk.  
-      However, even if the <code>id</code> is updated as described to mitigate its
-      tracking risk, it may still be possible to associate
-      a TD with a particular physical device, and from there to an identifiable person, 
-      through fingerprinting.
-      </p>
-      <p>Even if a specific device instance cannot be identified through fingerprinting,
-      it may be possible to infer the type of a device from the information in the TD, such
-      as the set of interactions, and use this type to infer private information about an
-      identifiable person, such as a medical condition.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-auth-users-only">
-          Only authorized users SHOULD be provided access
-          to the Thing Description for a <a>Thing</a>.
-	  </span>
-	  <span class="rfc2119-assertion" id="privacy-essential-metadata-only">
-	  Only the amount of
-          information needed for the level of authorization and the use case 
-	  SHOULD be provided in a TD.
-	  </span>
-          If the TD is only distributed to authorized users 
-          through secure and confidential channels, for
-          example through a directory service that requires authentication,
-          then external unauthorized parties will not have access to the TD to fingerprint it.
-          To further mitigate this risk, information not necessary for a particular
-          use case of a TD should be omitted whenever possible.  For example,
-          for an ad-hoc connection to a device where the Consumer does 
-          not store state about the Thing, the <code>id</code> can be omitted.
-          If the Consumer does not need certain interactions for its use case, 
-	  they can be omitted.
-          If the Consumer is not authorized to use certain interactions, 
-	  they can likewise be omitted.
-	  <!-- we don't have any mechanism to support this; a "null" language 
-	   negotiation might be suitable.
-          If the Consumer does not have any capability to display human-readable information
-          such as titles or descriptions, 
-	  they can be omitted or replaced with zero-length strings.
-	  -->
-      </dd></dl>
-   </section>
-   <section id="sec-privacy-consideration-id-metadata">
-   <h5>ID Metadata</h5>
-      <p>The value of the <code>id</code> field of a TD might become available to 
-      entities that do not have access to the full TD.  If the value of the <code>id</code>
-      contains embedded metadata, such as the type of the device or the owner, this 
-      could be used to infer personal information.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-id-metadata">
-	  The value of the <code>id</code> of a TD SHOULD NOT contain metadata
-	  describing the Thing or from the TD itself.
-	  </span>
-	  <span class="rfc2119-assertion" id="privacy-temp-id-metadata">
-          Any temporary ID generated to manage TDs, for example an ID for a database 
-	  or directory service, SHOULD NOT contain metadata 
-	  describing the Thing or from the TD itself.
-	  </span>
-	  Using random UUIDs as recommended in 
-	  <a href="#sec-privacy-consideration-global-id-risk"></a> also mitigates this
-	  risk.
-      </dd></dl>
-   </section>
-   <section id="sec-privacy-consideration-global-id-risk">
-   <h5>Globally Unique Identifiers</h5>
-      <p>Globally unique identifiers pose a privacy risk if a centralized authority is needed to
-      create and distribute them, since then a third party has knowledge of the identifiers.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-          The <code>id</code> field in TDs is intentionally not required to be globally unique.
-          There are several cryptographic mechanisms (e.g. random UUIDs) available to generate suitable IDs in a 
-          distributed fashion that do
-          not require a central registry.  These mechanisms typically have a very low probability
-          of generating duplicate identifiers, and this needs to be taken into account in the system
-          design; for example, by detecting duplicates and regenerating IDs when necessary.
-          The scope of IDs also does not need to be global: it is acceptable to use identifiers
-          that only distinguish Things in a certain context, such as within a home or factory.
-	  <span class="rfc2119-assertion" id="privacy-distributed-ids">
-          TD identifiers SHOULD be generated using a distributed mechanism such as UUIDs
-	  that provides a high probability of uniqueness.
-	  </span>
-	  <span class="rfc2119-assertion" id="privacy-centralized-ids">
-          TD identifiers SHOULD NOT be generated using a centralized authority.
-	  </span>
-      </dd></dl>
-   </section>
-   <section id="sec-privacy-consideration-inferencing">
-   <h5>Inferencing of Personally Identifiable Information</h5>
-      <p>In many locales, in order to protect the privacy of users,
-      there are legal requirements for the handling of
-      personally identifiable information,
-      that is,
-      information that can be associated with a particular person.
-      Such information can of course be generated by IoT devices directly.
-      However,
-      the existence and metadata of IoT devices
-      (the kind of data stored in a Thing Description)
-      can also contain or be used to infer personally identifiable information.
-      This information can be as simple as the fact that a certain person owns a certain
-      type of device,
-      which can lead to additional inferences about that person.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-td-pii">
-          A Thing Description associated with a 
-	  personal device SHOULD be treated as if it contained
-	  personally identifiable information, even if this information is not explicit.
-	  </span>
-          As an example application of this principle,
-          consider how to obtain user consent.  
-          Consent for usage of personally identifiable data
-          generated by a <a>Thing</a> is often obtained when a <a>Thing</a> is paired with system
-          consuming the data,
-          which is frequently also when the Thing Description
-          is registered with a local directory or the system consuming the 
-          Thing Description in order to access the device.
-          In this case, consent for using data from a <a>Thing</a> can be combined with
-          consent for accessing the Thing Description of the <a>Thing</a>.
-          As a second example, if we consider a TD to contain personally
-          identifiable information, then it should not be retained indefinitely
-          or used for purposes other than those for which consent was given.
-      </dd></dl>
-   </section>
-</section>
-
 <section id="thing-model" class="normative">
   <h1>Thing Model</h1>
       
@@ -7302,6 +6832,476 @@ instance.
     </pre>
   </section>
 </section>
+
+<section id="sec-security-consideration">
+  <h4>Security Considerations</h4>
+  <p>
+  In general the security measures taken to protect a WoT 
+  system will depend on the threats and attackers that system
+  may face and the value of the assets that need to be protected.
+  A detailed discussion of security (and privacy) considerations for the Web of Things,
+  including a threat model that can be adapted to various circumstances, is
+  presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
+  Many WoT Things are similar to and use the same technologies as web services.
+  In addition to the specific security considerations below,
+  the security risks and mitigations discussed in
+  guides such as the OWASP Top 10 [[OWASP-Top-10]] for web services should be
+  evaluated, and if applicable, addressed.
+  This section discusses only security risks
+  and possible mitigations directly relevant to the WoT Thing Description.
+  </p>
+  <p>A WoT Thing Description can describe both secure and 
+  insecure network interfaces.  When a Thing Description is 
+  retro-fitted to an existing network interface, no change in the 
+  security status of the network interface is to be expected.
+  </p>
+  <p>The use of a WoT Thing Description introduces  
+  the security risks given in the following sections.
+  After each risk, we suggest some possible mitigations.
+  </p>
+   <section id="sec-security-consideration-TD-tampering">
+   <h5>TD Interception and Tampering</h5>
+      <p>Intercepting and tampering with TDs can be used to launch man-in-the-middle attacks,
+      for example by rewriting URLs in TDs to redirect accesses to a malicious 
+      intermediary that can capture or manipulate data.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	  <span class="rfc2119-assertion" id="security-mutual-auth-td">
+          Thing Descriptions SHOULD be obtained only through
+          mutually authenticated secure channels.
+	  </span>
+          Mutual authentication
+	  ensures that the <a>Consumer</a> and the TD provider are both sure of the
+          identity of the other party to the communication.
+	  However, mutual authentication also can be used to identify the 
+	  Consumer, which may be undesirable in some cases (privacy risk).
+	  <span class="rfc2119-assertion" id="security-server-auth-td">
+	  In cases where the Consumer is associated
+	  with a person, e.g. browsers, TDs MAY be obtained
+	  through a channel where only the TD provider is authenticated.
+	  </span>
+      </dd></dl>
+   </section>
+   <section id="sec-security-consideration-context-tampering">
+   <h5>Context Interception and Tampering</h5>
+      <p>Intercepting and tampering with context definition
+      files can be used to facilitate attacks
+      by modifying the interpretation of vocabulary. 
+      Context extensions 
+      (see <a href="#sec-context-extensions"></a>)
+      that are loaded from the Web over non-secure connections,
+      such as HTTP, run the risk of being altered by an attacker, and
+      may modify the <a>TD Information Model</a> in ways that could
+      compromise security.
+      </p>
+      <p>
+      As recommended in 
+      <a href="#sec-privacy-consideration-context"></a>, 
+      on constrained implementations 
+      context definition files should be pre-installed and managed
+      using a secure software
+      update process and the context URLs only used to identify
+      known contexts, not to fetch them.
+      This consideration therefore applies only when fetching context definition
+      files dynamically is otherwise unavoidable, for example in a directory
+      service supporting general semantic processing.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	      Ideally context definition files would only be obtained through secure
+	      channels established by mutual authentication
+	      but it is notable (and unfortunate) that many contexts are indicated using
+	      "plain" HTTP URLs.  
+	      However, the HTTP protocol is vulnerable to interception and modification if 
+	      used without first establishing a secure transport channel using TLS. 
+	      <span class="rfc2119-assertion" id="security-context-secure-fetch">
+	      If it is necessary to fetch a context definition file,
+	      an implementation SHOULD first attempt to use HTTP over TLS 
+	      even when only an HTTP URL is given.
+	      </span>
+      </dd></dl>
+   </section>
+   <section id="security-consideration-access-duration">
+      <h5>Limited Duration Accesses</h5>
+      <p>
+      In some scenarios,
+      it may be desirable to limit the scope and duration of
+      access to a set of Things by some users.
+      For example, if A is visiting B's house, B may
+      want to provide A with temporary and limited access to the garage door opener and
+      car charger so A can use them.
+      The scope however may be limited so that A cannot access
+      certain administrative functions of these Things (for example, to change how long
+      the garage door can remain open, or to change the charging rate).
+      In addition, the access should expire after A is expected to have left,
+      e.g. after one week.
+      </p>
+      <dl>
+	<dt>Mitigations:</dt>
+	<dd>
+	<span class="rfc2119-assertion" id="security-oauth-limits">
+	To limit the scope and duration of access to Things, tokens SHOULD
+	be used to manage access.
+	</span>
+	Note that this includes mechanisms such as OAuth2, which provide
+	for token generation flows where verifying the authentication and 
+	authorization of a user is handled by a separate token provider 
+	service.
+	Token provider services (which could be managed directly 
+	by the Thing's administrator if
+	appropriate or desired for privacy) can
+	provide limited duration tokens and use scopes to limit access.
+	Scopes can limit access to specific interactions but
+	are not sufficient to limit duration.
+	See [[?RFC9200]].
+	</dd>
+     </dl>
+   </section>
+   <section id="sec-security-consideration-vulnerability-auditing">
+   <h5>Vulnerability Auditing</h5>
+      <p>An attacker with access to a set of TDs, for example those returned by
+      WoT Discovery, may be able to use this information to identify vulnerable devices
+      and plan attacks on them.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	      Deployers of IoT systems can use the same information to audit their IoT systems
+	      and ensure that vulnerable systems are adequately protected (if necessary
+	      by external means such as transport security and/or segmented networks) or hardened.
+	      It is also possible to not make the TDs for known-vulnerable systems available
+	      via discovery.  This is, however, not a recommended
+	      approach since security by obscurity is a poor defence: an attacker can still
+	      discover the system by other means, even if the TD has limited distribution.
+	      The definition of "vulnerable" however depends on the context 
+	      in which the information is made available, and to whom it is made available to.
+	      Ideally, only those with the rights to access the Things
+	      described by TDs should get access to those TDs.
+	      <span class="rfc2119-assertion" id="sec-vuln-auto">
+	      The <code>auto</code> security scheme MAY be used if vulnerability
+	      scanning is a concern.</span>
+      </dd></dl>
+   </section>
+   <section id="sec-security-consideration-script-injection">
+   <h5>Script Injection</h5>
+   <p>Many strings given in TDs, in particular the values carried in 
+      <code>title</code>/<code>titles</code>
+      and 
+      <code>description</code>/<code>descriptions</code>, 
+      are meant to be human-readable.  
+      An application may take
+      such strings and use them to generate a user interface, 
+      for example, a web dashboard listing a set of
+      available Things with their titles and descriptions. 
+      If such an interface is naively generated using
+      string substitution, for example inserting the values of these strings into
+      marked places in a HTML template to create final HTML, any HTML 
+      markup in the original string will be interpreted in the context
+      of the browser displaying the dashboard.  
+      It is possible for an attacker to embed scripts in HTML in
+      various ways and have these scripts executed upon user interaction or even automatically (e.g. upon
+      page load, or upon an error, which can be done intentionally).  
+      Since the string will be 
+      generated by the TD producer and the dashboard will be generated by a different origin,
+      this is a form of cross-site-scripting (XSS) attack.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	      Strings sourced from TDs should be treated like any other source of external string
+	      when generating HTML: with care. 
+	      <span class="rfc2119-assertion" id="sec-inj-sanitize">
+		      Strings sourced from TDs MUST either be sanitized using a carefully vetted HTML
+	      sanitizer that disables any markup or should be inserted into an HTML template using
+	      DOM node manipulation APIs that will escape any markup.
+	      </span>
+	      It is also possible that strings sourced from TDs could be used to generate documents
+	      in other markup languages, such as MD files or XML.  
+	      Such usages should take equivalent
+	      precautions to ensure that string values are sanitized before insertion in a template.
+	      Unfortunately such sanitization also will disable any HTML markup included for
+	      internationalization purposes, 
+	      for example to set the initial direction of text rendering in 
+	      bidirectional text.  
+	      <span class="rfc2119-assertion" id="sec-inj-no-intl-markup">
+	      HTML markup SHOULD NOT be used for internationalization purposes in TD strings.
+	      </span>
+
+      </dd></dl>
+   </section>
+   <section id="sec-security-consideration-execution">
+      <h5>JSON Parsing</h5>
+      <p>
+      See <a href="https://tools.ietf.org/html/rfc8259#section-12">RFC&nbsp;8259, section 12</a>: JSON should not be parsed as JavaScript using <code>eval()</code>.
+      A WoT Thing Description is intended to be a pure data exchange format for
+      <a>Thing</a> metadata, not for holding executable content.
+      An (invalid) TD may, however, contain JavaScript code that,
+      when executed, could have side effects compromising the security of a system.
+      <dl>
+	<dt>Mitigation:</dt>
+	<dd><span class="rfc2119-assertion" id="security-no-execution">
+        A WoT Thing Description JSON-LD serialization MUST NOT be passed through a
+        code execution mechanism such as JavaScript's <code>eval()</code>
+        function to be parsed.
+	</span></dd>
+     </dl>
+     <p class="ednote" title="Other Injection Risks">
+     There are additional code injection risks discussed in
+     [[WOT-DISCOVERY]]. Other strings in TDs, such as the values given for
+     <code>title</code> and <code>description</code>, should be sanitized before being
+     used in templates for SQL, HTML, or other executable contexts.
+     This risk, however, is specifically about the Javascript injection risk
+     when parsing JSON.
+     </p>
+  </section>
+   <section id="sec-security-consideration-jsonld-expansion">
+      <h5>JSON-LD Expansion</h5>
+      <p>
+      JSON-LD processing usually includes the replacement of short terms with
+      longer IRIs [[RFC3987]].
+      For this reason, WoT Thing Descriptions may expand considerably when processed using
+      a JSON-LD 1.1 processor and, in the worst case, the resulting data
+      might consume all of the recipient's resources or cause an exploitable
+      buffer overflow.
+      <dl>
+	<dt>Mitigation:</dt>
+	<dd>
+          <span class="rfc2119-assertion" id="security-jsonld-expansion">
+          <a>Consumers</a> SHOULD 
+	  set and enforce limits on
+	  memory usage to prevent buffer overflow and resource exhaustion
+	  during JSON-LD processing.
+          </span>
+        </dd>
+     </dl>
+  </section>
+</section>
+<section id="sec-privacy-consideration">
+  <h4>Privacy Considerations</h4>
+  <p>
+  Privacy risks will depend on the association of 
+  Things with identifiable people and both the direct information and 
+  the inferred information available from such an association.
+  A detailed discussion of privacy (and security) considerations for the Web of Things,
+  including a threat model that can be adapted to various circumstances, is
+  presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
+  This section discusses only privacy risks
+  and possible mitigations directly relevant to the WoT Thing Description.
+  </p>
+  <p>The use of a WoT Thing Description introduces  
+  the privacy risks given in the following sections.
+  After each risk, we suggest some possible mitigations.
+  </p>
+  <section id="sec-privacy-consideration-context">
+  <h5>Context Fetching</h5>
+        <p>
+          WoT Thing Descriptions can be evaluated with a 
+	  JSON-LD 1.1 processor [[json-ld11]],
+          which typically follows links to remote contexts (i.e., TD context
+          extensions, see <a href="#sec-context-extensions"></a>)
+          automatically, resulting in the transfer of files
+          without the explicit request of the <a>Consumer</a> for each one. 
+	  If remote
+          contexts are served by third parties, it may allow them to gather
+          usage patterns or similar information leading to disclosure
+	  of private information, or information that can be used to infer
+	  private information.
+          In the case of the WoT, an attacker can also observe the network
+          traffic produced by such fetches and can use the metadata
+          of the fetch, such as the destination IP address,
+          to infer information about the device, 
+	  especially if domain-specific vocabularies are used.  
+	  This is a risk even if the connection
+          is encrypted, and is related to DNS privacy leaks.
+	  See also <a href="#sec-security-consideration-context-tampering"></a>,
+	  which is a related security risk which can also be avoided with the
+	  following mitigations.
+      <dl>
+	<dt>Mitigation:</dt>
+	<dd>
+          Implementations on resource-constrained devices are expected
+          to perform raw JSON processing (as opposed to JSON-LD processing)
+	  and support only a limited set of domain-specific extensions.
+	  The set of supported extensions can be established by a 
+	  WoT Profile [[WOT-PROFILE]], for example.
+	  <span class="rfc2119-assertion" id="security-static-context">
+          Constrained implementations SHOULD use statically managed and vetted
+          versions of their supported context extensions. 
+          </span>
+	  <span class="rfc2119-assertion" id="security-remote-context">
+          Constrained implementations SHOULD NOT follow links to remote contexts.
+	  </span>
+	  In this case the URLs are used only to identify extensions,
+	  not to fetch their definitions.
+	  <span class="rfc2119-assertion" id="security-update-contexts">
+          Supported context extensions on constrained implementations MAY be managed
+          through secure software update mechanisms.
+	  </span>
+        </dd>
+     </dl>
+   </section>
+   <section id="sec-privacy-consideration-id">
+   <h5>Immutable Identifiers</h5>
+      <p>A Thing Description containing an identifier (<code>id</code>) may
+         describe a Thing that is associated with an identifiable
+         person.  Such identifiers pose various risks including tracking.
+         However, if the identifier is also immutable, then the 
+         tracking risk is amplified, since a device
+         may be sold or given to another person and the known ID used to 
+         track that person.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	  <span class="rfc2119-assertion" id="privacy-mutable-identifiers">
+          All identifiers used in a TD SHOULD be mutable,
+          and in particular there should be a mechanism to update the <code>id</code>
+          of a <a>Thing</a> when necessary.
+	  </span>
+          Specifically,
+          the <code>id</code> of a <a>Thing</a> should not be fixed in hardware.
+          This does, however, conflict with the Linked Data ideal that
+          identifiers are fixed URIs.  
+	  In many circumstances it
+          will be acceptable to only allow updates to identifiers if
+          a <a>Thing</a> is reinitialized.  In this case as a software entity the
+          old <a>Thing</a> ceases to exist and a new <a>Thing</a> is created.
+          This can be sufficient to break a tracking chain when, for
+          example, a device is sold to a new owner.
+          Alternatively, if more frequent changes are desired during 
+          the operational phase of a device,
+          a mechanism can be put into place to notify only authorized users
+          of the change in identifier when a change is made.
+          Note however that some classes of devices, e.g., medical devices,
+          may require immutable IDs by law in some jurisdictions.
+          In this case extra attention should be paid to secure 
+          access to files, such as Thing Descriptions, containing such
+          immutable identifiers.  
+	  It may also be desirable to not share
+          the "true" immutable identifier in such a case in the TD whenever possible.
+          </dd></dl>
+      </p>
+   </section>
+   <section id="sec-privacy-consideration-fingerprint">
+   <h5>Fingerprinting</h5>
+      <p>As noted above, the <code>id</code> member in a TD can pose a privacy risk.  
+      However, even if the <code>id</code> is updated as described to mitigate its
+      tracking risk, it may still be possible to associate
+      a TD with a particular physical device, and from there to an identifiable person, 
+      through fingerprinting.
+      </p>
+      <p>Even if a specific device instance cannot be identified through fingerprinting,
+      it may be possible to infer the type of a device from the information in the TD, such
+      as the set of interactions, and use this type to infer private information about an
+      identifiable person, such as a medical condition.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	  <span class="rfc2119-assertion" id="privacy-auth-users-only">
+          Only authorized users SHOULD be provided access
+          to the Thing Description for a <a>Thing</a>.
+	  </span>
+	  <span class="rfc2119-assertion" id="privacy-essential-metadata-only">
+	  Only the amount of
+          information needed for the level of authorization and the use case 
+	  SHOULD be provided in a TD.
+	  </span>
+          If the TD is only distributed to authorized users 
+          through secure and confidential channels, for
+          example through a directory service that requires authentication,
+          then external unauthorized parties will not have access to the TD to fingerprint it.
+          To further mitigate this risk, information not necessary for a particular
+          use case of a TD should be omitted whenever possible.  For example,
+          for an ad-hoc connection to a device where the Consumer does 
+          not store state about the Thing, the <code>id</code> can be omitted.
+          If the Consumer does not need certain interactions for its use case, 
+	  they can be omitted.
+          If the Consumer is not authorized to use certain interactions, 
+	  they can likewise be omitted.
+	  <!-- we don't have any mechanism to support this; a "null" language 
+	   negotiation might be suitable.
+          If the Consumer does not have any capability to display human-readable information
+          such as titles or descriptions, 
+	  they can be omitted or replaced with zero-length strings.
+	  -->
+      </dd></dl>
+   </section>
+   <section id="sec-privacy-consideration-id-metadata">
+   <h5>ID Metadata</h5>
+      <p>The value of the <code>id</code> field of a TD might become available to 
+      entities that do not have access to the full TD.  If the value of the <code>id</code>
+      contains embedded metadata, such as the type of the device or the owner, this 
+      could be used to infer personal information.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	  <span class="rfc2119-assertion" id="privacy-id-metadata">
+	  The value of the <code>id</code> of a TD SHOULD NOT contain metadata
+	  describing the Thing or from the TD itself.
+	  </span>
+	  <span class="rfc2119-assertion" id="privacy-temp-id-metadata">
+          Any temporary ID generated to manage TDs, for example an ID for a database 
+	  or directory service, SHOULD NOT contain metadata 
+	  describing the Thing or from the TD itself.
+	  </span>
+	  Using random UUIDs as recommended in 
+	  <a href="#sec-privacy-consideration-global-id-risk"></a> also mitigates this
+	  risk.
+      </dd></dl>
+   </section>
+   <section id="sec-privacy-consideration-global-id-risk">
+   <h5>Globally Unique Identifiers</h5>
+      <p>Globally unique identifiers pose a privacy risk if a centralized authority is needed to
+      create and distribute them, since then a third party has knowledge of the identifiers.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+          The <code>id</code> field in TDs is intentionally not required to be globally unique.
+          There are several cryptographic mechanisms (e.g. random UUIDs) available to generate suitable IDs in a 
+          distributed fashion that do
+          not require a central registry.  These mechanisms typically have a very low probability
+          of generating duplicate identifiers, and this needs to be taken into account in the system
+          design; for example, by detecting duplicates and regenerating IDs when necessary.
+          The scope of IDs also does not need to be global: it is acceptable to use identifiers
+          that only distinguish Things in a certain context, such as within a home or factory.
+	  <span class="rfc2119-assertion" id="privacy-distributed-ids">
+          TD identifiers SHOULD be generated using a distributed mechanism such as UUIDs
+	  that provides a high probability of uniqueness.
+	  </span>
+	  <span class="rfc2119-assertion" id="privacy-centralized-ids">
+          TD identifiers SHOULD NOT be generated using a centralized authority.
+	  </span>
+      </dd></dl>
+   </section>
+   <section id="sec-privacy-consideration-inferencing">
+   <h5>Inferencing of Personally Identifiable Information</h5>
+      <p>In many locales, in order to protect the privacy of users,
+      there are legal requirements for the handling of
+      personally identifiable information,
+      that is,
+      information that can be associated with a particular person.
+      Such information can of course be generated by IoT devices directly.
+      However,
+      the existence and metadata of IoT devices
+      (the kind of data stored in a Thing Description)
+      can also contain or be used to infer personally identifiable information.
+      This information can be as simple as the fact that a certain person owns a certain
+      type of device,
+      which can lead to additional inferences about that person.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	  <span class="rfc2119-assertion" id="privacy-td-pii">
+          A Thing Description associated with a 
+	  personal device SHOULD be treated as if it contained
+	  personally identifiable information, even if this information is not explicit.
+	  </span>
+          As an example application of this principle,
+          consider how to obtain user consent.  
+          Consent for usage of personally identifiable data
+          generated by a <a>Thing</a> is often obtained when a <a>Thing</a> is paired with system
+          consuming the data,
+          which is frequently also when the Thing Description
+          is registered with a local directory or the system consuming the 
+          Thing Description in order to access the device.
+          In this case, consent for using data from a <a>Thing</a> can be combined with
+          consent for accessing the Thing Description of the <a>Thing</a>.
+          As a second example, if we consider a TD to contain personally
+          identifiable information, then it should not be retained indefinitely
+          or used for purposes other than those for which consent was given.
+      </dd></dl>
+   </section>
+</section>
+
 <section id="iana-section" class="normative">
  
   <h1>IANA Considerations</h1>

--- a/index.template.html
+++ b/index.template.html
@@ -4482,476 +4482,6 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
 </section> <!-- end of id="behavior"-->
 
-
-<section id="sec-security-consideration">
-  <h4>Security Considerations</h4>
-  <p>
-  In general the security measures taken to protect a WoT 
-  system will depend on the threats and attackers that system
-  may face and the value of the assets that need to be protected.
-  A detailed discussion of security (and privacy) considerations for the Web of Things,
-  including a threat model that can be adapted to various circumstances, is
-  presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
-  Many WoT Things are similar to and use the same technologies as web services.
-  In addition to the specific security considerations below,
-  the security risks and mitigations discussed in
-  guides such as the OWASP Top 10 [[OWASP-Top-10]] for web services should be
-  evaluated, and if applicable, addressed.
-  This section discusses only security risks
-  and possible mitigations directly relevant to the WoT Thing Description.
-  </p>
-  <p>A WoT Thing Description can describe both secure and 
-  insecure network interfaces.  When a Thing Description is 
-  retro-fitted to an existing network interface, no change in the 
-  security status of the network interface is to be expected.
-  </p>
-  <p>The use of a WoT Thing Description introduces  
-  the security risks given in the following sections.
-  After each risk, we suggest some possible mitigations.
-  </p>
-   <section id="sec-security-consideration-TD-tampering">
-   <h5>TD Interception and Tampering</h5>
-      <p>Intercepting and tampering with TDs can be used to launch man-in-the-middle attacks,
-      for example by rewriting URLs in TDs to redirect accesses to a malicious 
-      intermediary that can capture or manipulate data.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="security-mutual-auth-td">
-          Thing Descriptions SHOULD be obtained only through
-          mutually authenticated secure channels.
-	  </span>
-          Mutual authentication
-	  ensures that the <a>Consumer</a> and the TD provider are both sure of the
-          identity of the other party to the communication.
-	  However, mutual authentication also can be used to identify the 
-	  Consumer, which may be undesirable in some cases (privacy risk).
-	  <span class="rfc2119-assertion" id="security-server-auth-td">
-	  In cases where the Consumer is associated
-	  with a person, e.g. browsers, TDs MAY be obtained
-	  through a channel where only the TD provider is authenticated.
-	  </span>
-      </dd></dl>
-   </section>
-   <section id="sec-security-consideration-context-tampering">
-   <h5>Context Interception and Tampering</h5>
-      <p>Intercepting and tampering with context definition
-      files can be used to facilitate attacks
-      by modifying the interpretation of vocabulary. 
-      Context extensions 
-      (see <a href="#sec-context-extensions"></a>)
-      that are loaded from the Web over non-secure connections,
-      such as HTTP, run the risk of being altered by an attacker, and
-      may modify the <a>TD Information Model</a> in ways that could
-      compromise security.
-      </p>
-      <p>
-      As recommended in 
-      <a href="#sec-privacy-consideration-context"></a>, 
-      on constrained implementations 
-      context definition files should be pre-installed and managed
-      using a secure software
-      update process and the context URLs only used to identify
-      known contexts, not to fetch them.
-      This consideration therefore applies only when fetching context definition
-      files dynamically is otherwise unavoidable, for example in a directory
-      service supporting general semantic processing.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	      Ideally context definition files would only be obtained through secure
-	      channels established by mutual authentication
-	      but it is notable (and unfortunate) that many contexts are indicated using
-	      "plain" HTTP URLs.  
-	      However, the HTTP protocol is vulnerable to interception and modification if 
-	      used without first establishing a secure transport channel using TLS. 
-	      <span class="rfc2119-assertion" id="security-context-secure-fetch">
-	      If it is necessary to fetch a context definition file,
-	      an implementation SHOULD first attempt to use HTTP over TLS 
-	      even when only an HTTP URL is given.
-	      </span>
-      </dd></dl>
-   </section>
-   <section id="security-consideration-access-duration">
-      <h5>Limited Duration Accesses</h5>
-      <p>
-      In some scenarios,
-      it may be desirable to limit the scope and duration of
-      access to a set of Things by some users.
-      For example, if A is visiting B's house, B may
-      want to provide A with temporary and limited access to the garage door opener and
-      car charger so A can use them.
-      The scope however may be limited so that A cannot access
-      certain administrative functions of these Things (for example, to change how long
-      the garage door can remain open, or to change the charging rate).
-      In addition, the access should expire after A is expected to have left,
-      e.g. after one week.
-      </p>
-      <dl>
-	<dt>Mitigations:</dt>
-	<dd>
-	<span class="rfc2119-assertion" id="security-oauth-limits">
-	To limit the scope and duration of access to Things, tokens SHOULD
-	be used to manage access.
-	</span>
-	Note that this includes mechanisms such as OAuth2, which provide
-	for token generation flows where verifying the authentication and 
-	authorization of a user is handled by a separate token provider 
-	service.
-	Token provider services (which could be managed directly 
-	by the Thing's administrator if
-	appropriate or desired for privacy) can
-	provide limited duration tokens and use scopes to limit access.
-	Scopes can limit access to specific interactions but
-	are not sufficient to limit duration.
-	See [[?RFC9200]].
-	</dd>
-     </dl>
-   </section>
-   <section id="sec-security-consideration-vulnerability-auditing">
-   <h5>Vulnerability Auditing</h5>
-      <p>An attacker with access to a set of TDs, for example those returned by
-      WoT Discovery, may be able to use this information to identify vulnerable devices
-      and plan attacks on them.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	      Deployers of IoT systems can use the same information to audit their IoT systems
-	      and ensure that vulnerable systems are adequately protected (if necessary
-	      by external means such as transport security and/or segmented networks) or hardened.
-	      It is also possible to not make the TDs for known-vulnerable systems available
-	      via discovery.  This is, however, not a recommended
-	      approach since security by obscurity is a poor defence: an attacker can still
-	      discover the system by other means, even if the TD has limited distribution.
-	      The definition of "vulnerable" however depends on the context 
-	      in which the information is made available, and to whom it is made available to.
-	      Ideally, only those with the rights to access the Things
-	      described by TDs should get access to those TDs.
-	      <span class="rfc2119-assertion" id="sec-vuln-auto">
-	      The <code>auto</code> security scheme MAY be used if vulnerability
-	      scanning is a concern.</span>
-      </dd></dl>
-   </section>
-   <section id="sec-security-consideration-script-injection">
-   <h5>Script Injection</h5>
-   <p>Many strings given in TDs, in particular the values carried in 
-      <code>title</code>/<code>titles</code>
-      and 
-      <code>description</code>/<code>descriptions</code>, 
-      are meant to be human-readable.  
-      An application may take
-      such strings and use them to generate a user interface, 
-      for example, a web dashboard listing a set of
-      available Things with their titles and descriptions. 
-      If such an interface is naively generated using
-      string substitution, for example inserting the values of these strings into
-      marked places in a HTML template to create final HTML, any HTML 
-      markup in the original string will be interpreted in the context
-      of the browser displaying the dashboard.  
-      It is possible for an attacker to embed scripts in HTML in
-      various ways and have these scripts executed upon user interaction or even automatically (e.g. upon
-      page load, or upon an error, which can be done intentionally).  
-      Since the string will be 
-      generated by the TD producer and the dashboard will be generated by a different origin,
-      this is a form of cross-site-scripting (XSS) attack.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	      Strings sourced from TDs should be treated like any other source of external string
-	      when generating HTML: with care. 
-	      <span class="rfc2119-assertion" id="sec-inj-sanitize">
-		      Strings sourced from TDs MUST either be sanitized using a carefully vetted HTML
-	      sanitizer that disables any markup or should be inserted into an HTML template using
-	      DOM node manipulation APIs that will escape any markup.
-	      </span>
-	      It is also possible that strings sourced from TDs could be used to generate documents
-	      in other markup languages, such as MD files or XML.  
-	      Such usages should take equivalent
-	      precautions to ensure that string values are sanitized before insertion in a template.
-	      Unfortunately such sanitization also will disable any HTML markup included for
-	      internationalization purposes, 
-	      for example to set the initial direction of text rendering in 
-	      bidirectional text.  
-	      <span class="rfc2119-assertion" id="sec-inj-no-intl-markup">
-	      HTML markup SHOULD NOT be used for internationalization purposes in TD strings.
-	      </span>
-
-      </dd></dl>
-   </section>
-   <section id="sec-security-consideration-execution">
-      <h5>JSON Parsing</h5>
-      <p>
-      See <a href="https://tools.ietf.org/html/rfc8259#section-12">RFC&nbsp;8259, section 12</a>: JSON should not be parsed as JavaScript using <code>eval()</code>.
-      A WoT Thing Description is intended to be a pure data exchange format for
-      <a>Thing</a> metadata, not for holding executable content.
-      An (invalid) TD may, however, contain JavaScript code that,
-      when executed, could have side effects compromising the security of a system.
-      <dl>
-	<dt>Mitigation:</dt>
-	<dd><span class="rfc2119-assertion" id="security-no-execution">
-        A WoT Thing Description JSON-LD serialization MUST NOT be passed through a
-        code execution mechanism such as JavaScript's <code>eval()</code>
-        function to be parsed.
-	</span></dd>
-     </dl>
-     <p class="ednote" title="Other Injection Risks">
-     There are additional code injection risks discussed in
-     [[WOT-DISCOVERY]]. Other strings in TDs, such as the values given for
-     <code>title</code> and <code>description</code>, should be sanitized before being
-     used in templates for SQL, HTML, or other executable contexts.
-     This risk, however, is specifically about the Javascript injection risk
-     when parsing JSON.
-     </p>
-  </section>
-   <section id="sec-security-consideration-jsonld-expansion">
-      <h5>JSON-LD Expansion</h5>
-      <p>
-      JSON-LD processing usually includes the replacement of short terms with
-      longer IRIs [[RFC3987]].
-      For this reason, WoT Thing Descriptions may expand considerably when processed using
-      a JSON-LD 1.1 processor and, in the worst case, the resulting data
-      might consume all of the recipient's resources or cause an exploitable
-      buffer overflow.
-      <dl>
-	<dt>Mitigation:</dt>
-	<dd>
-          <span class="rfc2119-assertion" id="security-jsonld-expansion">
-          <a>Consumers</a> SHOULD 
-	  set and enforce limits on
-	  memory usage to prevent buffer overflow and resource exhaustion
-	  during JSON-LD processing.
-          </span>
-        </dd>
-     </dl>
-  </section>
-</section>
-<section id="sec-privacy-consideration">
-  <h4>Privacy Considerations</h4>
-  <p>
-  Privacy risks will depend on the association of 
-  Things with identifiable people and both the direct information and 
-  the inferred information available from such an association.
-  A detailed discussion of privacy (and security) considerations for the Web of Things,
-  including a threat model that can be adapted to various circumstances, is
-  presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
-  This section discusses only privacy risks
-  and possible mitigations directly relevant to the WoT Thing Description.
-  </p>
-  <p>The use of a WoT Thing Description introduces  
-  the privacy risks given in the following sections.
-  After each risk, we suggest some possible mitigations.
-  </p>
-  <section id="sec-privacy-consideration-context">
-  <h5>Context Fetching</h5>
-        <p>
-          WoT Thing Descriptions can be evaluated with a 
-	  JSON-LD 1.1 processor [[json-ld11]],
-          which typically follows links to remote contexts (i.e., TD context
-          extensions, see <a href="#sec-context-extensions"></a>)
-          automatically, resulting in the transfer of files
-          without the explicit request of the <a>Consumer</a> for each one. 
-	  If remote
-          contexts are served by third parties, it may allow them to gather
-          usage patterns or similar information leading to disclosure
-	  of private information, or information that can be used to infer
-	  private information.
-          In the case of the WoT, an attacker can also observe the network
-          traffic produced by such fetches and can use the metadata
-          of the fetch, such as the destination IP address,
-          to infer information about the device, 
-	  especially if domain-specific vocabularies are used.  
-	  This is a risk even if the connection
-          is encrypted, and is related to DNS privacy leaks.
-	  See also <a href="#sec-security-consideration-context-tampering"></a>,
-	  which is a related security risk which can also be avoided with the
-	  following mitigations.
-      <dl>
-	<dt>Mitigation:</dt>
-	<dd>
-          Implementations on resource-constrained devices are expected
-          to perform raw JSON processing (as opposed to JSON-LD processing)
-	  and support only a limited set of domain-specific extensions.
-	  The set of supported extensions can be established by a 
-	  WoT Profile [[WOT-PROFILE]], for example.
-	  <span class="rfc2119-assertion" id="security-static-context">
-          Constrained implementations SHOULD use statically managed and vetted
-          versions of their supported context extensions. 
-          </span>
-	  <span class="rfc2119-assertion" id="security-remote-context">
-          Constrained implementations SHOULD NOT follow links to remote contexts.
-	  </span>
-	  In this case the URLs are used only to identify extensions,
-	  not to fetch their definitions.
-	  <span class="rfc2119-assertion" id="security-update-contexts">
-          Supported context extensions on constrained implementations MAY be managed
-          through secure software update mechanisms.
-	  </span>
-        </dd>
-     </dl>
-   </section>
-   <section id="sec-privacy-consideration-id">
-   <h5>Immutable Identifiers</h5>
-      <p>A Thing Description containing an identifier (<code>id</code>) may
-         describe a Thing that is associated with an identifiable
-         person.  Such identifiers pose various risks including tracking.
-         However, if the identifier is also immutable, then the 
-         tracking risk is amplified, since a device
-         may be sold or given to another person and the known ID used to 
-         track that person.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-mutable-identifiers">
-          All identifiers used in a TD SHOULD be mutable,
-          and in particular there should be a mechanism to update the <code>id</code>
-          of a <a>Thing</a> when necessary.
-	  </span>
-          Specifically,
-          the <code>id</code> of a <a>Thing</a> should not be fixed in hardware.
-          This does, however, conflict with the Linked Data ideal that
-          identifiers are fixed URIs.  
-	  In many circumstances it
-          will be acceptable to only allow updates to identifiers if
-          a <a>Thing</a> is reinitialized.  In this case as a software entity the
-          old <a>Thing</a> ceases to exist and a new <a>Thing</a> is created.
-          This can be sufficient to break a tracking chain when, for
-          example, a device is sold to a new owner.
-          Alternatively, if more frequent changes are desired during 
-          the operational phase of a device,
-          a mechanism can be put into place to notify only authorized users
-          of the change in identifier when a change is made.
-          Note however that some classes of devices, e.g., medical devices,
-          may require immutable IDs by law in some jurisdictions.
-          In this case extra attention should be paid to secure 
-          access to files, such as Thing Descriptions, containing such
-          immutable identifiers.  
-	  It may also be desirable to not share
-          the "true" immutable identifier in such a case in the TD whenever possible.
-          </dd></dl>
-      </p>
-   </section>
-   <section id="sec-privacy-consideration-fingerprint">
-   <h5>Fingerprinting</h5>
-      <p>As noted above, the <code>id</code> member in a TD can pose a privacy risk.  
-      However, even if the <code>id</code> is updated as described to mitigate its
-      tracking risk, it may still be possible to associate
-      a TD with a particular physical device, and from there to an identifiable person, 
-      through fingerprinting.
-      </p>
-      <p>Even if a specific device instance cannot be identified through fingerprinting,
-      it may be possible to infer the type of a device from the information in the TD, such
-      as the set of interactions, and use this type to infer private information about an
-      identifiable person, such as a medical condition.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-auth-users-only">
-          Only authorized users SHOULD be provided access
-          to the Thing Description for a <a>Thing</a>.
-	  </span>
-	  <span class="rfc2119-assertion" id="privacy-essential-metadata-only">
-	  Only the amount of
-          information needed for the level of authorization and the use case 
-	  SHOULD be provided in a TD.
-	  </span>
-          If the TD is only distributed to authorized users 
-          through secure and confidential channels, for
-          example through a directory service that requires authentication,
-          then external unauthorized parties will not have access to the TD to fingerprint it.
-          To further mitigate this risk, information not necessary for a particular
-          use case of a TD should be omitted whenever possible.  For example,
-          for an ad-hoc connection to a device where the Consumer does 
-          not store state about the Thing, the <code>id</code> can be omitted.
-          If the Consumer does not need certain interactions for its use case, 
-	  they can be omitted.
-          If the Consumer is not authorized to use certain interactions, 
-	  they can likewise be omitted.
-	  <!-- we don't have any mechanism to support this; a "null" language 
-	   negotiation might be suitable.
-          If the Consumer does not have any capability to display human-readable information
-          such as titles or descriptions, 
-	  they can be omitted or replaced with zero-length strings.
-	  -->
-      </dd></dl>
-   </section>
-   <section id="sec-privacy-consideration-id-metadata">
-   <h5>ID Metadata</h5>
-      <p>The value of the <code>id</code> field of a TD might become available to 
-      entities that do not have access to the full TD.  If the value of the <code>id</code>
-      contains embedded metadata, such as the type of the device or the owner, this 
-      could be used to infer personal information.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-id-metadata">
-	  The value of the <code>id</code> of a TD SHOULD NOT contain metadata
-	  describing the Thing or from the TD itself.
-	  </span>
-	  <span class="rfc2119-assertion" id="privacy-temp-id-metadata">
-          Any temporary ID generated to manage TDs, for example an ID for a database 
-	  or directory service, SHOULD NOT contain metadata 
-	  describing the Thing or from the TD itself.
-	  </span>
-	  Using random UUIDs as recommended in 
-	  <a href="#sec-privacy-consideration-global-id-risk"></a> also mitigates this
-	  risk.
-      </dd></dl>
-   </section>
-   <section id="sec-privacy-consideration-global-id-risk">
-   <h5>Globally Unique Identifiers</h5>
-      <p>Globally unique identifiers pose a privacy risk if a centralized authority is needed to
-      create and distribute them, since then a third party has knowledge of the identifiers.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-          The <code>id</code> field in TDs is intentionally not required to be globally unique.
-          There are several cryptographic mechanisms (e.g. random UUIDs) available to generate suitable IDs in a 
-          distributed fashion that do
-          not require a central registry.  These mechanisms typically have a very low probability
-          of generating duplicate identifiers, and this needs to be taken into account in the system
-          design; for example, by detecting duplicates and regenerating IDs when necessary.
-          The scope of IDs also does not need to be global: it is acceptable to use identifiers
-          that only distinguish Things in a certain context, such as within a home or factory.
-	  <span class="rfc2119-assertion" id="privacy-distributed-ids">
-          TD identifiers SHOULD be generated using a distributed mechanism such as UUIDs
-	  that provides a high probability of uniqueness.
-	  </span>
-	  <span class="rfc2119-assertion" id="privacy-centralized-ids">
-          TD identifiers SHOULD NOT be generated using a centralized authority.
-	  </span>
-      </dd></dl>
-   </section>
-   <section id="sec-privacy-consideration-inferencing">
-   <h5>Inferencing of Personally Identifiable Information</h5>
-      <p>In many locales, in order to protect the privacy of users,
-      there are legal requirements for the handling of
-      personally identifiable information,
-      that is,
-      information that can be associated with a particular person.
-      Such information can of course be generated by IoT devices directly.
-      However,
-      the existence and metadata of IoT devices
-      (the kind of data stored in a Thing Description)
-      can also contain or be used to infer personally identifiable information.
-      This information can be as simple as the fact that a certain person owns a certain
-      type of device,
-      which can lead to additional inferences about that person.
-      </p>
-      <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-td-pii">
-          A Thing Description associated with a 
-	  personal device SHOULD be treated as if it contained
-	  personally identifiable information, even if this information is not explicit.
-	  </span>
-          As an example application of this principle,
-          consider how to obtain user consent.  
-          Consent for usage of personally identifiable data
-          generated by a <a>Thing</a> is often obtained when a <a>Thing</a> is paired with system
-          consuming the data,
-          which is frequently also when the Thing Description
-          is registered with a local directory or the system consuming the 
-          Thing Description in order to access the device.
-          In this case, consent for using data from a <a>Thing</a> can be combined with
-          consent for accessing the Thing Description of the <a>Thing</a>.
-          As a second example, if we consider a TD to contain personally
-          identifiable information, then it should not be retained indefinitely
-          or used for purposes other than those for which consent was given.
-      </dd></dl>
-   </section>
-</section>
-
 <section id="thing-model" class="normative">
   <h1>Thing Model</h1>
       
@@ -6039,6 +5569,476 @@ instance.
     </pre>
   </section>
 </section>
+
+<section id="sec-security-consideration">
+  <h4>Security Considerations</h4>
+  <p>
+  In general the security measures taken to protect a WoT 
+  system will depend on the threats and attackers that system
+  may face and the value of the assets that need to be protected.
+  A detailed discussion of security (and privacy) considerations for the Web of Things,
+  including a threat model that can be adapted to various circumstances, is
+  presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
+  Many WoT Things are similar to and use the same technologies as web services.
+  In addition to the specific security considerations below,
+  the security risks and mitigations discussed in
+  guides such as the OWASP Top 10 [[OWASP-Top-10]] for web services should be
+  evaluated, and if applicable, addressed.
+  This section discusses only security risks
+  and possible mitigations directly relevant to the WoT Thing Description.
+  </p>
+  <p>A WoT Thing Description can describe both secure and 
+  insecure network interfaces.  When a Thing Description is 
+  retro-fitted to an existing network interface, no change in the 
+  security status of the network interface is to be expected.
+  </p>
+  <p>The use of a WoT Thing Description introduces  
+  the security risks given in the following sections.
+  After each risk, we suggest some possible mitigations.
+  </p>
+   <section id="sec-security-consideration-TD-tampering">
+   <h5>TD Interception and Tampering</h5>
+      <p>Intercepting and tampering with TDs can be used to launch man-in-the-middle attacks,
+      for example by rewriting URLs in TDs to redirect accesses to a malicious 
+      intermediary that can capture or manipulate data.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	  <span class="rfc2119-assertion" id="security-mutual-auth-td">
+          Thing Descriptions SHOULD be obtained only through
+          mutually authenticated secure channels.
+	  </span>
+          Mutual authentication
+	  ensures that the <a>Consumer</a> and the TD provider are both sure of the
+          identity of the other party to the communication.
+	  However, mutual authentication also can be used to identify the 
+	  Consumer, which may be undesirable in some cases (privacy risk).
+	  <span class="rfc2119-assertion" id="security-server-auth-td">
+	  In cases where the Consumer is associated
+	  with a person, e.g. browsers, TDs MAY be obtained
+	  through a channel where only the TD provider is authenticated.
+	  </span>
+      </dd></dl>
+   </section>
+   <section id="sec-security-consideration-context-tampering">
+   <h5>Context Interception and Tampering</h5>
+      <p>Intercepting and tampering with context definition
+      files can be used to facilitate attacks
+      by modifying the interpretation of vocabulary. 
+      Context extensions 
+      (see <a href="#sec-context-extensions"></a>)
+      that are loaded from the Web over non-secure connections,
+      such as HTTP, run the risk of being altered by an attacker, and
+      may modify the <a>TD Information Model</a> in ways that could
+      compromise security.
+      </p>
+      <p>
+      As recommended in 
+      <a href="#sec-privacy-consideration-context"></a>, 
+      on constrained implementations 
+      context definition files should be pre-installed and managed
+      using a secure software
+      update process and the context URLs only used to identify
+      known contexts, not to fetch them.
+      This consideration therefore applies only when fetching context definition
+      files dynamically is otherwise unavoidable, for example in a directory
+      service supporting general semantic processing.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	      Ideally context definition files would only be obtained through secure
+	      channels established by mutual authentication
+	      but it is notable (and unfortunate) that many contexts are indicated using
+	      "plain" HTTP URLs.  
+	      However, the HTTP protocol is vulnerable to interception and modification if 
+	      used without first establishing a secure transport channel using TLS. 
+	      <span class="rfc2119-assertion" id="security-context-secure-fetch">
+	      If it is necessary to fetch a context definition file,
+	      an implementation SHOULD first attempt to use HTTP over TLS 
+	      even when only an HTTP URL is given.
+	      </span>
+      </dd></dl>
+   </section>
+   <section id="security-consideration-access-duration">
+      <h5>Limited Duration Accesses</h5>
+      <p>
+      In some scenarios,
+      it may be desirable to limit the scope and duration of
+      access to a set of Things by some users.
+      For example, if A is visiting B's house, B may
+      want to provide A with temporary and limited access to the garage door opener and
+      car charger so A can use them.
+      The scope however may be limited so that A cannot access
+      certain administrative functions of these Things (for example, to change how long
+      the garage door can remain open, or to change the charging rate).
+      In addition, the access should expire after A is expected to have left,
+      e.g. after one week.
+      </p>
+      <dl>
+	<dt>Mitigations:</dt>
+	<dd>
+	<span class="rfc2119-assertion" id="security-oauth-limits">
+	To limit the scope and duration of access to Things, tokens SHOULD
+	be used to manage access.
+	</span>
+	Note that this includes mechanisms such as OAuth2, which provide
+	for token generation flows where verifying the authentication and 
+	authorization of a user is handled by a separate token provider 
+	service.
+	Token provider services (which could be managed directly 
+	by the Thing's administrator if
+	appropriate or desired for privacy) can
+	provide limited duration tokens and use scopes to limit access.
+	Scopes can limit access to specific interactions but
+	are not sufficient to limit duration.
+	See [[?RFC9200]].
+	</dd>
+     </dl>
+   </section>
+   <section id="sec-security-consideration-vulnerability-auditing">
+   <h5>Vulnerability Auditing</h5>
+      <p>An attacker with access to a set of TDs, for example those returned by
+      WoT Discovery, may be able to use this information to identify vulnerable devices
+      and plan attacks on them.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	      Deployers of IoT systems can use the same information to audit their IoT systems
+	      and ensure that vulnerable systems are adequately protected (if necessary
+	      by external means such as transport security and/or segmented networks) or hardened.
+	      It is also possible to not make the TDs for known-vulnerable systems available
+	      via discovery.  This is, however, not a recommended
+	      approach since security by obscurity is a poor defence: an attacker can still
+	      discover the system by other means, even if the TD has limited distribution.
+	      The definition of "vulnerable" however depends on the context 
+	      in which the information is made available, and to whom it is made available to.
+	      Ideally, only those with the rights to access the Things
+	      described by TDs should get access to those TDs.
+	      <span class="rfc2119-assertion" id="sec-vuln-auto">
+	      The <code>auto</code> security scheme MAY be used if vulnerability
+	      scanning is a concern.</span>
+      </dd></dl>
+   </section>
+   <section id="sec-security-consideration-script-injection">
+   <h5>Script Injection</h5>
+   <p>Many strings given in TDs, in particular the values carried in 
+      <code>title</code>/<code>titles</code>
+      and 
+      <code>description</code>/<code>descriptions</code>, 
+      are meant to be human-readable.  
+      An application may take
+      such strings and use them to generate a user interface, 
+      for example, a web dashboard listing a set of
+      available Things with their titles and descriptions. 
+      If such an interface is naively generated using
+      string substitution, for example inserting the values of these strings into
+      marked places in a HTML template to create final HTML, any HTML 
+      markup in the original string will be interpreted in the context
+      of the browser displaying the dashboard.  
+      It is possible for an attacker to embed scripts in HTML in
+      various ways and have these scripts executed upon user interaction or even automatically (e.g. upon
+      page load, or upon an error, which can be done intentionally).  
+      Since the string will be 
+      generated by the TD producer and the dashboard will be generated by a different origin,
+      this is a form of cross-site-scripting (XSS) attack.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	      Strings sourced from TDs should be treated like any other source of external string
+	      when generating HTML: with care. 
+	      <span class="rfc2119-assertion" id="sec-inj-sanitize">
+		      Strings sourced from TDs MUST either be sanitized using a carefully vetted HTML
+	      sanitizer that disables any markup or should be inserted into an HTML template using
+	      DOM node manipulation APIs that will escape any markup.
+	      </span>
+	      It is also possible that strings sourced from TDs could be used to generate documents
+	      in other markup languages, such as MD files or XML.  
+	      Such usages should take equivalent
+	      precautions to ensure that string values are sanitized before insertion in a template.
+	      Unfortunately such sanitization also will disable any HTML markup included for
+	      internationalization purposes, 
+	      for example to set the initial direction of text rendering in 
+	      bidirectional text.  
+	      <span class="rfc2119-assertion" id="sec-inj-no-intl-markup">
+	      HTML markup SHOULD NOT be used for internationalization purposes in TD strings.
+	      </span>
+
+      </dd></dl>
+   </section>
+   <section id="sec-security-consideration-execution">
+      <h5>JSON Parsing</h5>
+      <p>
+      See <a href="https://tools.ietf.org/html/rfc8259#section-12">RFC&nbsp;8259, section 12</a>: JSON should not be parsed as JavaScript using <code>eval()</code>.
+      A WoT Thing Description is intended to be a pure data exchange format for
+      <a>Thing</a> metadata, not for holding executable content.
+      An (invalid) TD may, however, contain JavaScript code that,
+      when executed, could have side effects compromising the security of a system.
+      <dl>
+	<dt>Mitigation:</dt>
+	<dd><span class="rfc2119-assertion" id="security-no-execution">
+        A WoT Thing Description JSON-LD serialization MUST NOT be passed through a
+        code execution mechanism such as JavaScript's <code>eval()</code>
+        function to be parsed.
+	</span></dd>
+     </dl>
+     <p class="ednote" title="Other Injection Risks">
+     There are additional code injection risks discussed in
+     [[WOT-DISCOVERY]]. Other strings in TDs, such as the values given for
+     <code>title</code> and <code>description</code>, should be sanitized before being
+     used in templates for SQL, HTML, or other executable contexts.
+     This risk, however, is specifically about the Javascript injection risk
+     when parsing JSON.
+     </p>
+  </section>
+   <section id="sec-security-consideration-jsonld-expansion">
+      <h5>JSON-LD Expansion</h5>
+      <p>
+      JSON-LD processing usually includes the replacement of short terms with
+      longer IRIs [[RFC3987]].
+      For this reason, WoT Thing Descriptions may expand considerably when processed using
+      a JSON-LD 1.1 processor and, in the worst case, the resulting data
+      might consume all of the recipient's resources or cause an exploitable
+      buffer overflow.
+      <dl>
+	<dt>Mitigation:</dt>
+	<dd>
+          <span class="rfc2119-assertion" id="security-jsonld-expansion">
+          <a>Consumers</a> SHOULD 
+	  set and enforce limits on
+	  memory usage to prevent buffer overflow and resource exhaustion
+	  during JSON-LD processing.
+          </span>
+        </dd>
+     </dl>
+  </section>
+</section>
+<section id="sec-privacy-consideration">
+  <h4>Privacy Considerations</h4>
+  <p>
+  Privacy risks will depend on the association of 
+  Things with identifiable people and both the direct information and 
+  the inferred information available from such an association.
+  A detailed discussion of privacy (and security) considerations for the Web of Things,
+  including a threat model that can be adapted to various circumstances, is
+  presented in the informative document [[WOT-SECURITY-GUIDELINES]].  
+  This section discusses only privacy risks
+  and possible mitigations directly relevant to the WoT Thing Description.
+  </p>
+  <p>The use of a WoT Thing Description introduces  
+  the privacy risks given in the following sections.
+  After each risk, we suggest some possible mitigations.
+  </p>
+  <section id="sec-privacy-consideration-context">
+  <h5>Context Fetching</h5>
+        <p>
+          WoT Thing Descriptions can be evaluated with a 
+	  JSON-LD 1.1 processor [[json-ld11]],
+          which typically follows links to remote contexts (i.e., TD context
+          extensions, see <a href="#sec-context-extensions"></a>)
+          automatically, resulting in the transfer of files
+          without the explicit request of the <a>Consumer</a> for each one. 
+	  If remote
+          contexts are served by third parties, it may allow them to gather
+          usage patterns or similar information leading to disclosure
+	  of private information, or information that can be used to infer
+	  private information.
+          In the case of the WoT, an attacker can also observe the network
+          traffic produced by such fetches and can use the metadata
+          of the fetch, such as the destination IP address,
+          to infer information about the device, 
+	  especially if domain-specific vocabularies are used.  
+	  This is a risk even if the connection
+          is encrypted, and is related to DNS privacy leaks.
+	  See also <a href="#sec-security-consideration-context-tampering"></a>,
+	  which is a related security risk which can also be avoided with the
+	  following mitigations.
+      <dl>
+	<dt>Mitigation:</dt>
+	<dd>
+          Implementations on resource-constrained devices are expected
+          to perform raw JSON processing (as opposed to JSON-LD processing)
+	  and support only a limited set of domain-specific extensions.
+	  The set of supported extensions can be established by a 
+	  WoT Profile [[WOT-PROFILE]], for example.
+	  <span class="rfc2119-assertion" id="security-static-context">
+          Constrained implementations SHOULD use statically managed and vetted
+          versions of their supported context extensions. 
+          </span>
+	  <span class="rfc2119-assertion" id="security-remote-context">
+          Constrained implementations SHOULD NOT follow links to remote contexts.
+	  </span>
+	  In this case the URLs are used only to identify extensions,
+	  not to fetch their definitions.
+	  <span class="rfc2119-assertion" id="security-update-contexts">
+          Supported context extensions on constrained implementations MAY be managed
+          through secure software update mechanisms.
+	  </span>
+        </dd>
+     </dl>
+   </section>
+   <section id="sec-privacy-consideration-id">
+   <h5>Immutable Identifiers</h5>
+      <p>A Thing Description containing an identifier (<code>id</code>) may
+         describe a Thing that is associated with an identifiable
+         person.  Such identifiers pose various risks including tracking.
+         However, if the identifier is also immutable, then the 
+         tracking risk is amplified, since a device
+         may be sold or given to another person and the known ID used to 
+         track that person.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	  <span class="rfc2119-assertion" id="privacy-mutable-identifiers">
+          All identifiers used in a TD SHOULD be mutable,
+          and in particular there should be a mechanism to update the <code>id</code>
+          of a <a>Thing</a> when necessary.
+	  </span>
+          Specifically,
+          the <code>id</code> of a <a>Thing</a> should not be fixed in hardware.
+          This does, however, conflict with the Linked Data ideal that
+          identifiers are fixed URIs.  
+	  In many circumstances it
+          will be acceptable to only allow updates to identifiers if
+          a <a>Thing</a> is reinitialized.  In this case as a software entity the
+          old <a>Thing</a> ceases to exist and a new <a>Thing</a> is created.
+          This can be sufficient to break a tracking chain when, for
+          example, a device is sold to a new owner.
+          Alternatively, if more frequent changes are desired during 
+          the operational phase of a device,
+          a mechanism can be put into place to notify only authorized users
+          of the change in identifier when a change is made.
+          Note however that some classes of devices, e.g., medical devices,
+          may require immutable IDs by law in some jurisdictions.
+          In this case extra attention should be paid to secure 
+          access to files, such as Thing Descriptions, containing such
+          immutable identifiers.  
+	  It may also be desirable to not share
+          the "true" immutable identifier in such a case in the TD whenever possible.
+          </dd></dl>
+      </p>
+   </section>
+   <section id="sec-privacy-consideration-fingerprint">
+   <h5>Fingerprinting</h5>
+      <p>As noted above, the <code>id</code> member in a TD can pose a privacy risk.  
+      However, even if the <code>id</code> is updated as described to mitigate its
+      tracking risk, it may still be possible to associate
+      a TD with a particular physical device, and from there to an identifiable person, 
+      through fingerprinting.
+      </p>
+      <p>Even if a specific device instance cannot be identified through fingerprinting,
+      it may be possible to infer the type of a device from the information in the TD, such
+      as the set of interactions, and use this type to infer private information about an
+      identifiable person, such as a medical condition.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	  <span class="rfc2119-assertion" id="privacy-auth-users-only">
+          Only authorized users SHOULD be provided access
+          to the Thing Description for a <a>Thing</a>.
+	  </span>
+	  <span class="rfc2119-assertion" id="privacy-essential-metadata-only">
+	  Only the amount of
+          information needed for the level of authorization and the use case 
+	  SHOULD be provided in a TD.
+	  </span>
+          If the TD is only distributed to authorized users 
+          through secure and confidential channels, for
+          example through a directory service that requires authentication,
+          then external unauthorized parties will not have access to the TD to fingerprint it.
+          To further mitigate this risk, information not necessary for a particular
+          use case of a TD should be omitted whenever possible.  For example,
+          for an ad-hoc connection to a device where the Consumer does 
+          not store state about the Thing, the <code>id</code> can be omitted.
+          If the Consumer does not need certain interactions for its use case, 
+	  they can be omitted.
+          If the Consumer is not authorized to use certain interactions, 
+	  they can likewise be omitted.
+	  <!-- we don't have any mechanism to support this; a "null" language 
+	   negotiation might be suitable.
+          If the Consumer does not have any capability to display human-readable information
+          such as titles or descriptions, 
+	  they can be omitted or replaced with zero-length strings.
+	  -->
+      </dd></dl>
+   </section>
+   <section id="sec-privacy-consideration-id-metadata">
+   <h5>ID Metadata</h5>
+      <p>The value of the <code>id</code> field of a TD might become available to 
+      entities that do not have access to the full TD.  If the value of the <code>id</code>
+      contains embedded metadata, such as the type of the device or the owner, this 
+      could be used to infer personal information.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	  <span class="rfc2119-assertion" id="privacy-id-metadata">
+	  The value of the <code>id</code> of a TD SHOULD NOT contain metadata
+	  describing the Thing or from the TD itself.
+	  </span>
+	  <span class="rfc2119-assertion" id="privacy-temp-id-metadata">
+          Any temporary ID generated to manage TDs, for example an ID for a database 
+	  or directory service, SHOULD NOT contain metadata 
+	  describing the Thing or from the TD itself.
+	  </span>
+	  Using random UUIDs as recommended in 
+	  <a href="#sec-privacy-consideration-global-id-risk"></a> also mitigates this
+	  risk.
+      </dd></dl>
+   </section>
+   <section id="sec-privacy-consideration-global-id-risk">
+   <h5>Globally Unique Identifiers</h5>
+      <p>Globally unique identifiers pose a privacy risk if a centralized authority is needed to
+      create and distribute them, since then a third party has knowledge of the identifiers.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+          The <code>id</code> field in TDs is intentionally not required to be globally unique.
+          There are several cryptographic mechanisms (e.g. random UUIDs) available to generate suitable IDs in a 
+          distributed fashion that do
+          not require a central registry.  These mechanisms typically have a very low probability
+          of generating duplicate identifiers, and this needs to be taken into account in the system
+          design; for example, by detecting duplicates and regenerating IDs when necessary.
+          The scope of IDs also does not need to be global: it is acceptable to use identifiers
+          that only distinguish Things in a certain context, such as within a home or factory.
+	  <span class="rfc2119-assertion" id="privacy-distributed-ids">
+          TD identifiers SHOULD be generated using a distributed mechanism such as UUIDs
+	  that provides a high probability of uniqueness.
+	  </span>
+	  <span class="rfc2119-assertion" id="privacy-centralized-ids">
+          TD identifiers SHOULD NOT be generated using a centralized authority.
+	  </span>
+      </dd></dl>
+   </section>
+   <section id="sec-privacy-consideration-inferencing">
+   <h5>Inferencing of Personally Identifiable Information</h5>
+      <p>In many locales, in order to protect the privacy of users,
+      there are legal requirements for the handling of
+      personally identifiable information,
+      that is,
+      information that can be associated with a particular person.
+      Such information can of course be generated by IoT devices directly.
+      However,
+      the existence and metadata of IoT devices
+      (the kind of data stored in a Thing Description)
+      can also contain or be used to infer personally identifiable information.
+      This information can be as simple as the fact that a certain person owns a certain
+      type of device,
+      which can lead to additional inferences about that person.
+      </p>
+      <dl><dt>Mitigation:</dt><dd>
+	  <span class="rfc2119-assertion" id="privacy-td-pii">
+          A Thing Description associated with a 
+	  personal device SHOULD be treated as if it contained
+	  personally identifiable information, even if this information is not explicit.
+	  </span>
+          As an example application of this principle,
+          consider how to obtain user consent.  
+          Consent for usage of personally identifiable data
+          generated by a <a>Thing</a> is often obtained when a <a>Thing</a> is paired with system
+          consuming the data,
+          which is frequently also when the Thing Description
+          is registered with a local directory or the system consuming the 
+          Thing Description in order to access the device.
+          In this case, consent for using data from a <a>Thing</a> can be combined with
+          consent for accessing the Thing Description of the <a>Thing</a>.
+          As a second example, if we consider a TD to contain personally
+          identifiable information, then it should not be retained indefinitely
+          or used for purposes other than those for which consent was given.
+      </dd></dl>
+   </section>
+</section>
+
 <section id="iana-section" class="normative">
  
   <h1>IANA Considerations</h1>


### PR DESCRIPTION
Currently, the Thing Model section is after Security and Privacy Considerations but before IANA Considerations.  This is an odd place for it and implies that the Security and Privacy Considerations do not apply to TMs, which is not the case.

This PR simply moves the TM section to just before Security Considerations, grouping all the "Considerations" sections together.  It does not make any other changes to content.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 17, 2022, 4:29 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fwot-thing-description%2Fpull%2F1545%2F0faa800.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fmmccool%2Fwot-thing-description%2Fpull%2F1545.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/wot-thing-description%231545.)._
</details>
