### PR TITLE
Explain uriVariable cannot contain non string-like types

### DIFF
--- a/index.html
+++ b/index.html
@@ -1241,7 +1241,8 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
                 based on DataSchema declarations. The Thing level <code>uriVariables</code> can be used in Thing-level 
                 <code>forms</code> or in Interaction Affordances.
-                The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema.
+                The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
+                to be serialized to a string inside the <code>href</code> upon the execution of the operation.
                 If the same variable is both declared in Thing-level <code>uriVariables</code> and in Interaction Affordance level,
                  the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>
               For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:
@@ -1422,7 +1423,8 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
                 how an operation can be performed. Forms are
                 serializations of Protocol Bindings.</td><td>mandatory</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
-                based on DataSchema declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema. 
+                based on DataSchema declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
+                to be serialized to a string inside the <code>href</code> upon the execution of the operation. 
                 If the same variable is both declared in Thing-level <code>uriVariables</code>and in Interaction Affordance level, 
                 the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>The class <code>InteractionAffordance</code> has the following subclasses:</p><ul><li><a href="#propertyaffordance"><code>PropertyAffordance</code></a></li>
 <li><a href="#actionaffordance"><code>ActionAffordance</code></a></li>
@@ -7079,11 +7081,10 @@ instance.
       <dl><dt>Mitigation:</dt><dd>
 	      Strings sourced from TDs should be treated like any other source of external string
 	      when generating HTML: with care. 
-	      <span class="rfc2119-assertion" id="sec-inj-sanitize">
-		      Strings sourced from TDs MUST either be sanitized using a carefully vetted HTML
-	      sanitizer that disables any markup or should be inserted into an HTML template using
-	      DOM node manipulation APIs that will escape any markup.
-	      </span>
+        As a matter of policy, it is strongly suggested that 
+        strings sourced from TDs either be sanitized using a carefully vetted HTML 
+        sanitizer that disables any markup or be inserted into an HTML template using 
+        DOM node manipulation APIs that will escape any markup.
 	      It is also possible that strings sourced from TDs could be used to generate documents
 	      in other markup languages, such as MD files or XML.  
 	      Such usages should take equivalent
@@ -7194,18 +7195,14 @@ instance.
 	  The set of supported extensions can be established by a 
 	  WoT Profile [[WOT-PROFILE]], for example.
 	  <span class="rfc2119-assertion" id="security-static-context">
-          Constrained implementations SHOULD use statically managed and vetted
-          versions of their supported context extensions. 
-          </span>
+          Constrained implementations SHOULD use vetted
+          versions of their supported context extensions 
+          managed statically or as part of a secure update process.</span>
 	  <span class="rfc2119-assertion" id="security-remote-context">
           Constrained implementations SHOULD NOT follow links to remote contexts.
 	  </span>
 	  In this case the URLs are used only to identify extensions,
 	  not to fetch their definitions.
-	  <span class="rfc2119-assertion" id="security-update-contexts">
-          Supported context extensions on constrained implementations MAY be managed
-          through secure software update mechanisms.
-	  </span>
         </dd>
      </dl>
    </section>
@@ -7229,10 +7226,8 @@ instance.
           the <code>id</code> of a <a>Thing</a> should not be fixed in hardware.
           This does, however, conflict with the Linked Data ideal that
           identifiers are fixed URIs.  
-          However,
-          <span class="rfc2119-assertion" id="privacy-mutable-id-ownership">TD 
-          identifiers SHOULD be updated upon major changes in configuration
-          or reinitialization.</span>
+          However, as a matter of policy, it is strongly suggested that deployments 
+          update identifiers upon major changes in configuration or reinitialization.
           Examples of major changes in configuration include moving a Thing to a new
           local area network, assigning a new domain name,
           or unregistering the Thing from one hub and registering it with a new
@@ -7361,11 +7356,10 @@ instance.
       which can lead to additional inferences about that person.
       </p>
       <dl><dt>Mitigation:</dt><dd>
-	  <span class="rfc2119-assertion" id="privacy-td-pii">
-          A Thing Description associated with a 
-	  personal device SHOULD be treated as if it contained
-	  personally identifiable information, even if this information is not explicit.
-	  </span>
+          As a matter of policy, it is strongly suggested that 
+          Thing Descriptions associated with  
+          personal devices be treated as if they contained 
+          personally identifiable information, even if this information is not explicit.
           As an example application of this principle,
           consider how to obtain user consent.  
           Consent for usage of personally identifiable data

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -184,7 +184,8 @@
         skos:definition """Define URI template variables according to [[RFC6570]]  as collection
                 based on DataSchema declarations. The Thing level <code>uriVariables</code> can be used in Thing-level 
                 <code>forms</code> or in Interaction Affordances.
-                The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema.
+                The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
+                to be serialized to a string inside the <code>href</code> upon the execution of the operation.
                 If the same variable is both declared in Thing-level <code>uriVariables</code> and in Interaction Affordance level,
                  the Interaction Affordance level variable takes precedence."""^^rdf:HTML ;
         sh:node :DataSchemaShape ;
@@ -377,7 +378,8 @@
     sh:property [
         sh:path td:hasUriTemplateSchema ;
         skos:definition """Define URI template variables according to [[RFC6570]]  as collection
-                based on DataSchema declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema. 
+                based on DataSchema declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
+                to be serialized to a string inside the <code>href</code> upon the execution of the operation. 
                 If the same variable is both declared in Thing-level <code>uriVariables</code>and in Interaction Affordance level, 
                 the Interaction Affordance level variable takes precedence."""^^rdf:HTML ;
         sh:node :DataSchemaShape ;


### PR DESCRIPTION
fixes #1656


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1660.html" title="Last updated on Aug 10, 2022, 2:48 PM UTC (98d5fe9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1660/f17b8d5...98d5fe9.html" title="Last updated on Aug 10, 2022, 2:48 PM UTC (98d5fe9)">Diff</a>