### PR TITLE
[schema] remove trailing space

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -2,7 +2,7 @@
   "title": "Thing Description",
   "version": "1.1-10-June-2022",
   "description": "JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values",
-  "$schema ": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id":"https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",
   "definitions": {
     "anyUri": {
@@ -77,7 +77,7 @@
         {
           "$comment":"New context URI with other vocabularies after it but not the old one",
           "type": "array",
-          "prefixItems": [
+          "items": [
             {
               "$ref": "#/definitions/thing-context-td-uri-v1.1"
             }

--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -77,7 +77,7 @@
         {
           "$comment":"New context URI with other vocabularies after it but not the old one",
           "type": "array",
-          "items": [
+          "prefixItems": [
             {
               "$ref": "#/definitions/thing-context-td-uri-v1.1"
             }


### PR DESCRIPTION
This was actually causing our schema to be invalid against the JSON Schema Meta Schema (a schema to validate schemas) and a popular python implementation (https://github.com/python-jsonschema/jsonschema) was not validating any TDs at all. Since we are using draft 7, the use of items is only possible with an object as a value.

This however means that we should also not allow this in our array schema? I am a bit confused since I see different behavior in different JSON Schema validators. I will check with JSON Schema community to see what can be really happening