### PR TITLE
Remove two obsolete assertions from extra-asserts

### DIFF
--- a/testing/inputs/extra-asserts.html
+++ b/testing/inputs/extra-asserts.html
@@ -50,9 +50,6 @@ MUST be serialized as a JSON name within an Action object.
 The type of the member <code>forms</code> MUST be serialized as a JSON array.
 </span></li>
 -->
-<li><span class="rfc2119-assertion" id="td-arrays_scopes">
-The type of the member <code>scopes</code> MUST be a JSON array.
-</span></li>
 <li><span class="rfc2119-assertion" id="td-arrays_links">
 The type of the member <code>links</code> MUST be a JSON array.
 </span></li>
@@ -105,11 +102,6 @@ MUST be serialized as a JSON name within an Action object.
 The vocabulary term 
 <code>output</code>
 MUST be serialized as a JSON name within an Action object.
-</span></li>
-<li><span class="rfc2119-assertion" id="td-arrays_security">
-The value of the member
-<code>security</code> 
-MUST be serialized as a JSON array.
 </span></li>
 <li><span class="rfc2119-assertion" id="td-data-schema-arrays_enum">
 The value of the member 


### PR DESCRIPTION
`td-arrays_scopes` and `td-arrays_security` are not needed anymore and cause extra fields in manual.csv. I am merging this rightaway