### PR TITLE
add semantic tag definition and links to it

### DIFF
--- a/index.html
+++ b/index.html
@@ -751,7 +751,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         <dfn id="dfn-semantic-tag">Semantic Tag</dfn>
     </dt>
     <dd>
-        A JSON-LD mechanism that links object properties in a <a>Thing Descriptions</a> document to concepts in an (RDF) ontology. 
+        A JSON-LD mechanism that links definitions in a <a>Thing Descriptions</a> document to concepts in an (RDF) ontology. 
         This allows to give further context about the object property and express the domain knowledge in a standardized
         way. In a <a>Thing Descriptions</a> document, this can seen in <code>@type</code> or as prefixes to a string with the usage
         of a column (<code>:</code>).

--- a/index.html
+++ b/index.html
@@ -748,6 +748,15 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
   <dl>
     <dt>
+        <dfn id="dfn-semantic-tag">Semantic Tag</dfn>
+    </dt>
+    <dd>
+        A JSON-LD mechanism that links object properties in a <a>Thing Descriptions</a> document to concepts in an (RDF) ontology. 
+        This allows to give further context about the object property and express the domain knowledge in a standardized
+        way. In a <a>Thing Descriptions</a> document, this can seen in <code>@type</code> or as prefixes to a string with the usage
+        of a column (<code>:</code>).
+    </dd>
+    <dt>
         <dfn id="dfn-context-ext">TD Context Extension</dfn>
     </dt>
     <dd>
@@ -1178,7 +1187,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       <section><h3><code>Thing</code></h3><p>An abstraction of a physical or a virtual entity whose
           metadata and interfaces are described by a WoT Thing
           Description, whereas a virtual entity is the composition
-          of one or more Things.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing"><td><code>@context</code></td><td>JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.</td><td>mandatory</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-id--Thing"><td><code>id</code></td><td>Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI, URI with local IP address, URN, etc.).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--Thing"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
+          of one or more Things.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing"><td><code>@context</code></td><td>JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.</td><td>mandatory</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-id--Thing"><td><code>id</code></td><td>Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI, URI with local IP address, URN, etc.).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--Thing"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
                 a text for UI representation) based on a default
                 language.</td><td>mandatory</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing"><td><code>titles</code></td><td>Provides multi-language human-readable titles
@@ -1408,7 +1417,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           Thing. There are many types of potential affordances, but
           <abbr title="World Wide Web Consortium">W3C</abbr> WoT
           defines three types of Interaction Affordances:
-          Properties, Actions, and Events.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
+          Properties, Actions, and Events.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
                 a text for UI representation) based on a default
                 language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance"><td><code>titles</code></td><td>Provides multi-language human-readable titles
@@ -1598,7 +1607,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
       <!-- rendered from RDF definitions -->
       <section><h3><code>DataSchema</code></h3><p>Metadata that describes the data format used. It can
-          be used for validation.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types)</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
+          be used for validation.</p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
                 a text for UI representation) based on a default
                 language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema"><td><code>titles</code></td><td>Provides multi-language human-readable titles
@@ -1839,7 +1848,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           <span class="rfc2119-assertion" id="td-security-uri-variables-distinct">The names of URI variables 
           declared in a <code>SecurityScheme</code> 
           <em class="rfc2119" title="MUST">MUST</em> be distinct from all other URI variables 
-          declared in the TD.</span></p></p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with semantic tags (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable)
+          declared in the TD.</span></p></p><table class="def"><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable)
                       information based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
                        information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
@@ -7079,11 +7088,10 @@ instance.
       <dl><dt>Mitigation:</dt><dd>
 	      Strings sourced from TDs should be treated like any other source of external string
 	      when generating HTML: with care. 
-	      <span class="rfc2119-assertion" id="sec-inj-sanitize">
-		      Strings sourced from TDs MUST either be sanitized using a carefully vetted HTML
-	      sanitizer that disables any markup or should be inserted into an HTML template using
-	      DOM node manipulation APIs that will escape any markup.
-	      </span>
+        As a matter of policy, it is strongly suggested that 
+        strings sourced from TDs either be sanitized using a carefully vetted HTML 
+        sanitizer that disables any markup or be inserted into an HTML template using 
+        DOM node manipulation APIs that will escape any markup.
 	      It is also possible that strings sourced from TDs could be used to generate documents
 	      in other markup languages, such as MD files or XML.  
 	      Such usages should take equivalent
@@ -7194,18 +7202,14 @@ instance.
 	  The set of supported extensions can be established by a 
 	  WoT Profile [[WOT-PROFILE]], for example.
 	  <span class="rfc2119-assertion" id="security-static-context">
-          Constrained implementations SHOULD use statically managed and vetted
-          versions of their supported context extensions. 
-          </span>
+          Constrained implementations SHOULD use vetted
+          versions of their supported context extensions 
+          managed statically or as part of a secure update process.</span>
 	  <span class="rfc2119-assertion" id="security-remote-context">
           Constrained implementations SHOULD NOT follow links to remote contexts.
 	  </span>
 	  In this case the URLs are used only to identify extensions,
 	  not to fetch their definitions.
-	  <span class="rfc2119-assertion" id="security-update-contexts">
-          Supported context extensions on constrained implementations MAY be managed
-          through secure software update mechanisms.
-	  </span>
         </dd>
      </dl>
    </section>
@@ -7229,10 +7233,8 @@ instance.
           the <code>id</code> of a <a>Thing</a> should not be fixed in hardware.
           This does, however, conflict with the Linked Data ideal that
           identifiers are fixed URIs.  
-          However,
-          <span class="rfc2119-assertion" id="privacy-mutable-id-ownership">TD 
-          identifiers SHOULD be updated upon major changes in configuration
-          or reinitialization.</span>
+          However, as a matter of policy, it is strongly suggested that deployments 
+          update identifiers upon major changes in configuration or reinitialization.
           Examples of major changes in configuration include moving a Thing to a new
           local area network, assigning a new domain name,
           or unregistering the Thing from one hub and registering it with a new
@@ -7361,11 +7363,10 @@ instance.
       which can lead to additional inferences about that person.
       </p>
       <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-td-pii">
-          A Thing Description associated with a 
-	  personal device SHOULD be treated as if it contained
-	  personally identifiable information, even if this information is not explicit.
-	  </span>
+          As a matter of policy, it is strongly suggested that 
+          Thing Descriptions associated with  
+          personal devices be treated as if they contained 
+          personally identifiable information, even if this information is not explicit.
           As an example application of this principle,
           consider how to obtain user consent.  
           Consent for usage of personally identifiable data

--- a/index.template.html
+++ b/index.template.html
@@ -751,7 +751,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
         <dfn id="dfn-semantic-tag">Semantic Tag</dfn>
     </dt>
     <dd>
-        A JSON-LD mechanism that links object properties in a <a>Thing Descriptions</a> document to concepts in an (RDF) ontology. 
+        A JSON-LD mechanism that links definitions in a <a>Thing Descriptions</a> document to concepts in an (RDF) ontology. 
         This allows to give further context about the object property and express the domain knowledge in a standardized
         way. In a <a>Thing Descriptions</a> document, this can seen in <code>@type</code> or as prefixes to a string with the usage
         of a column (<code>:</code>).

--- a/index.template.html
+++ b/index.template.html
@@ -748,6 +748,15 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
   <dl>
     <dt>
+        <dfn id="dfn-semantic-tag">Semantic Tag</dfn>
+    </dt>
+    <dd>
+        A JSON-LD mechanism that links object properties in a <a>Thing Descriptions</a> document to concepts in an (RDF) ontology. 
+        This allows to give further context about the object property and express the domain knowledge in a standardized
+        way. In a <a>Thing Descriptions</a> document, this can seen in <code>@type</code> or as prefixes to a string with the usage
+        of a column (<code>:</code>).
+    </dd>
+    <dt>
         <dfn id="dfn-context-ext">TD Context Extension</dfn>
     </dt>
     <dd>

--- a/templates.sparql
+++ b/templates.sparql
@@ -71,7 +71,7 @@ template :fields(?class ?ns) {
                        "</tr>",
                        "<tr class=\"rfc2119-table-assertion\" id=\"td-vocab-at-type--Thing\">",
                        "<td><code>@type</code></td>",
-                       "<td>JSON-LD keyword to label the object with semantic tags (or types).</td>",
+                       "<td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>",
                        "<td>optional</td>",
                        "<td><a href=\"http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a> or <a>Array</a> of <a href=\"http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a></td>",
                        "</tr>",
@@ -85,7 +85,7 @@ template :fields(?class ?ns) {
             if(?class = <https://www.w3.org/2019/wot/td#InteractionAffordance>,
                 concat("<tr class=\"rfc2119-table-assertion\" id=\"td-vocab-at-type--InteractionAffordance\">",
                        "<td><code>@type</code></td>",
-                       "<td>JSON-LD keyword to label the object with semantic tags (or types).</td>",
+                       "<td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>",
                        "<td>optional</td>",
                        "<td><a href=\"http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a> or <a>Array</a> of <a href=\"http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a></td>",
                        "</tr>"
@@ -93,7 +93,7 @@ template :fields(?class ?ns) {
             if(?class = <https://www.w3.org/2019/wot/json-schema#DataSchema>,
                 concat("<tr class=\"rfc2119-table-assertion\" id=\"td-vocab-at-type--DataSchema\">",
                        "<td><code>@type</code></td>",
-                       "<td>JSON-LD keyword to label the object with semantic tags (or types)</td>",
+                       "<td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td>",
                        "<td>optional</td>",
                        "<td><a href=\"http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a> or <a>Array</a> of <a href=\"http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a></td>",
                        "</tr>"
@@ -101,7 +101,7 @@ template :fields(?class ?ns) {
             if(?class = <https://www.w3.org/2019/wot/security#SecurityScheme>,
                 concat("<tr class=\"rfc2119-table-assertion\" id=\"td-vocab-at-type--SecurityScheme\">",
                        "<td><code>@type</code></td>",
-                       "<td>JSON-LD keyword to label the object with semantic tags (or types).</td>",
+                       "<td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>",
                        "<td>optional</td>",
                        "<td><a href=\"http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a> or <a>Array</a> of <a href=\"http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string\"><code>string</code></a></td>",
                        "</tr>"


### PR DESCRIPTION
fixes #1655


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1657.html" title="Last updated on Aug 10, 2022, 3:43 PM UTC (e411468)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1657/f17b8d5...e411468.html" title="Last updated on Aug 10, 2022, 3:43 PM UTC (e411468)">Diff</a>