### PR TITLE
Remove custom RFC 9200 bibliography entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,21 +172,6 @@
                     ],
                     publisher: "W3C",
                     date: "July 2022"
-                }, 
-                "RFC9200": {
-                    "href": "https://www.rfc-editor.org/rfc/rfc9200",
-                    "title": "Authentication and Authorization for Constrained Environments (ACE) Using the OAuth 2.0 Framework (ACE-OAuth)",
-                    "authors": [
-                      "L. Seitz",
-                      "G. Selander",
-                      "E. Wahlstroem", 
-                      "S. Erdtman",
-                      "H. Tschofenig"
-                    ],
-                    "status": "Publication in process",
-                    "publisher": "IETF",
-                    "id": "rfc9200",
-                    "date": "March 2022"
                 }
             },
             otherLinks: [

--- a/index.template.html
+++ b/index.template.html
@@ -172,21 +172,6 @@
                     ],
                     publisher: "W3C",
                     date: "July 2022"
-                }, 
-                "RFC9200": {
-                    "href": "https://www.rfc-editor.org/rfc/rfc9200",
-                    "title": "Authentication and Authorization for Constrained Environments (ACE) Using the OAuth 2.0 Framework (ACE-OAuth)",
-                    "authors": [
-                      "L. Seitz",
-                      "G. Selander",
-                      "E. Wahlstroem", 
-                      "S. Erdtman",
-                      "H. Tschofenig"
-                    ],
-                    "status": "Publication in process",
-                    "publisher": "IETF",
-                    "id": "rfc9200",
-                    "date": "March 2022"
                 }
             },
             otherLinks: [


### PR DESCRIPTION
With [RFC 9200](https://www.rfc-editor.org/rfc/rfc9200.txt) finally published, this PR removes the now obsolete custom bibliography entry from the specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-thing-description/pull/1688.html" title="Last updated on Sep 1, 2022, 2:10 PM UTC (1f2795a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1688/cf94154...JKRhb:1f2795a.html" title="Last updated on Sep 1, 2022, 2:10 PM UTC (1f2795a)">Diff</a>