### PR TITLE
fix contentType of TM links

### DIFF
--- a/index.html
+++ b/index.html
@@ -5932,7 +5932,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
             "links" : [{
                 "rel": "tm:extends",
                 "href": "http://example.com/BasicOnOffTM",
-                "type": "application/td+json"
+                "type": "application/tm+json"
              }],
             "properties" : {
                 "dim" : {
@@ -6094,7 +6094,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
             "links" : [{
                 "rel": "extends",
                 "href": "http://example.com/BasicOnOffTM",
-                "type": "application/td+json"
+                "type": "application/tm+json"
              }],
             "properties" : {
                 "status" : {
@@ -6798,7 +6798,7 @@ instance.
 	"links" : [{
 		"rel" : "type",
 		"href" : "http://example.com/ThingModelPool/Pump",
-		"type": "application/td+json"
+		"type": "application/tm+json"
 	}],
 	...
 }
@@ -6832,7 +6832,7 @@ instance.
         "links" : [{
             "rel": "tm:extends",
             "href": "http://example.com/SmartControlLampTM",
-            "type": "application/td+json"
+            "type": "application/tm+json"
          }],
         "properties" : {
             "dim" : {
@@ -6856,7 +6856,7 @@ instance.
             "links" : [{
                 "rel": "type",
                 "href": "url/to/SmartLampControlModifiedDimTM",
-                "type": "application/td+json"
+                "type": "application/tm+json"
              }
            ],
            "properties" : {

--- a/index.template.html
+++ b/index.template.html
@@ -4662,7 +4662,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
             "links" : [{
                 "rel": "tm:extends",
                 "href": "http://example.com/BasicOnOffTM",
-                "type": "application/td+json"
+                "type": "application/tm+json"
              }],
             "properties" : {
                 "dim" : {
@@ -4824,7 +4824,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
             "links" : [{
                 "rel": "extends",
                 "href": "http://example.com/BasicOnOffTM",
-                "type": "application/td+json"
+                "type": "application/tm+json"
              }],
             "properties" : {
                 "status" : {
@@ -5528,7 +5528,7 @@ instance.
 	"links" : [{
 		"rel" : "type",
 		"href" : "http://example.com/ThingModelPool/Pump",
-		"type": "application/td+json"
+		"type": "application/tm+json"
 	}],
 	...
 }
@@ -5562,7 +5562,7 @@ instance.
         "links" : [{
             "rel": "tm:extends",
             "href": "http://example.com/SmartControlLampTM",
-            "type": "application/td+json"
+            "type": "application/tm+json"
          }],
         "properties" : {
             "dim" : {
@@ -5586,7 +5586,7 @@ instance.
             "links" : [{
                 "rel": "type",
                 "href": "url/to/SmartLampControlModifiedDimTM",
-                "type": "application/td+json"
+                "type": "application/tm+json"
              }
            ],
            "properties" : {


### PR DESCRIPTION
some used to use td+json instead of tm+json

fixes #1378


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1577.html" title="Last updated on Jul 13, 2022, 11:06 AM UTC (824914f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1577/d4daa90...824914f.html" title="Last updated on Jul 13, 2022, 11:06 AM UTC (824914f)">Diff</a>