### PR TITLE
Fix a trailing space in the a JSON Schema's $schema

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -2,7 +2,7 @@
   "title": "Thing Description",
   "version": "1.1-10-June-2022",
   "description": "JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values",
-  "$schema ": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id":"https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",
   "definitions": {
     "anyUri": {


### PR DESCRIPTION
This was ignoring it previously! As `$schema ` is unfortunately different from `$schema`.