### PR TITLE
Changes section WD-4

### DIFF
--- a/publication/ver11/4-wd/Overview.html
+++ b/publication/ver11/4-wd/Overview.html
@@ -1461,13 +1461,19 @@
         <ol class="toc">
           <li class="tocline">
             <a class="tocxref" href=
-            "#changes-from-june-2021"><bdi class="secno">D.1</bdi>
+            "#changes-from-march-2022"><bdi class="secno">D.1</bdi>
+            Changes from Third Public Working Draft 11 March
+            2022</a>
+          </li>
+          <li class="tocline">
+            <a class="tocxref" href=
+            "#changes-from-june-2021"><bdi class="secno">D.2</bdi>
             Changes from Second Public Working Draft 7 June
             2021</a>
           </li>
           <li class="tocline">
             <a class="tocxref" href=
-            "#changes-from-fpwd"><bdi class="secno">D.2</bdi>
+            "#changes-from-fpwd"><bdi class="secno">D.3</bdi>
             Changes from First Public Working Draft 24 November
             2020</a>
           </li>
@@ -14791,13 +14797,26 @@
       "Permalink for Appendix D."></a>
     </div>
     <section id=
+    "changes-from-third-public-working-draft-11-march-2022">
+      <div class="header-wrapper">
+        <h3 id="changes-from-march-2022"><bdi class=
+        "secno">D.1</bdi> Changes from Third Public Working Draft
+        11 March 2022</h3><a class="self-link" href=
+        "#changes-from-march-2022" aria-label=
+        "Permalink for Appendix D.1"></a>
+      </div>
+      <ul>
+        <li>TEST_ENTRY</li>
+      </ul>
+    </section>
+    <section id=
     "changes-from-second-public-working-draft-7-june-2021">
       <div class="header-wrapper">
         <h3 id="changes-from-june-2021"><bdi class=
-        "secno">D.1</bdi> Changes from Second Public Working Draft
+        "secno">D.2</bdi> Changes from Second Public Working Draft
         7 June 2021</h3><a class="self-link" href=
         "#changes-from-june-2021" aria-label=
-        "Permalink for Appendix D.1"></a>
+        "Permalink for Appendix D.2"></a>
       </div>
       <ul>
         <li>In section <a href="#namespaces" class=
@@ -15047,10 +15066,10 @@
     <section id=
     "changes-from-first-public-working-draft-24-november-2020">
       <div class="header-wrapper">
-        <h3 id="changes-from-fpwd"><bdi class="secno">D.2</bdi>
+        <h3 id="changes-from-fpwd"><bdi class="secno">D.3</bdi>
         Changes from First Public Working Draft 24 November
         2020</h3><a class="self-link" href="#changes-from-fpwd"
-        aria-label="Permalink for Appendix D.2"></a>
+        aria-label="Permalink for Appendix D.3"></a>
       </div>
       <p>Changes from First Public Working Draft 24 November 2020
       are described in the <a href=

--- a/publication/ver11/4-wd/Overview.html
+++ b/publication/ver11/4-wd/Overview.html
@@ -14806,7 +14806,45 @@
         "Permalink for Appendix D.1"></a>
       </div>
       <ul>
-        <li>TEST_ENTRY</li>
+        <li>
+			In section <a href="#class-definitions" class="sec-ref"><bdi class="secno">5.3</bdi> Class Definitions</a> it was made clear that all vocabulary terms and values are case sensitive.
+		</li>
+        <li>
+			In section <a href="#thing" class="sec-ref"><bdi class="secno">5.3.1.1</bdi> Thing</a> the rules for <code>@context</code> were clarified by stating that TD 1.1 consumers must accept TD 1.0 TDs.
+		</li>
+        <li>
+			In section <a href="#actionaffordance" class="sec-ref"><bdi class="secno">5.3.1.4</bdi> <code>ActionAffordance</code></a> the term <code>synchronous</code> was added.
+		</li>
+        <li>
+			In section <a href="#nullschema" class="sec-ref"><bdi class="secno">5.3.2.8</bdi> <code>NullSchema</code></a> it was clarified that <code>null</code> does not mean the absence of a value.
+		</li>
+        <li>
+			The section <a href="#autosecurityscheme" class="sec-ref"><bdi class="secno">5.3.3.3</bdi> AutoSecurityScheme</a> with the corresponding <code>"scheme": "auto"</code> was added to indicate that the security parameters are going to be negotiated by the underlying protocols at runtime.
+		</li>
+        <li>
+			In section <a href="#link" class="sec-ref"><bdi class="secno">5.3.4.1.</bdi> <code> Link </code></a> the vocabulary term <code>hreflang</code> was added that to specify the language of a linked document.
+		</li>
+        <li>
+			The section <a href="#sec-op-data-schema-mapping" class="sec-ref"><bdi class="secno"> 5.3.4.2.1</bdi> Mapping op Values to Data Schemas </a> was added which summarizes the available data schema related terms with the <code>op</code> keywords.
+		</li>
+        <li>
+			In section <a href="#sec-security-consideration" class="sec-ref"><bdi class="secno">9.</bdi> Security Considerations</a> and the according subsections the text has been  revised and improved following the latest security guidelines. Moreover, new sections about <a href="#security-consideration-access-duration" class="sec-ref">9.3. Limited Duration Accesses <a/>, <a href="#sec-security-consideration-vulnerability-auditing" class="sec-ref">9.4 Vulnerability Auditing <a/>, <a href="#sec-security-consideration-script-injection" class="sec-ref">9.5 Script Injection <a/>, <a href="#sec-security-consideration-execution" class="sec-ref"> 9.6 JSON Parsing <a/>, and <a href="#sec-security-consideration-jsonld-expansion" class="sec-ref">9.7 JSON-LD Expansion <a/> have been added.
+		</li>
+        <li>
+			In section <a href="#sec-privacy-consideration" class="sec-ref"><bdi class="secno">10.</bdi> Privacy Considerations</a> and the according subsections the text has been  revised and improved following the latest security guidelines. In addition, a new section about <a href="#sec-privacy-consideration-id-metadata" class="sec-ref">10.4 ID Metadata  <a/> was added.
+		</li>
+        <li>
+			In section <a href="#thing-model-extension-import" class="sec-ref"><bdi class="secno">11.3.2 </bdi> Extension and Import</a> it was made explicit that <code>tm:extends</code> and the import mechanism based on <code>tm:ref</code> supports transitive extension.
+		</li>
+        <li>
+			The section <a href="#media-type-section-tm" class="sec-ref"><bdi class="secno"> 12.2</bdi> <code>application/tm+json</code> Media Type Registration</a> was added to provide Thing Model registration information.
+		</li>
+        <li>
+			The section <a href="#content-format-section" class="sec-ref"><bdi class="secno"> 12.3</bdi> CoAP Content-Format Registration</a> was split into <a href="#wot-thing-description" class="sec-ref">12.3.1 WoT Thing Description<a/> and <a href="#wot-thing-model" class="sec-ref">12.3.2 WoT Thing Model<a/>.
+		</li>
+        <li>
+			In appendix <a href="#json-schema-for-validation" class="sec-ref"><bdi class="secno">B. </bdi> JSON Schema for TD Instance Validation</a> the JSON Schema is now linked instead of being included in the specification itself.
+		</li>
       </ul>
     </section>
     <section id=


### PR DESCRIPTION
Note: Next time we should add the changes section **before** creating the static HTML. I had to tweak the generated HTML of ToC etc.

The changes list comes from a [diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FTR%2F2022%2FWD-wot-thing-description11-20220311%2F&doc2=http%3A%2F%2Fpeintner.org%2Ftmp%2F4-wd%2FOverview.html) I created between the last published version and the current version.

While working on the actual change list I noticed also some TODOs/bugs
- [x] [Section 9.3](http://peintner.org/tmp/4-wd/Overview.html#security-consideration-access-duration) is still broken. it uses undefined ACE-OAuth bib reference. 
![grafik](https://user-images.githubusercontent.com/11281461/180239615-e842de76-6600-4529-8899-4d6402ce5042.png)
  I think we need to integrate https://github.com/w3c/wot-thing-description/pull/1544.
  Corresponding PR created, see https://github.com/w3c/wot-thing-description/pull/1620

- [ ] [Appendix B](http://peintner.org/tmp/4-wd/Overview.html#json-schema-for-validation) speaks about adding a link to the JSON Schema. This did not happen yet.

- [ ] create corresponding PR for changes section on Editor/github.io version as well