### PR TITLE
use proper Architecture 1.1 reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,7 +463,7 @@ a[href].internalDFN {
   Events (<a href="#eventaffordance"><code>EventAffordance</code></a> class) are used
   for the push model of communication where notifications,
   discrete events, or streams of values are sent asynchronously to the receiver.
-  See [[?WOT-ARCHITECTURE]] for details.
+  See [[wot-architecture11]] for details.
   </p>
   <p>
   In general, the TD provides metadata for different <a>Protocol Bindings</a>
@@ -724,7 +724,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
   <dfn>WoT Interface</dfn>, and
   <dfn>WoT Runtime</dfn>
   are defined in <a href="https://www.w3.org/TR/wot-architecture/#terminology">Section 3</a>
-  of the WoT Architecture specification [[?WOT-ARCHITECTURE]].
+  of the WoT Architecture specification [[wot-architecture11]].
   </p>
 
   <p>
@@ -914,7 +914,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             <li>
                 the <em>core</em> TD <a>Vocabulary</a>, which reflects the
                 <a>Interaction Model</a> with the <a>Properties</a>, <a>Actions</a>, and <a>Events</a>
-                <a>Interaction Affordances</a> [[?WOT-ARCHITECTURE]]
+                <a>Interaction Affordances</a> [[wot-architecture11]]
             </li>
             <li>
                 the <em>Data Schema</em> <a>Vocabulary</a>, including (a subset of)
@@ -2257,8 +2257,8 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           includes the well-known types necessary to implement the
           WoT interaction model described in [<cite><a class=
           "bibref" data-link-type="biblio" href=
-          "#bib-wot-architecture" title=
-          "Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>].
+          "#bib-wot-architecture11" title=
+          "Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>].
           Future versions of the standard may extend this list but
           <span class="rfc2119-assertion" id=
           "well-known-operation-types-only">operations types
@@ -5511,7 +5511,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
   <p>
     Every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>. 
-    The URI scheme [[!RFC3986]] of this submission target indicates what <a>Protocol Binding</a> the <a>Thing</a> implements [[?WOT-ARCHITECTURE]].
+    The URI scheme [[!RFC3986]] of this submission target indicates what <a>Protocol Binding</a> the <a>Thing</a> implements [[wot-architecture11]].
     For instance, if the target starts with <code>http</code> or
     <code>https</code>, a <a>Consumer</a> can then infer the <a>Thing</a> implements the
     <a>Protocol Binding</a> based on HTTP and it should expect HTTP-specific terms in the

--- a/index.template.html
+++ b/index.template.html
@@ -463,7 +463,7 @@ a[href].internalDFN {
   Events (<a href="#eventaffordance"><code>EventAffordance</code></a> class) are used
   for the push model of communication where notifications,
   discrete events, or streams of values are sent asynchronously to the receiver.
-  See [[?WOT-ARCHITECTURE]] for details.
+  See [[wot-architecture11]] for details.
   </p>
   <p>
   In general, the TD provides metadata for different <a>Protocol Bindings</a>
@@ -724,7 +724,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
   <dfn>WoT Interface</dfn>, and
   <dfn>WoT Runtime</dfn>
   are defined in <a href="https://www.w3.org/TR/wot-architecture/#terminology">Section 3</a>
-  of the WoT Architecture specification [[?WOT-ARCHITECTURE]].
+  of the WoT Architecture specification [[wot-architecture11]].
   </p>
 
   <p>
@@ -914,7 +914,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             <li>
                 the <em>core</em> TD <a>Vocabulary</a>, which reflects the
                 <a>Interaction Model</a> with the <a>Properties</a>, <a>Actions</a>, and <a>Events</a>
-                <a>Interaction Affordances</a> [[?WOT-ARCHITECTURE]]
+                <a>Interaction Affordances</a> [[wot-architecture11]]
             </li>
             <li>
                 the <em>Data Schema</em> <a>Vocabulary</a>, including (a subset of)
@@ -4235,7 +4235,7 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
 
   <p>
     Every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>. 
-    The URI scheme [[!RFC3986]] of this submission target indicates what <a>Protocol Binding</a> the <a>Thing</a> implements [[?WOT-ARCHITECTURE]].
+    The URI scheme [[!RFC3986]] of this submission target indicates what <a>Protocol Binding</a> the <a>Thing</a> implements [[wot-architecture11]].
     For instance, if the target starts with <code>http</code> or
     <code>https</code>, a <a>Consumer</a> can then infer the <a>Thing</a> implements the
     <a>Protocol Binding</a> based on HTTP and it should expect HTTP-specific terms in the

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -762,8 +762,8 @@
           includes the well-known types necessary to implement the
           WoT interaction model described in [<cite><a class=
           "bibref" data-link-type="biblio" href=
-          "#bib-wot-architecture" title=
-          "Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>].
+          "#bib-wot-architecture11" title=
+          "Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>].
           Future versions of the standard may extend this list but
           <span class="rfc2119-assertion" id=
           "well-known-operation-types-only">operations types


### PR DESCRIPTION
fixes https://github.com/w3c/wot-thing-description/issues/1723

Question: can/shall we link to Architecture 1.1 OR Architecture 1.0 ?

Note: WoT Discovery is linked from editor note. Hence I think "why" it is under informative references..


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1727.html" title="Last updated on Oct 19, 2022, 2:12 PM UTC (d19b284)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1727/57bf285...danielpeintner:d19b284.html" title="Last updated on Oct 19, 2022, 2:12 PM UTC (d19b284)">Diff</a>