### PR TITLE
Fix local biblio references

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,147 +6,143 @@
     <title>Web of Things (WoT) Thing Description 1.1</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class='remove'>
-          var respecConfig = {
-              specStatus:     "ED"
-            , crEnd: "2019-06-13"
-            , previousMaturity: "FPWD"
-            , previousPublishDate: "2020-11-24"
-            , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report11.html"
+        var respecConfig = {
+            specStatus: "ED",
+            crEnd: "2019-06-13",
+            previousMaturity: "FPWD",
+            previousPublishDate: "2020-11-24",
+            implementationReportURI: "https://w3c.github.io/wot-thing-description/testing/report11.html",
             //, processVersion: 2020
             //, wgPatentPolicy: "PP2017" // deprecated, "group" option sets this automatically
-            , shortName:      "wot-thing-description11"
-            , copyrightStart: 2017
-            , noLegacyStyle:  true
-            , inlineCSS:      true
-            , noIDLIn:        true
-            , group:          "wg/wot"
-            , charterDisclosureURI : "https://www.w3.org/2004/01/pp-impl/95969/status"
-            , wgPublicList:   "public-wot-wg"
-            , edDraftURI:     "https://w3c.github.io/wot-thing-description/"
-            , github:         "https://github.com/w3c/wot-thing-description"
-            , issueBase:      "https://www.github.com/w3c/wot-thing-description/issues"
-            , editors: [
+            shortName:      "wot-thing-description11",
+            copyrightStart: 2017,
+            noLegacyStyle:  true,
+            inlineCSS:      true,
+            noIDLIn:        true,
+            group:          "wg/wot",
+            charterDisclosureURI : "https://www.w3.org/2004/01/pp-impl/95969/status",
+            wgPublicList:   "public-wot-wg",
+            edDraftURI:     "https://w3c.github.io/wot-thing-description/",
+            github:         "https://github.com/w3c/wot-thing-description",
+            issueBase:      "https://www.github.com/w3c/wot-thing-description/issues",
+            editors: [
                 {
-                  name:       "Sebastian Kaebisch"
-                , w3cid:      "43064"
-                , company:    "Siemens AG"
-                , companyURL: "https://www.siemens.com/"
+                    name:       "Sebastian Kaebisch",
+                    w3cid:      "43064",
+                    company:    "Siemens AG",
+                    companyURL: "https://www.siemens.com/"
+                },
+                {
+                    name:       "Takuki Kamiya",
+                    w3cid:      "29376",
+                    company:    "Fujitsu Research of America",
+                    companyURL: "https://www.fujitsu.com/"
+                },
+                {
+                    name:       "Michael McCool",
+                    w3cid:      "93137",
+                    company:    "Intel",
+                    companyURL: "https://www.intel.com/"
+                },
+                {
+                    name:       "Victor Charpenay",
+                    w3cid:      "84448",
+                    company:    "Siemens AG",
+                    companyURL: "https://www.siemens.com/"
                 }
-              , {
-                  name:       "Takuki Kamiya"
-                , w3cid:      "29376"
-                , company:    "Fujitsu Research of America"
-                , companyURL: "https://www.fujitsu.com/"
-                }
-                , {
-                  name:       "Michael McCool"
-                , w3cid:      "93137"
-                , company:    "Intel"
-                , companyURL: "https://www.intel.com/"
-                }
-                , {
-                  name:       "Victor Charpenay"
-                , w3cid:      "84448"
-                , company:    "Siemens AG"
-                , companyURL: "https://www.siemens.com/"
-                }
-              ]
-            , xref: ["i18n-glossary"]  
-            , localBiblio: {
+            ],
+            xref: ["i18n-glossary"], 
+            localBiblio: {
                 "LINKSET-MEDIA-TYPES": {
-                  title: "Linkset: Media Types and a Link Relation Type for Link Sets"
-                , href: "https://datatracker.ietf.org/doc/draft-ietf-httpapi-linkset/"
-                , publisher: "IETF"
+                    title: "Linkset: Media Types and a Link Relation Type for Link Sets",
+                    href: "https://datatracker.ietf.org/doc/draft-ietf-httpapi-linkset/",
+                    publisher: "IETF",
+                    authors: ["Erik Wilde","Herbert Van de Sompel"]
                 },
                 "OWASP-Top-10": {
-                  title: "OWASP Top Ten"
-                , href: "https://owasp.org/www-project-top-ten"
-                , publisher: "OWASP"
-                }
-              , "JSON-SCHEMA": {
-                  title:    "JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
-                , href:     "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01"
-                , authors: [
-                    "Austin Wright"
-                  , "Henry Andrews"
-                  , "Geraint Luff"
-                  ]
-                , status:   "Internet-Draft"
-                , date: "19 March 2018"
-                , publisher:  "IETF"
-                }
-              , "OPENAPI": {
-                  title:    "OpenAPI Specification: Version 3.0.1"
-                , href:     "https://swagger.io/specification/"
-                , authors:  [
-		                "Darrel Miller"
-                  , "Jason Harmon"
-                  , "Jeremy Whitlock"
-                  , "Kris Hahn"
-                  , "Marsh Gardiner"
-                  , "Mike Ralphson"
-                  , "Rob Dolin"
-                  , "Ron Ratovsky"
-                  , "Tony Tam"
-                  ]
-                , publisher: "OpenAPI Initiative, Linux Foundation"
-                , date: "7 December 2017"
-                }
-              , "SEMVER": {
-                  title:    "Semantic Versioning 2.0.0"
-                , href:     "https://semver.org/"
-                , authors:  ["Tom Preston-Werner"]
-                , date: "26 December 2017"
-                }
-              , "WOT-ARCHITECTURE": {
-                  title: "Web of Things (WoT) Architecture 1.1"
-                , href: "https://www.w3.org/TR/wot-architecture11/"
-                , authors:  [
-                    "Michael Lagally"
-                  , "Ryuichi Matsukura"
-                  , "Toru Kawaguchi"
-                  , "Kunihiko Toumura"
-                  , "Kazuo Kajimoto"
-                  ]
-                , publisher: "W3C"
-                , date: "November 2020"
-                }
-              , "WOT-PROFILE": {
-                  title: "Web of Things (WoT) Profile"
-                , href: "https://www.w3.org/TR/wot-profile/"
-                , authors:  [
-                    "Michael Lagally"
-                  , "Michael McCool"
-                  , "Ryuichi Matsukura"
-                  , "Sebastian Kaebisch"
-                  , "Tomoaki Mizushima"
-                  ]
-                , publisher: "W3C"
-                , date: "November 2020"
-                }
-              , "WOT-SECURITY-GUIDELINES": {
-                title: "Web of Things (WoT) Security and Privacy Guidelines"
-                //, href: "https://www.w3.org/TR/wot-security/"
-                , href: "https://w3c.github.io/wot-security/"
-                , authors:  [
-                  , "Michael McCool"
-                  , "Elena Reshetova"
-                  ]
-                , publisher: "W3C"
-                , date: "March 2019"
-                }
-	      , "MQTT": {
-                  title: "MQTT Version 3.1.1"
-                , href: "http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html"
-                , authors:  [
-                    "Andrew Banks",
-                    "Rahul Gupta"
-                  ]
-                , publisher: "OASIS"
-                , date: "10 December 2015"
-                , status: "OASIS Standard Incorporating Approved Errata 01"
-                }
-              , "RIJGERSBERG": {
+                    title: "OWASP Top Ten",
+                    href: "https://owasp.org/www-project-top-ten",
+                    publisher: "OWASP"
+                }, 
+                "JSON-SCHEMA": {
+                    title:    "JSON Schema Validation: A Vocabulary for Structural Validation of JSON",
+                    href:     "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01",
+                    authors: [
+                        "Austin Wright",
+                        "Henry Andrews",
+                        "Geraint Luff"
+                    ],
+                    status:   "Internet-Draft",
+                    date: "19 March 2018",
+                    publisher:  "IETF"
+                }, 
+                "OPENAPI": {
+                    title:    "OpenAPI Specification: Version 3.0.1",
+                    href:     "https://spec.openapis.org/oas/v3.0.1",
+                    authors:  [
+                        "Darrel Miller",
+                        "Jeremy Whitlock",
+                        "Marsh Gardiner",
+                        "Mike Ralphson",
+                        "Ron Ratovsky",
+                        "Uri Sarid"
+                    ],
+                    publisher: "OpenAPI Initiative, Linux Foundation",
+                    date: "6 December 2017"
+                }, 
+                "SEMVER": {
+                    title:    "Semantic Versioning 2.0.0",
+                    href:     "https://semver.org/",
+                    authors:  ["Tom Preston-Werner"],
+                    date: "26 December 2017"
+                },
+                "WOT-ARCHITECTURE": {
+                    title: "Web of Things (WoT) Architecture 1.1",
+                    href: "https://www.w3.org/TR/wot-architecture11/",
+                    authors:  [
+                        "Michael Lagally",
+                        "Ryuichi Matsukura",
+                        "Kunihiko Toumura"
+                    ],
+                    publisher: "W3C",
+                    date: "November 2020"
+                },
+                "WOT-PROFILE": {
+                    title: "Web of Things (WoT) Profile",
+                    href: "https://www.w3.org/TR/wot-profile/",
+                    authors:  [
+                        "Michael Lagally",
+                        "Michael McCool",
+                        "Ryuichi Matsukura",
+                        "Sebastian Kaebisch",
+                        "Tomoaki Mizushima"
+                    ],
+                    publisher: "W3C",
+                    date: "November 2020"
+                },
+                "WOT-SECURITY-GUIDELINES": {
+                    title: "Web of Things (WoT) Security and Privacy Guidelines",
+                    //, href: "https://www.w3.org/TR/wot-security/"
+                    href: "https://w3c.github.io/wot-security/",
+                    authors:  [
+                    "Michael McCool",
+                    "Elena Reshetova"
+                    ],
+                    publisher: "W3C",
+                    date: "July 2021"
+                },
+                "MQTT": {
+                    title: "MQTT Version 3.1.1",
+                    href: "http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html",
+                    authors:  [
+                        "Andrew Banks",
+                        "Rahul Gupta"
+                    ],
+                    publisher: "OASIS",
+                    date: "December 2015",
+                    status: "OASIS Standard Incorporating Approved Errata 01"
+                },
+                "RIJGERSBERG": {
                     "href": "http://www.semantic-web-journal.net/content/ontology-units-measure-and-related-concepts",
                     "authors": [
                         "Hajo Rijgersberg",
@@ -156,26 +152,28 @@
                     "title": "Ontology of Units of Measure and Related Concepts",
                     "publisher": "Semantic Web journal, IOS Press",
                     "date": "2013"
-                }
-	      , "LDML": {
+                },
+                "LDML": {
                     "title": "Unicode Technical Standard #35: Unicode Locale Data Markup Language (LDML)",
                     "href": "https://unicode.org/reports/tr35/",
                     "authors": [
                         "Mark Davis",
                         "CLDR Contributors"
-                    ]
-                }
-	      , "JSON-SCHEMA-ONTOLOGY": {
-                  "title": "JSON Schema in RDF"
-                , "href": "https://www.w3.org/2019/wot/json-schema"
-                , "authors": [
+                    ],
+                    "date": "March 2022"
+                },
+                "JSON-SCHEMA-ONTOLOGY": {
+                    "title": "JSON Schema in RDF",
+                    "href": "https://www.w3.org/2019/wot/json-schema",
+                    "authors": [
                         "Victor Charpenay",
                         "Maxime Lefrançois",
                         "María Poveda Villalón"
-                  ]
-                , publisher: "W3C"
-                }
-                , "RFC9200": {
+                    ],
+                    publisher: "W3C",
+                    date: "July 2022"
+                }, 
+                "RFC9200": {
                     "href": "https://www.rfc-editor.org/rfc/rfc9200",
                     "title": "Authentication and Authorization for Constrained Environments (ACE) Using the OAuth 2.0 Framework (ACE-OAuth)",
                     "authors": [
@@ -190,32 +188,32 @@
                     "id": "rfc9200",
                     "date": "March 2022"
                 }
-              }
-            , otherLinks: [
+            },
+            otherLinks: [
                 {
-                  key: "Contributors"
-                , data: [
+                    key: "Contributors",
+                    data: [
                     {
-                      value: "In the GitHub repository"
-                    , href: "https://github.com/w3c/wot-thing-description/graphs/contributors"
+                        value: "In the GitHub repository",
+                        href: "https://github.com/w3c/wot-thing-description/graphs/contributors"
                     }
-                  ]
-                }
-              , {
+                    ]
+                },
+                {
                   key: "Repository",
                   data: [
                     {
-                      value: "We are on GitHub"
-                    , href: "https://github.com/w3c/wot-thing-description/"
-                    }
-                  , {
-                      value: "File a bug"
-                    , href: "https://github.com/w3c/wot-thing-description/issues"
+                        value: "We are on GitHub",
+                        href: "https://github.com/w3c/wot-thing-description/"
+                    },
+                    {
+                        value: "File a bug",
+                        href: "https://github.com/w3c/wot-thing-description/issues"
                     }
                   ]
                 }
               ]
-            };
+        };
     </script>
 <style>
 a[href].internalDFN {

--- a/index.template.html
+++ b/index.template.html
@@ -57,13 +57,14 @@
                   title: "Linkset: Media Types and a Link Relation Type for Link Sets"
                 , href: "https://datatracker.ietf.org/doc/draft-ietf-httpapi-linkset/"
                 , publisher: "IETF"
+                , authors: ["Erik Wilde","Herbert Van de Sompel"]
                 },
                 "OWASP-Top-10": {
                   title: "OWASP Top Ten"
                 , href: "https://owasp.org/www-project-top-ten"
                 , publisher: "OWASP"
-                }
-              , "JSON-SCHEMA": {
+                }, 
+                "JSON-SCHEMA": {
                   title:    "JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
                 , href:     "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01"
                 , authors: [
@@ -74,44 +75,39 @@
                 , status:   "Internet-Draft"
                 , date: "19 March 2018"
                 , publisher:  "IETF"
-                }
-              , "OPENAPI": {
+                }, 
+                "OPENAPI": {
                   title:    "OpenAPI Specification: Version 3.0.1"
-                , href:     "https://swagger.io/specification/"
+                , href:     "https://spec.openapis.org/oas/v3.0.1"
                 , authors:  [
-		                "Darrel Miller"
-                  , "Jason Harmon"
+		            "Darrel Miller"
                   , "Jeremy Whitlock"
-                  , "Kris Hahn"
                   , "Marsh Gardiner"
                   , "Mike Ralphson"
-                  , "Rob Dolin"
                   , "Ron Ratovsky"
-                  , "Tony Tam"
+                  , "Uri Sarid"
                   ]
                 , publisher: "OpenAPI Initiative, Linux Foundation"
-                , date: "7 December 2017"
-                }
-              , "SEMVER": {
+                , date: "6 December 2017"
+                }, 
+                "SEMVER": {
                   title:    "Semantic Versioning 2.0.0"
                 , href:     "https://semver.org/"
                 , authors:  ["Tom Preston-Werner"]
                 , date: "26 December 2017"
-                }
-              , "WOT-ARCHITECTURE": {
+                },
+                "WOT-ARCHITECTURE": {
                   title: "Web of Things (WoT) Architecture 1.1"
                 , href: "https://www.w3.org/TR/wot-architecture11/"
                 , authors:  [
                     "Michael Lagally"
                   , "Ryuichi Matsukura"
-                  , "Toru Kawaguchi"
                   , "Kunihiko Toumura"
-                  , "Kazuo Kajimoto"
                   ]
                 , publisher: "W3C"
                 , date: "November 2020"
-                }
-              , "WOT-PROFILE": {
+                },
+                "WOT-PROFILE": {
                   title: "Web of Things (WoT) Profile"
                 , href: "https://www.w3.org/TR/wot-profile/"
                 , authors:  [
@@ -123,8 +119,8 @@
                   ]
                 , publisher: "W3C"
                 , date: "November 2020"
-                }
-              , "WOT-SECURITY-GUIDELINES": {
+                },
+                "WOT-SECURITY-GUIDELINES": {
                 title: "Web of Things (WoT) Security and Privacy Guidelines"
                 //, href: "https://www.w3.org/TR/wot-security/"
                 , href: "https://w3c.github.io/wot-security/"
@@ -133,9 +129,9 @@
                   , "Elena Reshetova"
                   ]
                 , publisher: "W3C"
-                , date: "March 2019"
-                }
-	      , "MQTT": {
+                , date: "July 2021"
+                },
+                "MQTT": {
                   title: "MQTT Version 3.1.1"
                 , href: "http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html"
                 , authors:  [
@@ -143,10 +139,10 @@
                     "Rahul Gupta"
                   ]
                 , publisher: "OASIS"
-                , date: "10 December 2015"
+                , date: "December 2015"
                 , status: "OASIS Standard Incorporating Approved Errata 01"
-                }
-              , "RIJGERSBERG": {
+                },
+                "RIJGERSBERG": {
                     "href": "http://www.semantic-web-journal.net/content/ontology-units-measure-and-related-concepts",
                     "authors": [
                         "Hajo Rijgersberg",
@@ -156,16 +152,17 @@
                     "title": "Ontology of Units of Measure and Related Concepts",
                     "publisher": "Semantic Web journal, IOS Press",
                     "date": "2013"
-                }
-	      , "LDML": {
+                },
+                "LDML": {
                     "title": "Unicode Technical Standard #35: Unicode Locale Data Markup Language (LDML)",
                     "href": "https://unicode.org/reports/tr35/",
                     "authors": [
                         "Mark Davis",
                         "CLDR Contributors"
-                    ]
-                }
-	      , "JSON-SCHEMA-ONTOLOGY": {
+                    ],
+                    "date": "March 2022"
+                },
+                "JSON-SCHEMA-ONTOLOGY": {
                   "title": "JSON Schema in RDF"
                 , "href": "https://www.w3.org/2019/wot/json-schema"
                 , "authors": [
@@ -173,9 +170,10 @@
                         "Maxime Lefrançois",
                         "María Poveda Villalón"
                   ]
-                , publisher: "W3C"
-                }
-                , "RFC9200": {
+                , publisher: "W3C",
+                  date: "July 2022"
+                }, 
+                "RFC9200": {
                     "href": "https://www.rfc-editor.org/rfc/rfc9200",
                     "title": "Authentication and Authorization for Constrained Environments (ACE) Using the OAuth 2.0 Framework (ACE-OAuth)",
                     "authors": [

--- a/index.template.html
+++ b/index.template.html
@@ -6,141 +6,141 @@
     <title>Web of Things (WoT) Thing Description 1.1</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class='remove'>
-          var respecConfig = {
-              specStatus:     "ED"
-            , crEnd: "2019-06-13"
-            , previousMaturity: "FPWD"
-            , previousPublishDate: "2020-11-24"
-            , implementationReportURI:      "https://w3c.github.io/wot-thing-description/testing/report11.html"
+        var respecConfig = {
+            specStatus: "ED",
+            crEnd: "2019-06-13",
+            previousMaturity: "FPWD",
+            previousPublishDate: "2020-11-24",
+            implementationReportURI: "https://w3c.github.io/wot-thing-description/testing/report11.html",
             //, processVersion: 2020
             //, wgPatentPolicy: "PP2017" // deprecated, "group" option sets this automatically
-            , shortName:      "wot-thing-description11"
-            , copyrightStart: 2017
-            , noLegacyStyle:  true
-            , inlineCSS:      true
-            , noIDLIn:        true
-            , group:          "wg/wot"
-            , charterDisclosureURI : "https://www.w3.org/2004/01/pp-impl/95969/status"
-            , wgPublicList:   "public-wot-wg"
-            , edDraftURI:     "https://w3c.github.io/wot-thing-description/"
-            , github:         "https://github.com/w3c/wot-thing-description"
-            , issueBase:      "https://www.github.com/w3c/wot-thing-description/issues"
-            , editors: [
+            shortName:      "wot-thing-description11",
+            copyrightStart: 2017,
+            noLegacyStyle:  true,
+            inlineCSS:      true,
+            noIDLIn:        true,
+            group:          "wg/wot",
+            charterDisclosureURI : "https://www.w3.org/2004/01/pp-impl/95969/status",
+            wgPublicList:   "public-wot-wg",
+            edDraftURI:     "https://w3c.github.io/wot-thing-description/",
+            github:         "https://github.com/w3c/wot-thing-description",
+            issueBase:      "https://www.github.com/w3c/wot-thing-description/issues",
+            editors: [
                 {
-                  name:       "Sebastian Kaebisch"
-                , w3cid:      "43064"
-                , company:    "Siemens AG"
-                , companyURL: "https://www.siemens.com/"
+                    name:       "Sebastian Kaebisch",
+                    w3cid:      "43064",
+                    company:    "Siemens AG",
+                    companyURL: "https://www.siemens.com/"
+                },
+                {
+                    name:       "Takuki Kamiya",
+                    w3cid:      "29376",
+                    company:    "Fujitsu Research of America",
+                    companyURL: "https://www.fujitsu.com/"
+                },
+                {
+                    name:       "Michael McCool",
+                    w3cid:      "93137",
+                    company:    "Intel",
+                    companyURL: "https://www.intel.com/"
+                },
+                {
+                    name:       "Victor Charpenay",
+                    w3cid:      "84448",
+                    company:    "Siemens AG",
+                    companyURL: "https://www.siemens.com/"
                 }
-              , {
-                  name:       "Takuki Kamiya"
-                , w3cid:      "29376"
-                , company:    "Fujitsu Research of America"
-                , companyURL: "https://www.fujitsu.com/"
-                }
-                , {
-                  name:       "Michael McCool"
-                , w3cid:      "93137"
-                , company:    "Intel"
-                , companyURL: "https://www.intel.com/"
-                }
-                , {
-                  name:       "Victor Charpenay"
-                , w3cid:      "84448"
-                , company:    "Siemens AG"
-                , companyURL: "https://www.siemens.com/"
-                }
-              ]
-            , xref: ["i18n-glossary"]  
-            , localBiblio: {
+            ],
+            xref: ["i18n-glossary"], 
+            localBiblio: {
                 "LINKSET-MEDIA-TYPES": {
-                  title: "Linkset: Media Types and a Link Relation Type for Link Sets"
-                , href: "https://datatracker.ietf.org/doc/draft-ietf-httpapi-linkset/"
-                , publisher: "IETF"
-                , authors: ["Erik Wilde","Herbert Van de Sompel"]
+                    title: "Linkset: Media Types and a Link Relation Type for Link Sets",
+                    href: "https://datatracker.ietf.org/doc/draft-ietf-httpapi-linkset/",
+                    publisher: "IETF",
+                    authors: ["Erik Wilde","Herbert Van de Sompel"]
                 },
                 "OWASP-Top-10": {
-                  title: "OWASP Top Ten"
-                , href: "https://owasp.org/www-project-top-ten"
-                , publisher: "OWASP"
+                    title: "OWASP Top Ten",
+                    href: "https://owasp.org/www-project-top-ten",
+                    publisher: "OWASP"
                 }, 
                 "JSON-SCHEMA": {
-                  title:    "JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
-                , href:     "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01"
-                , authors: [
-                    "Austin Wright"
-                  , "Henry Andrews"
-                  , "Geraint Luff"
-                  ]
-                , status:   "Internet-Draft"
-                , date: "19 March 2018"
-                , publisher:  "IETF"
+                    title:    "JSON Schema Validation: A Vocabulary for Structural Validation of JSON",
+                    href:     "https://tools.ietf.org/html/draft-handrews-json-schema-validation-01",
+                    authors: [
+                        "Austin Wright",
+                        "Henry Andrews",
+                        "Geraint Luff"
+                    ],
+                    status:   "Internet-Draft",
+                    date: "19 March 2018",
+                    publisher:  "IETF"
                 }, 
                 "OPENAPI": {
-                  title:    "OpenAPI Specification: Version 3.0.1"
-                , href:     "https://spec.openapis.org/oas/v3.0.1"
-                , authors:  [
-		            "Darrel Miller"
-                  , "Jeremy Whitlock"
-                  , "Marsh Gardiner"
-                  , "Mike Ralphson"
-                  , "Ron Ratovsky"
-                  , "Uri Sarid"
-                  ]
-                , publisher: "OpenAPI Initiative, Linux Foundation"
-                , date: "6 December 2017"
+                    title:    "OpenAPI Specification: Version 3.0.1",
+                    href:     "https://spec.openapis.org/oas/v3.0.1",
+                    authors:  [
+                        "Darrel Miller",
+                        "Jeremy Whitlock",
+                        "Marsh Gardiner",
+                        "Mike Ralphson",
+                        "Ron Ratovsky",
+                        "Uri Sarid"
+                    ],
+                    publisher: "OpenAPI Initiative, Linux Foundation",
+                    date: "6 December 2017"
                 }, 
                 "SEMVER": {
-                  title:    "Semantic Versioning 2.0.0"
-                , href:     "https://semver.org/"
-                , authors:  ["Tom Preston-Werner"]
-                , date: "26 December 2017"
+                    title:    "Semantic Versioning 2.0.0",
+                    href:     "https://semver.org/",
+                    authors:  ["Tom Preston-Werner"],
+                    date: "26 December 2017"
                 },
                 "WOT-ARCHITECTURE": {
-                  title: "Web of Things (WoT) Architecture 1.1"
-                , href: "https://www.w3.org/TR/wot-architecture11/"
-                , authors:  [
-                    "Michael Lagally"
-                  , "Ryuichi Matsukura"
-                  , "Kunihiko Toumura"
-                  ]
-                , publisher: "W3C"
-                , date: "November 2020"
+                    title: "Web of Things (WoT) Architecture 1.1",
+                    href: "https://www.w3.org/TR/wot-architecture11/",
+                    authors:  [
+                        "Michael Lagally",
+                        "Ryuichi Matsukura",
+                        "Kunihiko Toumura"
+                    ],
+                    publisher: "W3C",
+                    date: "November 2020"
                 },
                 "WOT-PROFILE": {
-                  title: "Web of Things (WoT) Profile"
-                , href: "https://www.w3.org/TR/wot-profile/"
-                , authors:  [
-                    "Michael Lagally"
-                  , "Michael McCool"
-                  , "Ryuichi Matsukura"
-                  , "Sebastian Kaebisch"
-                  , "Tomoaki Mizushima"
-                  ]
-                , publisher: "W3C"
-                , date: "November 2020"
+                    title: "Web of Things (WoT) Profile",
+                    href: "https://www.w3.org/TR/wot-profile/",
+                    authors:  [
+                        "Michael Lagally",
+                        "Michael McCool",
+                        "Ryuichi Matsukura",
+                        "Sebastian Kaebisch",
+                        "Tomoaki Mizushima"
+                    ],
+                    publisher: "W3C",
+                    date: "November 2020"
                 },
                 "WOT-SECURITY-GUIDELINES": {
-                title: "Web of Things (WoT) Security and Privacy Guidelines"
-                //, href: "https://www.w3.org/TR/wot-security/"
-                , href: "https://w3c.github.io/wot-security/"
-                , authors:  [
-                  , "Michael McCool"
-                  , "Elena Reshetova"
-                  ]
-                , publisher: "W3C"
-                , date: "July 2021"
+                    title: "Web of Things (WoT) Security and Privacy Guidelines",
+                    //, href: "https://www.w3.org/TR/wot-security/"
+                    href: "https://w3c.github.io/wot-security/",
+                    authors:  [
+                    "Michael McCool",
+                    "Elena Reshetova"
+                    ],
+                    publisher: "W3C",
+                    date: "July 2021"
                 },
                 "MQTT": {
-                  title: "MQTT Version 3.1.1"
-                , href: "http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html"
-                , authors:  [
-                    "Andrew Banks",
-                    "Rahul Gupta"
-                  ]
-                , publisher: "OASIS"
-                , date: "December 2015"
-                , status: "OASIS Standard Incorporating Approved Errata 01"
+                    title: "MQTT Version 3.1.1",
+                    href: "http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html",
+                    authors:  [
+                        "Andrew Banks",
+                        "Rahul Gupta"
+                    ],
+                    publisher: "OASIS",
+                    date: "December 2015",
+                    status: "OASIS Standard Incorporating Approved Errata 01"
                 },
                 "RIJGERSBERG": {
                     "href": "http://www.semantic-web-journal.net/content/ontology-units-measure-and-related-concepts",
@@ -163,15 +163,15 @@
                     "date": "March 2022"
                 },
                 "JSON-SCHEMA-ONTOLOGY": {
-                  "title": "JSON Schema in RDF"
-                , "href": "https://www.w3.org/2019/wot/json-schema"
-                , "authors": [
+                    "title": "JSON Schema in RDF",
+                    "href": "https://www.w3.org/2019/wot/json-schema",
+                    "authors": [
                         "Victor Charpenay",
                         "Maxime Lefrançois",
                         "María Poveda Villalón"
-                  ]
-                , publisher: "W3C",
-                  date: "July 2022"
+                    ],
+                    publisher: "W3C",
+                    date: "July 2022"
                 }, 
                 "RFC9200": {
                     "href": "https://www.rfc-editor.org/rfc/rfc9200",
@@ -188,32 +188,32 @@
                     "id": "rfc9200",
                     "date": "March 2022"
                 }
-              }
-            , otherLinks: [
+            },
+            otherLinks: [
                 {
-                  key: "Contributors"
-                , data: [
+                    key: "Contributors",
+                    data: [
                     {
-                      value: "In the GitHub repository"
-                    , href: "https://github.com/w3c/wot-thing-description/graphs/contributors"
+                        value: "In the GitHub repository",
+                        href: "https://github.com/w3c/wot-thing-description/graphs/contributors"
                     }
-                  ]
-                }
-              , {
+                    ]
+                },
+                {
                   key: "Repository",
                   data: [
                     {
-                      value: "We are on GitHub"
-                    , href: "https://github.com/w3c/wot-thing-description/"
-                    }
-                  , {
-                      value: "File a bug"
-                    , href: "https://github.com/w3c/wot-thing-description/issues"
+                        value: "We are on GitHub",
+                        href: "https://github.com/w3c/wot-thing-description/"
+                    },
+                    {
+                        value: "File a bug",
+                        href: "https://github.com/w3c/wot-thing-description/issues"
                     }
                   ]
                 }
               ]
-            };
+        };
     </script>
 <style>
 a[href].internalDFN {


### PR DESCRIPTION
fixes #1381 

I have also formatted the respec config since it had mixed usage of tab spaces, comma locations


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1576.html" title="Last updated on Jul 13, 2022, 10:57 AM UTC (73b8b94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1576/d4daa90...73b8b94.html" title="Last updated on Jul 13, 2022, 10:57 AM UTC (73b8b94)">Diff</a>