### PR TITLE
SHACLE Type fixes

### DIFF
--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -32,6 +32,7 @@
                 a text for UI representation) based on a default
                 language."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:order 1 ;
@@ -69,6 +70,7 @@
                 [<cite><a class="bibref" data-link-type="biblio" href='#bib-rfc6068' title="The 'mailto' URI Scheme">RFC6068</a></cite>],
                 <code>tel</code> [<cite><a class="bibref" data-link-type="biblio" href='#bib-rfc3966' title="The tel URI for Telephone Numbers">RFC3966</a></cite>],
                 <code>https</code>)."""^^rdf:HTML ;
+        sh:datatype xsd:anyURI ;
         sh:maxCount 1 ;
         sh:order 8 ;
     ] ;
@@ -147,7 +149,8 @@
                 those defined in <code>securityDefinitions</code>.
                 These must all be satisfied for access to
                 resources."""^^rdf:HTML ;
-        sh:nodeKind sh:IRI ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:minCount 1 ;
         sh:order 15 ;
     ] ;
@@ -569,6 +572,7 @@
         skos:definition """Provides a version indicator of this TD.
                 instance."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:order 2 ;
@@ -578,6 +582,7 @@
         skos:definition """Provides a version indicator of the underlying TM.
                 instance."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:order 2 ;
     ] ;
@@ -608,7 +613,7 @@
                 form."""^^rdf:HTML ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
-        sh:nodeKind sh:Literal ;
+        sh:nodeKind sh:IRI ;
         sh:order 2 ;
     ] ;
     sh:property [
@@ -618,6 +623,7 @@
                 parameters (e.g., <code>charset=utf-8</code>) for
                 the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:defaultValue "application/json"^^xsd:string ;
         sh:order 3 ;
@@ -633,6 +639,7 @@
                 loss of information. Examples of content coding
                 include "gzip", "deflate", etc. ."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:order 4 ;
     ] ;
@@ -690,7 +697,8 @@
             td:unsubscribeAllEvents
             td:queryAllActions
         );
-        sh:nodeKind sh:IRI ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:order 1 ;
     ] ;
     sh:property [
@@ -709,6 +717,7 @@
                 mechanisms can also be announced by this
                 subprotocol term."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         skos:example (
             "longpoll"
@@ -723,7 +732,8 @@
                 those defined in <code>securityDefinitions</code>.
                 These must all be satisfied for access to
                 resources."""^^rdf:HTML ;
-        sh:nodeKind sh:IRI ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         #sh:node :SecuritySchemeShape ;
         sh:order 6 ;
     ] ;
@@ -738,6 +748,7 @@
                 <code>OAuth2SecurityScheme</code> active on that
                 form."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:order 7 ;
     ] ;
     skos:scopeNote """<p>Possible values for the <code>contentCoding</code>
@@ -1056,7 +1067,8 @@
                 form."""^^rdf:HTML ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
-        sh:nodeKind sh:Literal ;
+        sh:nodeKind sh:IRI ;
+        #sh:datatype xsd:string ;
         sh:order 1 ;
     ] ;
     sh:property [
@@ -1066,6 +1078,7 @@
                 of the result of dereferencing the link should
                 be."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:order 2 ;
     ] ;
@@ -1073,8 +1086,9 @@
         sh:path hctl:hasRelationType ;
         skos:definition """A link relation type identifies the semantics
                 of a link."""^^rdf:HTML ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
-        sh:nodeKind sh:IRI ; # TODO could be relaxed
+       #sh:nodeKind sh:IRI ; # TODO could be relaxed
         sh:order 3 ;
     ] ;
     sh:property [
@@ -1083,6 +1097,7 @@
                 Thing itself identified by its <code>id</code>)
                 with the given URI or IRI."""^^rdf:HTML ;
         sh:node sh:IRI ;
+        sh:datatype xsd:anyURI ;
         sh:maxCount 1 ;
         sh:order 4 ;
     ] ;
@@ -1091,14 +1106,16 @@
         skos:definition """Target attribute that specifies one or more sizes for the referenced icon. 
                     Only applicable for relation type \"icon\". The value pattern follows 
                     {Height}x{Width} (e.g., \"16x16\", \"16x16 32x32\")."""^^rdf:HTML ;
-        sh:nodeKind sh:IRI ;
+        #sh:nodeKind sh:IRI ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:order 5 ;
     ] ;
     sh:property [
         sh:path hctl:hasHreflang ;
         skos:definition """The hreflang attribute specifies the language of a linked document. The value of this must be a valid language tag [[BCP47]]."""^^rdf:HTML ;
-        sh:nodeKind sh:IRI ;
+        #sh:nodeKind sh:IRI ;
+        sh:datatype xsd:string ;
         sh:order 6 ;
     ] ;
     skos:scopeNote """<p class="ednote" title="hreflang type">
@@ -1283,6 +1300,7 @@
                 parameters (e.g., <code>charset=utf-8</code>) for
                 the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:minCount 1 ;
     ] .
@@ -1302,7 +1320,8 @@
                 name of a previous definition given in a 
                 <code>schemaDefinitions</code> map must be used."""^^rdf:HTML ;
         # sh:node :DataSchemaShape ;
-        sh:nodeKind sh:IRI ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
@@ -1319,6 +1338,7 @@
                 parameters (e.g., <code>charset=utf-8</code>) for
                 the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:defaultValue false ;
         sh:maxCount 1 ;
     ] .
@@ -1431,7 +1451,8 @@
     sh:order 1 ;
     sh:property [
         sh:path rdf:type ;
-        sh:nodeKind sh:IRI ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         skos:definition """Identification of the security mechanism being
@@ -1462,6 +1483,7 @@
                 corresponding security configuration is for the
                 endpoint."""^^rdf:HTML ;
         sh:nodeKind sh:IRI ;
+        sh:datatype xsd:anyURI ;
         sh:maxCount 1 ;
         sh:order 4 ;
     ] .
@@ -1518,6 +1540,7 @@
         sh:path wotsec:qop ;
         skos:definition """Quality of protection."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:in (
           "auth"
@@ -1628,6 +1651,7 @@
         sh:path wotsec:authorization ;
         skos:definition """URI of the authorization server. In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]."""^^rdf:HTML ;
         sh:nodeKind sh:IRI ;
+        sh:datatype xsd:anyURI ;
         sh:maxCount 1 ;
         sh:order 1 ;
     ] ;
@@ -1635,6 +1659,7 @@
         sh:path wotsec:token ;
         skos:definition """URI of the token server."""^^rdf:HTML ;
         sh:nodeKind sh:IRI ;
+        sh:datatype xsd:anyURI ;
         sh:maxCount 1 ;
         sh:order 2 ;
     ] ;
@@ -1642,6 +1667,7 @@
         sh:path wotsec:refresh ;
         skos:definition """URI of the refresh server."""^^rdf:HTML ;
         sh:nodeKind sh:IRI ;
+        sh:datatype xsd:anyURI ;
         sh:maxCount 1 ;
         sh:order 3 ;
     ] ;
@@ -1656,12 +1682,14 @@
                 <code>OAuth2SecurityScheme</code> active on that
                 form."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:order 4 ;
     ] ;
     sh:property [
         sh:path wotsec:flow ;
         skos:definition """Authorization flow."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         skos:example (
 #            "implicit"
@@ -1724,6 +1752,8 @@
                 with JSON Schema (one of boolean, integer, number,
                 string, object, array, or null)."""^^rdf:HTML ;
         sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:in (
             jsonschema:ObjectSchema
             jsonschema:ArraySchema
@@ -1759,6 +1789,7 @@
                 the value of the unit points to a semantic definition (also see Section <a href="#semantic-annotations-example-version-units"
           class="internalDFN" data-link-type="dfn">Semantic Annotations</a>)."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:order 8 ;
     ] ;
@@ -1801,6 +1832,7 @@
                 such as "date-time", "email", "uri", etc. (Also see
                 below.)"""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:order 13 ;
     ] ;
@@ -1982,6 +2014,7 @@
         skos:definition """Defines which members of the object type are
                 mandatory."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:order 2 ;
     ] .
 
@@ -2011,6 +2044,7 @@
         sh:path jsonschema:pattern ;
         skos:definition """Provides a regular expression to express constraints of the string value. The regular expression must follow the [[ECMA-262]] dialect."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         sh:maxCount 1 ;
         sh:order 3 ;
     ] ;
@@ -2018,6 +2052,7 @@
         sh:path jsonschema:contentEncoding ;
         skos:definition """Specifies the encoding used to store the contents, as specified in RFC 2054."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         skos:example (
            "7bit" 
            "8bit" 
@@ -2032,6 +2067,7 @@
         sh:path jsonschema:contentMediaType ;
         skos:definition """Specifies the MIME type of the contents of a string value, as described in RFC 2046."""^^rdf:HTML ;
         sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
         skos:example (
            "image/png" 
            "audio/mpeg"
@@ -2058,6 +2094,8 @@ _:title sh:path td:title ;
         skos:definition """Provides a human-readable title (e.g., display
                 a text for UI representation) based on a default
                 language."""^^rdf:HTML ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;        
         sh:maxCount 1 ;
         sh:order 1 .
 
@@ -2073,6 +2111,7 @@ _:description sh:path td:description ;
               skos:definition """Provides additional (human-readable)
                       information based on a default language."""^^rdf:HTML ;
               sh:nodeKind sh:Literal ;
+              sh:datatype xsd:string ;
               sh:maxCount 1 ;
               sh:order 3 .
 
@@ -2087,6 +2126,7 @@ _:in sh:path wotsec:in ;
      skos:definition """Specifies the location of security
             authentication information.  """^^rdf:HTML ;
      sh:nodeKind sh:Literal ;
+     sh:datatype xsd:string ;
      sh:defaultValue "header"^^xsd:string ;
      sh:maxCount 1 ;
      sh:in (
@@ -2102,6 +2142,7 @@ _:apikeyIn sh:path wotsec:in ;
      skos:definition """Specifies the location of security
             authentication information.  """^^rdf:HTML ;
      sh:nodeKind sh:Literal ;
+     sh:datatype xsd:string ;
      sh:defaultValue "header"^^xsd:string ;
      sh:maxCount 1 ;
      sh:in (
@@ -2118,6 +2159,7 @@ _:name sh:path wotsec:name ;
        skos:definition """Name for query, header, cookie, or uri
                parameters."""^^rdf:HTML ;
        sh:nodeKind sh:Literal ;
+       sh:datatype xsd:string ;
        sh:maxCount 1 ;
        sh:order 101 .
 
@@ -2130,6 +2172,7 @@ _:uriVariables sh:path wotsec:uriVariables ;
 _:authorization sh:path wotsec:authorization ;
                 skos:definition """URI of the authorization server."""^^rdf:HTML ;
                 sh:nodeKind sh:IRI ;
+                sh:datatype xsd:anyURI ;
                 sh:maxCount 1 ;
                 sh:order 1 .
 
@@ -2137,12 +2180,14 @@ _:identity sh:path wotsec:identity ;
            skos:definition """Identifier providing information which can be
                    used for selection or confirmation."""^^rdf:HTML ;
            sh:maxCount 1 ;
-           sh:nodeKind sh:Literal .
+           sh:nodeKind sh:Literal ;
+           sh:datatype xsd:string .
 
 _:format sh:path wotsec:format ;
          skos:definition """Specifies format of security authentication
                  information."""^^rdf:HTML ;
          sh:nodeKind sh:Literal ;
+         sh:datatype xsd:string ;
          sh:maxCount 1 ;
          skos:example (
            "jwt" 
@@ -2156,6 +2201,7 @@ _:format sh:path wotsec:format ;
 _:alg sh:path wotsec:alg ;
       skos:definition """Encoding, encryption, or digest algorithm."""^^rdf:HTML ;
       sh:nodeKind sh:Literal ;
+      sh:datatype xsd:string ;
       sh:maxCount 1 ;
       skos:example (
         "ES256"
@@ -2167,11 +2213,13 @@ _:alg sh:path wotsec:alg ;
 _:oneOf sh:path wotsec:oneOf ;
       skos:definition """Array of two or more strings identifying other named security scheme definitions, any one of which, when satisfied, will allow access.  Only one may be chosen for use."""^^rdf:HTML ;
       sh:nodeKind sh:Literal ;
+      sh:datatype xsd:string ;
       sh:minCount 2 ;
       sh:order 1 .
 
 _:allOf sh:path wotsec:allOf ;
       skos:definition """Array of two or more strings identifying other named security scheme definitions, all of which must be satisfied for access."""^^rdf:HTML ;
       sh:nodeKind sh:Literal ;
+      sh:datatype xsd:string ;
       sh:minCount 2 ;
       sh:order 2 .


### PR DESCRIPTION
it seems there are some mistakes defined in the validation file coming from PR #1574. This result to strange rendering behavoir in PR #1638 and #1639 (many places have "any type" defined instead of the specific datatype).

This PR should fix this issue and the render script should work correct again.