### PR TITLE
fix: syntax highlighting of example 4, 51, 52, 60, 61, 65, 66, and 71

### DIFF
--- a/index.html
+++ b/index.html
@@ -5620,7 +5620,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
                 <input type="checkbox">
                 <span><i>with default values for Protocol Binding based on HTTP</i></span>
             </div>
-            <pre>{
+            <pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:3a559b69-cbec-4e7b-b543-bd8e6e41fd8b",
     "title": "MyLampThing",
@@ -5668,7 +5668,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         }
     }
 }</pre>
-        <pre>{
+        <pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:3deca264-4f90-4321-a5ea-f197e6a1c7cf",
     "title": "MyLampThing",
@@ -5734,7 +5734,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
                 <input type="checkbox">
                 <span><i>extended <code>forms</code> in case of multiple values in <code>op</code></i></span>
             </div>
-            <pre>{
+            <pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:43e2081d-3fd9-41bf-803d-baaefb79c70f",
     "title": "MyLampThing",
@@ -5759,7 +5759,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         }
     }
 }</pre>
-        <pre>{
+        <pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:9cd44eef-0b3f-4566-94b0-1358af3d86bd",
     "title": "MyLampThing",
@@ -6218,7 +6218,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
          <button class="exampleTab1 Ventilation"         onclick="openTab('exampleTab1', 'Ventilation')">Ventilation TM</button>
          <button class="exampleTab1 LED"    onclick="openTab('exampleTab1', 'LED')">LED TM</button>
        </div>
-       <pre class="SmartVentilator exampleTab1 selected ">
+       <pre class="SmartVentilator exampleTab1 selected json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "@type": "tm:ThingModel",
@@ -6243,7 +6243,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
           }
        </pre>
-       <pre class="Ventilation exampleTab1">
+       <pre class="Ventilation exampleTab1 json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "@type": "tm:ThingModel",
@@ -6264,7 +6264,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
         }
        </pre>
-       <pre class="LED exampleTab1">
+       <pre class="LED exampleTab1 json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "@type": "tm:ThingModel",
@@ -6336,7 +6336,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
          <button class="exampleTab1 Ventilation"         onclick="openTab('exampleTab1', 'Ventilation')">Ventilation TD</button>
          <button class="exampleTab1 LED"    onclick="openTab('exampleTab1', 'LED')">LED TD</button>
        </div>
-       <pre class="SmartVentilator exampleTab1 selected ">
+       <pre class="SmartVentilator exampleTab1 selected json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "title": "Smart Ventilator",
@@ -6381,7 +6381,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
         }
        </pre>
-       <pre class="Ventilation exampleTab1">
+       <pre class="Ventilation exampleTab1 json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "title": "Ventilator",
@@ -6428,7 +6428,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
         }
        </pre>
-       <pre class="LED exampleTab1">
+       <pre class="LED exampleTab1 json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "title": "LED Thing Model",
@@ -6761,7 +6761,7 @@ instance.
       <button class="exampleTab1 placeholder"         onclick="openTab('exampleTab1', 'placeholder')">Placeholder Map</button>
       <button class="exampleTab1 thingdescription"    onclick="openTab('exampleTab1', 'thingdescription')">Thing Description</button>
     </div>
-    <pre class="thingmodel exampleTab1 selected ">
+    <pre class="thingmodel exampleTab1 selected json">
 {
 	"@context": ["https://www.w3.org/2022/wot/td/v1.1"], 
 	"@type" : "tm:ThingModel",
@@ -6780,7 +6780,7 @@ instance.
 	...
 }
 	</pre>
-    <pre class="placeholder exampleTab1">
+    <pre class="placeholder exampleTab1 json">
 {
 	"THERMOSTATE_NUMBER": 4, 
 	"MQTT_BROKER_ADDRESS" : "192.168.178.72:1883",
@@ -6789,7 +6789,7 @@ instance.
 	"VERSION_INFO": {"instance": "1.0.1", "model": "2.0.0"}
 }
 	</pre>
-    <pre class="thingdescription exampleTab1">
+    <pre class="thingdescription exampleTab1 json">
 {
 	"@context": ["https://www.w3.org/2022/wot/td/v1.1"], 
 	"@type" : "Thing",
@@ -6861,20 +6861,20 @@ instance.
              <button class="selected exampleTab2 thingmodel" onclick="openTab('exampleTab2', 'thingmodel')">Thing Model</button>
              <button class="exampleTab2 thingdescription"    onclick="openTab('exampleTab2', 'thingdescription')">Thing Description</button>
            </div>
-           <pre class="selected exampleTab2 thingmodel">
+           <pre class="selected exampleTab2 thingmodel json">
 {
-	...
+	// ...
 	"@type": "tm:ThingModel",
 	"title": "Smart Pump",
 	"id" : "urn:example:{{RANDOM_ID_PATTERN}}",
 	"description": "Smart Pump live plant and simulator",
 	"version" : {"model" : "1.0.0" },
-	...
+	// ...
 }
 		</pre>
-        <pre class="exampleTab2 thingdescription">
+        <pre class="exampleTab2 thingdescription json">
 {
-	...
+	// ...
 	"@type": "Thing",
 	"title": "Smart Pump",
 	"id" : "urn:example:123-321-123-321",
@@ -6885,7 +6885,7 @@ instance.
 		"href" : "http://example.com/ThingModelPool/Pump",
 		"type": "application/tm+json"
 	}],
-	...
+	// ...
 }
 		</pre>
         </aside>
@@ -7787,7 +7787,7 @@ instance.
          <button class="selected exampleTab1 without" onclick="openTab('exampleTab1', 'without')">Without uriVariables</button>
          <button class="exampleTab1 with"         onclick="openTab('exampleTab1', 'with')">With uriVariables</button>
        </div>
-       <pre class="without exampleTab1 selected ">
+       <pre class="without exampleTab1 selected json">
         {
             "@context": "http://www.w3.org/ns/td",
             "id": "urn:uuid:4778f80a-4c78-4cbb-a0e4-fa37b7d748df",
@@ -7845,7 +7845,7 @@ instance.
             }
         }
        </pre>
-       <pre class="with exampleTab1">
+       <pre class="with exampleTab1 json">
         {
             "@context": "http://www.w3.org/ns/td",
             "id": "urn:uuid:3c1b4716-247f-4cda-ba53-d3307ac6feb0",

--- a/index.html
+++ b/index.html
@@ -2893,7 +2893,7 @@ In summary, this requires the following:
       <input type="checkbox"/>
       <span><i>with Default Values</i></span>
     </div>
-<pre>{
+<pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:645ab619-19ba-4b37-9933-8f0594398245",
     "title": "MyLampThing",
@@ -2931,7 +2931,7 @@ In summary, this requires the following:
     }
 }
 </pre>
-<pre>{
+<pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:014139c9-b267-4db5-9c61-cc2d2bfc217d",
     "title": "MyLampThing",

--- a/index.template.html
+++ b/index.template.html
@@ -1617,7 +1617,7 @@ In summary, this requires the following:
       <input type="checkbox"/>
       <span><i>with Default Values</i></span>
     </div>
-<pre>{
+<pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:645ab619-19ba-4b37-9933-8f0594398245",
     "title": "MyLampThing",
@@ -1655,7 +1655,7 @@ In summary, this requires the following:
     }
 }
 </pre>
-<pre>{
+<pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:014139c9-b267-4db5-9c61-cc2d2bfc217d",
     "title": "MyLampThing",

--- a/index.template.html
+++ b/index.template.html
@@ -4344,7 +4344,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
                 <input type="checkbox">
                 <span><i>with default values for Protocol Binding based on HTTP</i></span>
             </div>
-            <pre>{
+            <pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:3a559b69-cbec-4e7b-b543-bd8e6e41fd8b",
     "title": "MyLampThing",
@@ -4392,7 +4392,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         }
     }
 }</pre>
-        <pre>{
+        <pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:3deca264-4f90-4321-a5ea-f197e6a1c7cf",
     "title": "MyLampThing",
@@ -4458,7 +4458,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
                 <input type="checkbox">
                 <span><i>extended <code>forms</code> in case of multiple values in <code>op</code></i></span>
             </div>
-            <pre>{
+            <pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:43e2081d-3fd9-41bf-803d-baaefb79c70f",
     "title": "MyLampThing",
@@ -4483,7 +4483,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         }
     }
 }</pre>
-        <pre>{
+        <pre class="json">{
     "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "id": "urn:uuid:9cd44eef-0b3f-4566-94b0-1358af3d86bd",
     "title": "MyLampThing",
@@ -4942,7 +4942,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
          <button class="exampleTab1 Ventilation"         onclick="openTab('exampleTab1', 'Ventilation')">Ventilation TM</button>
          <button class="exampleTab1 LED"    onclick="openTab('exampleTab1', 'LED')">LED TM</button>
        </div>
-       <pre class="SmartVentilator exampleTab1 selected ">
+       <pre class="SmartVentilator exampleTab1 selected json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "@type": "tm:ThingModel",
@@ -4967,7 +4967,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
           }
        </pre>
-       <pre class="Ventilation exampleTab1">
+       <pre class="Ventilation exampleTab1 json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "@type": "tm:ThingModel",
@@ -4988,7 +4988,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
         }
        </pre>
-       <pre class="LED exampleTab1">
+       <pre class="LED exampleTab1 json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "@type": "tm:ThingModel",
@@ -5060,7 +5060,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
          <button class="exampleTab1 Ventilation"         onclick="openTab('exampleTab1', 'Ventilation')">Ventilation TD</button>
          <button class="exampleTab1 LED"    onclick="openTab('exampleTab1', 'LED')">LED TD</button>
        </div>
-       <pre class="SmartVentilator exampleTab1 selected ">
+       <pre class="SmartVentilator exampleTab1 selected json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "title": "Smart Ventilator",
@@ -5105,7 +5105,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
         }
        </pre>
-       <pre class="Ventilation exampleTab1">
+       <pre class="Ventilation exampleTab1 json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "title": "Ventilator",
@@ -5152,7 +5152,7 @@ provides <code>dimmable</code> and <code>RGB</code> capabilities.
             }
         }
        </pre>
-       <pre class="LED exampleTab1">
+       <pre class="LED exampleTab1 json">
         {
             "@context": "https://www.w3.org/2022/wot/td/v1.1",
             "title": "LED Thing Model",
@@ -5485,7 +5485,7 @@ instance.
       <button class="exampleTab1 placeholder"         onclick="openTab('exampleTab1', 'placeholder')">Placeholder Map</button>
       <button class="exampleTab1 thingdescription"    onclick="openTab('exampleTab1', 'thingdescription')">Thing Description</button>
     </div>
-    <pre class="thingmodel exampleTab1 selected ">
+    <pre class="thingmodel exampleTab1 selected json">
 {
 	"@context": ["https://www.w3.org/2022/wot/td/v1.1"], 
 	"@type" : "tm:ThingModel",
@@ -5504,7 +5504,7 @@ instance.
 	...
 }
 	</pre>
-    <pre class="placeholder exampleTab1">
+    <pre class="placeholder exampleTab1 json">
 {
 	"THERMOSTATE_NUMBER": 4, 
 	"MQTT_BROKER_ADDRESS" : "192.168.178.72:1883",
@@ -5513,7 +5513,7 @@ instance.
 	"VERSION_INFO": {"instance": "1.0.1", "model": "2.0.0"}
 }
 	</pre>
-    <pre class="thingdescription exampleTab1">
+    <pre class="thingdescription exampleTab1 json">
 {
 	"@context": ["https://www.w3.org/2022/wot/td/v1.1"], 
 	"@type" : "Thing",
@@ -5585,20 +5585,20 @@ instance.
              <button class="selected exampleTab2 thingmodel" onclick="openTab('exampleTab2', 'thingmodel')">Thing Model</button>
              <button class="exampleTab2 thingdescription"    onclick="openTab('exampleTab2', 'thingdescription')">Thing Description</button>
            </div>
-           <pre class="selected exampleTab2 thingmodel">
+           <pre class="selected exampleTab2 thingmodel json">
 {
-	...
+	// ...
 	"@type": "tm:ThingModel",
 	"title": "Smart Pump",
 	"id" : "urn:example:{{RANDOM_ID_PATTERN}}",
 	"description": "Smart Pump live plant and simulator",
 	"version" : {"model" : "1.0.0" },
-	...
+	// ...
 }
 		</pre>
-        <pre class="exampleTab2 thingdescription">
+        <pre class="exampleTab2 thingdescription json">
 {
-	...
+	// ...
 	"@type": "Thing",
 	"title": "Smart Pump",
 	"id" : "urn:example:123-321-123-321",
@@ -5609,7 +5609,7 @@ instance.
 		"href" : "http://example.com/ThingModelPool/Pump",
 		"type": "application/tm+json"
 	}],
-	...
+	// ...
 }
 		</pre>
         </aside>
@@ -6509,7 +6509,7 @@ instance.
          <button class="selected exampleTab1 without" onclick="openTab('exampleTab1', 'without')">Without uriVariables</button>
          <button class="exampleTab1 with"         onclick="openTab('exampleTab1', 'with')">With uriVariables</button>
        </div>
-       <pre class="without exampleTab1 selected ">
+       <pre class="without exampleTab1 selected json">
         {
             "@context": "http://www.w3.org/ns/td",
             "id": "urn:uuid:4778f80a-4c78-4cbb-a0e4-fa37b7d748df",
@@ -6567,7 +6567,7 @@ instance.
             }
         }
        </pre>
-       <pre class="with exampleTab1">
+       <pre class="with exampleTab1 json">
         {
             "@context": "http://www.w3.org/ns/td",
             "id": "urn:uuid:3c1b4716-247f-4cda-ba53-d3307ac6feb0",


### PR DESCRIPTION
see https://www.w3.org/TR/wot-thing-description11/#example-4


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1700.html" title="Last updated on Oct 5, 2022, 8:00 AM UTC (c608e71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1700/55cd7fd...danielpeintner:c608e71.html" title="Last updated on Oct 5, 2022, 8:00 AM UTC (c608e71)">Diff</a>