### PR TITLE
Add hreflang to schema

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -152,6 +152,10 @@
         }
       ]
     },
+    "bcp47_string":{
+      "type":"string",
+      "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
+    },
     "type_declaration": {
       "oneOf": [
         {
@@ -750,6 +754,17 @@
         },
         "anchor": {
           "$ref": "#/definitions/anyUri"
+        },
+        "hreflang": {
+            "anyOf":[
+              {"$ref": "#/definitions/bcp47_string"},
+              {
+                "type":"array",
+                "items":{
+                  "$ref": "#/definitions/bcp47_string"
+                }
+              }
+            ]
         }
       },
       "required": [


### PR DESCRIPTION
Tests see: https://www.jsonschemavalidator.net/s/qwTU2Kxb

to remove fail, go to the last line and change the hreflang value to `de` or any other bcp47 tag

We should add this to descriptions and titles but it might be breaking some implementations that were looking at the schema but not reading the spec properly