### PR TITLE
Make some text assertive

### DIFF
--- a/index.html
+++ b/index.html
@@ -1334,14 +1334,18 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           <p><a href="#dfn-td-processor" class="internalDFN"
           data-link-type="dfn">TD Processors</a> should be aware of
           certain special cases when processing bidirectional text.
-          They should take care to use bidi isolation when
+          <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
+          <a href="#dfn-td-processor" class="internalDFN"
+          data-link-type="dfn">TD Processors</a> SHOULD take care to use bidi isolation when
           presenting strings to users, particularly when embedding
-          in surrounding text (e.g., for Web user interface). Mixed
-          direction text can occur in any language, even when the
+          in surrounding text (e.g., for Web user interface)</span>. 
+          Mixed direction text can occur in any language, even when the
           language is properly identified.</p>
-          <p>TD producers should attempt to provide mixed direction
+          <p><span class="rfc2119-assertion" id="td-producer-mixed-direction">
+          TD producers SHOULD attempt to provide mixed direction
           strings in a way that can be displayed successfully by a
-          naive user agent. For example, if an RTL string begins
+          naive user agent. </span>
+          For example, if an RTL string begins
           with an LTR run (such as a number or a brand or trade
           name in Latin script), including an RLM character at the
           start of the string or wrapping opposite direction runs
@@ -7079,11 +7083,10 @@ instance.
       <dl><dt>Mitigation:</dt><dd>
 	      Strings sourced from TDs should be treated like any other source of external string
 	      when generating HTML: with care. 
-	      <span class="rfc2119-assertion" id="sec-inj-sanitize">
-		      Strings sourced from TDs MUST either be sanitized using a carefully vetted HTML
-	      sanitizer that disables any markup or should be inserted into an HTML template using
-	      DOM node manipulation APIs that will escape any markup.
-	      </span>
+        As a matter of policy, it is strongly suggested that 
+        strings sourced from TDs either be sanitized using a carefully vetted HTML 
+        sanitizer that disables any markup or be inserted into an HTML template using 
+        DOM node manipulation APIs that will escape any markup.
 	      It is also possible that strings sourced from TDs could be used to generate documents
 	      in other markup languages, such as MD files or XML.  
 	      Such usages should take equivalent
@@ -7194,18 +7197,14 @@ instance.
 	  The set of supported extensions can be established by a 
 	  WoT Profile [[WOT-PROFILE]], for example.
 	  <span class="rfc2119-assertion" id="security-static-context">
-          Constrained implementations SHOULD use statically managed and vetted
-          versions of their supported context extensions. 
-          </span>
+          Constrained implementations SHOULD use vetted
+          versions of their supported context extensions 
+          managed statically or as part of a secure update process.</span>
 	  <span class="rfc2119-assertion" id="security-remote-context">
           Constrained implementations SHOULD NOT follow links to remote contexts.
 	  </span>
 	  In this case the URLs are used only to identify extensions,
 	  not to fetch their definitions.
-	  <span class="rfc2119-assertion" id="security-update-contexts">
-          Supported context extensions on constrained implementations MAY be managed
-          through secure software update mechanisms.
-	  </span>
         </dd>
      </dl>
    </section>
@@ -7229,10 +7228,8 @@ instance.
           the <code>id</code> of a <a>Thing</a> should not be fixed in hardware.
           This does, however, conflict with the Linked Data ideal that
           identifiers are fixed URIs.  
-          However,
-          <span class="rfc2119-assertion" id="privacy-mutable-id-ownership">TD 
-          identifiers SHOULD be updated upon major changes in configuration
-          or reinitialization.</span>
+          However, as a matter of policy, it is strongly suggested that deployments 
+          update identifiers upon major changes in configuration or reinitialization.
           Examples of major changes in configuration include moving a Thing to a new
           local area network, assigning a new domain name,
           or unregistering the Thing from one hub and registering it with a new
@@ -7361,11 +7358,10 @@ instance.
       which can lead to additional inferences about that person.
       </p>
       <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-td-pii">
-          A Thing Description associated with a 
-	  personal device SHOULD be treated as if it contained
-	  personally identifiable information, even if this information is not explicit.
-	  </span>
+          As a matter of policy, it is strongly suggested that 
+          Thing Descriptions associated with  
+          personal devices be treated as if they contained 
+          personally identifiable information, even if this information is not explicit.
           As an example application of this principle,
           consider how to obtain user consent.  
           Consent for usage of personally identifiable data

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -281,14 +281,18 @@
           <p><a href="#dfn-td-processor" class="internalDFN"
           data-link-type="dfn">TD Processors</a> should be aware of
           certain special cases when processing bidirectional text.
-          They should take care to use bidi isolation when
+          <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
+          <a href="#dfn-td-processor" class="internalDFN"
+          data-link-type="dfn">TD Processors</a> SHOULD take care to use bidi isolation when
           presenting strings to users, particularly when embedding
-          in surrounding text (e.g., for Web user interface). Mixed
-          direction text can occur in any language, even when the
+          in surrounding text (e.g., for Web user interface)</span>. 
+          Mixed direction text can occur in any language, even when the
           language is properly identified.</p>
-          <p>TD producers should attempt to provide mixed direction
+          <p><span class="rfc2119-assertion" id="td-producer-mixed-direction">
+          TD producers SHOULD attempt to provide mixed direction
           strings in a way that can be displayed successfully by a
-          naive user agent. For example, if an RTL string begins
+          naive user agent. </span>
+          For example, if an RTL string begins
           with an LTR run (such as a number or a brand or trade
           name in Latin script), including an RLM character at the
           start of the string or wrapping opposite direction runs


### PR DESCRIPTION
fixes #1599 

This is sort of a normative change since the text that was not in an RFC span is not in an RFC span


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1659.html" title="Last updated on Aug 10, 2022, 2:50 PM UTC (540f017)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1659/f17b8d5...540f017.html" title="Last updated on Aug 10, 2022, 2:50 PM UTC (540f017)">Diff</a>