### PR TITLE
fix: add link to form

### DIFF
--- a/index.html
+++ b/index.html
@@ -5449,7 +5449,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
   </p>
 
   <p>
-    Every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a>Form</a>. 
+    Every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>. 
     The URI scheme [[!RFC3986]] of this submission target indicates what <a>Protocol Binding</a> the <a>Thing</a> implements [[?WOT-ARCHITECTURE]].
     For instance, if the target starts with <code>http</code> or
     <code>https</code>, a <a>Consumer</a> can then infer the <a>Thing</a> implements the

--- a/index.template.html
+++ b/index.template.html
@@ -4179,7 +4179,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
   </p>
 
   <p>
-    Every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a>Form</a>. 
+    Every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>. 
     The URI scheme [[!RFC3986]] of this submission target indicates what <a>Protocol Binding</a> the <a>Thing</a> implements [[?WOT-ARCHITECTURE]].
     For instance, if the target starts with <code>http</code> or
     <code>https</code>, a <a>Consumer</a> can then infer the <a>Thing</a> implements the


### PR DESCRIPTION
fixes https://github.com/w3c/wot-thing-description/issues/1519


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1570.html" title="Last updated on Jul 8, 2022, 12:11 PM UTC (a80ba8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1570/d4daa90...danielpeintner:a80ba8c.html" title="Last updated on Jul 8, 2022, 12:11 PM UTC (a80ba8c)">Diff</a>