### PR TITLE
Enumerate At-Risk Items

### DIFF
--- a/index.html
+++ b/index.html
@@ -434,6 +434,27 @@ a[href].internalDFN {
       <li>A <a href="#td-writeall-consumer">behavioral assertion</a> for <code>writeallproperties</code> that allows rejection of incomplete writes.</li>
     </ul>
 -->
+    <p>At the time of CR transition, due to insufficient implementation
+    experience the following features are at risk:</p>
+    <ul>
+    <li><a href="#sec-body-name-json-pointer">Indicating location of security information in body of payload using JSON pointers.</a></li>
+    <li><a href="#td-security-in-uri-variable">Indicating location of security information using URI template.</a></li>
+    <li><a href="#td-ns-multilanguage-content-negotiation">Multilanguage content negotiation.</a></li>
+    <li><a href="#td-processor-bidi-isolation">TD Processor bidi isolation.</a></li>
+    <li><a href="#td-producer-mixed-direction">TD Producer mixed direction scripts.</a></li>
+    <li><a href="#td-text-direction-first-strong">Text direction inferencing.</a></li>
+    <li><a href="#td-security-oauth2-client-flow">Support for OAuth2 client flow.</a></li>
+    <li><a href="#td-security-oauth2-device-flow">Support for OAuth2 device flow.</a></li>
+    <li><a href="#td-vocab-op--Form_queryallactions">Support for <code>queryallactions</code> operation.</a></li>
+    </ul>
+    <p>In addition, a number of assertions in the Privacy Considerations 
+    and Security Considerations sections are at risk.  These represent best
+    practices but often relate to deployment policy rather than implementations
+    and in some cases are difficult to validate.  The intention is to complete
+    as many of these as possible by PR; those that cannot be validated but
+    that represent best-practice recommendations will be converted into
+    informative statements.</p>
+    <p class="at-risk">At-risk assertions are marked with yellow highlighting.</span></p>
   </section>
 
   <section id="introduction" class="informative">
@@ -6876,7 +6897,7 @@ instance.
 	"title": "Smart Pump",
 	"id": "urn:example:123-321-123-321",
 	"description": "Smart Pump live plant and simulator",
-	"version": {"instance": "1.0.0", "model": "1.0.0" },
+	"version" : {"instance": "1.0.0", "model": "1.0.0" },
 	"links" : [{
 		"rel": "type",
 		"href": "http://example.com/ThingModelPool/Pump",
@@ -6960,6 +6981,12 @@ instance.
 
 <section id="sec-security-consideration">
   <h4>Security Considerations</h4>
+        <p class="at-risk">Several assertions in the following are at risk, as indicated
+        by yellow highlighting.  These represent best practices but at the
+        time of CR transition have insufficient implementation experience.
+        These will be converted to informative statements if sufficient
+        implementation experience is not obtained by time of PR transition.
+        </p>
   <p>
   In general the security measures taken to protect a WoT 
   system will depend on the threats and attackers that system
@@ -7197,6 +7224,12 @@ instance.
 </section>
 <section id="sec-privacy-consideration">
   <h4>Privacy Considerations</h4>
+        <p class="at-risk">Several assertions in the following are at risk, as indicated
+        by yellow highlighting.  These represent best practices but at the
+        time of CR transition have insufficient implementation experience.
+        These will be converted to informative statements if sufficient
+        implementation experience is not obtained by time of PR transition.
+        </p>
   <p>
   Privacy risks will depend on the association of 
   Things with identifiable people and both the direct information and 

--- a/index.template.html
+++ b/index.template.html
@@ -434,6 +434,27 @@ a[href].internalDFN {
       <li>A <a href="#td-writeall-consumer">behavioral assertion</a> for <code>writeallproperties</code> that allows rejection of incomplete writes.</li>
     </ul>
 -->
+    <p>At the time of CR transition, due to insufficient implementation
+    experience the following features are at risk:</p>
+    <ul>
+    <li><a href="#sec-body-name-json-pointer">Indicating location of security information in body of payload using JSON pointers.</a></li>
+    <li><a href="#td-security-in-uri-variable">Indicating location of security information using URI template.</a></li>
+    <li><a href="#td-ns-multilanguage-content-negotiation">Multilanguage content negotiation.</a></li>
+    <li><a href="#td-processor-bidi-isolation">TD Processor bidi isolation.</a></li>
+    <li><a href="#td-producer-mixed-direction">TD Producer mixed direction scripts.</a></li>
+    <li><a href="#td-text-direction-first-strong">Text direction inferencing.</a></li>
+    <li><a href="#td-security-oauth2-client-flow">Support for OAuth2 client flow.</a></li>
+    <li><a href="#td-security-oauth2-device-flow">Support for OAuth2 device flow.</a></li>
+    <li><a href="#td-vocab-op--Form_queryallactions">Support for <code>queryallactions</code> operation.</a></li>
+    </ul>
+    <p>In addition, a number of assertions in the Privacy Considerations 
+    and Security Considerations sections are at risk.  These represent best
+    practices but often relate to deployment policy rather than implementations
+    and in some cases are difficult to validate.  The intention is to complete
+    as many of these as possible by PR; those that cannot be validated but
+    that represent best-practice recommendations will be converted into
+    informative statements.</p>
+    <p class="at-risk">At-risk assertions are marked with yellow highlighting.</span></p>
   </section>
 
   <section id="introduction" class="informative">
@@ -5684,6 +5705,12 @@ instance.
 
 <section id="sec-security-consideration">
   <h4>Security Considerations</h4>
+        <p class="at-risk">Several assertions in the following are at risk, as indicated
+        by yellow highlighting.  These represent best practices but at the
+        time of CR transition have insufficient implementation experience.
+        These will be converted to informative statements if sufficient
+        implementation experience is not obtained by time of PR transition.
+        </p>
   <p>
   In general the security measures taken to protect a WoT 
   system will depend on the threats and attackers that system
@@ -5921,6 +5948,12 @@ instance.
 </section>
 <section id="sec-privacy-consideration">
   <h4>Privacy Considerations</h4>
+        <p class="at-risk">Several assertions in the following are at risk, as indicated
+        by yellow highlighting.  These represent best practices but at the
+        time of CR transition have insufficient implementation experience.
+        These will be converted to informative statements if sufficient
+        implementation experience is not obtained by time of PR transition.
+        </p>
   <p>
   Privacy risks will depend on the association of 
   Things with identifiable people and both the direct information and 


### PR DESCRIPTION
- Add content to sotd to explicitly list at-risk items (linking to assertions representing each feature)
- The set of at-risk features is not based on the atrisk.csv in the current repo, but on the [pending PR updating the atrisk items with the latest results](https://github.com/w3c/wot-thing-description/pull/1725)
- Since many of the at-risk assertions are bunched up in the S&P Considerations sections, mention in opening paras of these sections how these will be dealt with if not completed by PR (will be converted to informative statements, not deleted)
- This text is consistent to what I am also proposing for Discovery and Architecture
- I have put this into the "main" top-level index file due to other pending PRs, to avoid having to re-sync a copy in publication/ver11.  Note that for Architecture and Discovery though I only added this to the CR version.  We can delete these comments after the copy for the CR transition is taken from the top-level version if necessary.