### PR TITLE
CR exit criteria

### DIFF
--- a/publication/ver11/5-cr/Overview.html
+++ b/publication/ver11/5-cr/Overview.html
@@ -639,8 +639,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       ]
     }
   ],
-  "publishISODate": "2022-10-21T00:00:00.000Z",
-  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 21 October 2022"
+  "publishISODate": "2022-11-01T00:00:00.000Z",
+  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 01 November 2022"
 }
 </script>
 <link rel="stylesheet" href=
@@ -657,13 +657,13 @@ src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width=
 <p id="w3c-state"><a href=
 "https://www.w3.org/standards/types#CR">W3C Candidate
 Recommendation Snapshot</a> <time class="dt-published" datetime=
-"2022-10-21">21 October 2022</time></p>
+"2022-11-01">01 November 2022</time></p>
 <details open="">
 <summary>More details about this document</summary>
 <dl>
 <dt>This version:</dt>
 <dd><a class="u-url" href=
-"https://www.w3.org/TR/2022/CR-wot-thing-description11-20221021/">https://www.w3.org/TR/2022/CR-wot-thing-description11-20221021/</a></dd>
+"https://www.w3.org/TR/2022/CR-wot-thing-description11-20221101/">https://www.w3.org/TR/2022/CR-wot-thing-description11-20221101/</a></dd>
 <dt>Latest published version:</dt>
 <dd><a href=
 "https://www.w3.org/TR/wot-thing-description11/">https://www.w3.org/TR/wot-thing-description11/</a></dd>
@@ -846,6 +846,14 @@ best-practice recommendations will be converted into informative
 statements.</p>
 <p class="at-risk">At-risk assertions are marked with yellow
 highlighting.</p>
+<p>The Web of Things Working Group intends to submit this document
+for consideration as a <abbr title=
+"World Wide Web Consortium">W3C</abbr> Proposed Recommendation on
+Jan 11, 2023, as long as there are no formal objections. However,
+before PR transition is requested, any features or assertions
+currently marked as at-risk that do not have at least two
+implementations at that time will either be removed or converted
+into informative statements, as appropriate.</p>
 <p>This document was published by the <a href=
 "https://www.w3.org/groups/wg/wot">Web of Things Working Group</a>
 as a Candidate Recommendation Snapshot using the <a href=
@@ -13357,33 +13365,37 @@ Changes from Fourth Public Working Draft 3 August 2022</h3>
 <a class="self-link" href="#changes-from-august-2022" aria-label=
 "Permalink for Appendix D.1"></a></div>
 <ul>
-       <li>
-            Status of the document Section: add list of at-risk features
-        </li>
-        <li>
-            All TD examples: fix highlighting problems and improve formatting
-        </li>
-		<li>
-			add security scheme auto, provide definition what "satisfying" a securityDefinition means and new wording of assertion (td-security-no-secrets) in Section <a href="#securityscheme"></a>
-		</li>
-		<li>
-			Section <a href="#form-additionalResponses"></a> has been newly added.
-		</li>
-        <li>
-            Remove TD Context Extensions CoAP example in Section <a href="#adding-protocol-bindings"></a>
-        </li>
-        <li>
-            Remove reference to Binding Document in assertion (bindings-requirements-scheme) in Section <a href="#protocol-bindings"></a>
-        </li>
-		<li>
-			Chapter <a href="#thing-model"></a> moved before <a href="#sec-security-consideration"></a> and <a href="#sec-privacy-consideration"></a>
-		</li>
-		<li>
-			The term <code>tm:required</code> changed to <a href="#thing-model-td-optional"></a>
-		</li>
-        <li>
-            Section <a href="#content-format-section"></a>: add CoAP Content-Format ID for Thing Model
-        </li>
+<li>Status of the document Section: add list of at-risk
+features</li>
+<li>All TD examples: fix highlighting problems and improve
+formatting</li>
+<li>add security scheme auto, provide definition what "satisfying"
+a securityDefinition means and new wording of assertion
+(td-security-no-secrets) in Section <a href="#securityscheme"
+class="sec-ref"><bdi class="secno">5.3.3.1</bdi>
+<code>SecurityScheme</code></a></li>
+<li>Section <a href="#form-additionalResponses" class=
+"sec-ref"><bdi class="secno">6.3.9.4</bdi>
+<code>additionalResponses</code></a> has been newly added.</li>
+<li>Remove TD Context Extensions CoAP example in Section <a href=
+"#adding-protocol-bindings" class="sec-ref"><bdi class=
+"secno">7.2</bdi> Adding Protocol Bindings</a></li>
+<li>Remove reference to Binding Document in assertion
+(bindings-requirements-scheme) in Section <a href=
+"#protocol-bindings" class="sec-ref"><bdi class="secno">8.3</bdi>
+Protocol Bindings</a></li>
+<li>Chapter <a href="#thing-model" class="sec-ref"><bdi class=
+"secno">9.</bdi> Thing Model</a> moved before <a href=
+"#sec-security-consideration" class="sec-ref"><bdi class=
+"secno">10.</bdi> Security Considerations</a> and <a href=
+"#sec-privacy-consideration" class="sec-ref"><bdi class=
+"secno">11.</bdi> Privacy Considerations</a></li>
+<li>The term <code>tm:required</code> changed to <a href=
+"#thing-model-td-optional" class="sec-ref"><bdi class=
+"secno">9.3.4</bdi> tm:optional</a></li>
+<li>Section <a href="#content-format-section" class=
+"sec-ref"><bdi class="secno">12.3</bdi> CoAP Content-Format
+Registration</a>: add CoAP Content-Format ID for Thing Model</li>
 </ul>
 </section>
 <section id=
@@ -13746,7 +13758,7 @@ Normative references</h3>
 <dd><a href="https://www.w3.org/TR/appmanifest/"><cite>Web
 Application Manifest</cite></a>. Marcos Caceres; Kenneth
 Christiansen; Matt Giuca; Aaron Gustafson; Daniel Murphy; Anssi
-Kostiainen. W3C. 17 February 2022. W3C Working Draft. URL: <a href=
+Kostiainen. W3C. 31 October 2022. W3C Working Draft. URL: <a href=
 "https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a></dd>
 <dt id="bib-bcp47">[BCP47]</dt>
 <dd><a href="https://www.rfc-editor.org/rfc/rfc5646"><cite>Tags for

--- a/publication/ver11/5-cr/Overview.html
+++ b/publication/ver11/5-cr/Overview.html
@@ -833,12 +833,38 @@ and <a href=
 "#td-security-oauth2-client-flow-no-auth">td-security-oauth2-client-flow-no-auth</a>.</li>
 <li>Support for OAuth2 device flow. <a href=
 "#td-security-oauth2-device-flow">td-security-oauth2-device-flow</a>.</li>
+<li>Use of extensions for security vocabulary. <a href=
+"#td-security-extension">td-security-extension</a>.</li>
 <li>Support for <code>queryallactions</code> operation. <a href=
 "#td-vocab-op--Form">td-vocab-op--Form_queryallactions</a>.</li>
+<li>Thing Model references and versioning. <a href=
+"#tm-tmRef1">tm-tmRef1</a>, <a href="#tm-tmRef2">tm-tmRef2</a>,
+<a href="#tm-versioning-1">tm-versioning-1</a>, and <a href=
+"#tm-derivation-validity">tm-derivation-validity</a>.</li>
 </ul>
 <p>In addition, a number of assertions in the Privacy
-Considerations and Security Considerations sections are at risk.
-These represent best practices but often relate to deployment
+Considerations and Security Considerations sections are at
+risk:</p>
+<ul>
+<li><a href=
+"#privacy-immutable-id-as-property">privacy-immutable-id-as-property</a></li>
+<li><a href=
+"#privacy-temp-id-metadata">privacy-temp-id-metadata</a></li>
+<li><a href=
+"#security-context-secure-fetch">security-context-secure-fetch</a></li>
+<li><a href=
+"#security-jsonld-expansion">security-jsonld-expansion</a></li>
+<li><a href=
+"#security-mutual-auth-td">security-mutual-auth-td</a></li>
+<li><a href="#security-oauth-limits">security-oauth-limits</a></li>
+<li><a href=
+"#security-remote-context">security-remote-context</a></li>
+<li><a href=
+"#security-server-auth-td">security-server-auth-td</a></li>
+<li><a href=
+"#security-static-context">security-static-context</a></li>
+</ul>
+<p>These represent best practices but often relate to deployment
 policy rather than implementations and in some cases are difficult
 to validate. The intention is to complete as many of these as
 possible by PR; those that cannot be validated but that represent

--- a/publication/ver11/5-cr/Overview.html
+++ b/publication/ver11/5-cr/Overview.html
@@ -639,8 +639,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       ]
     }
   ],
-  "publishISODate": "2022-11-01T00:00:00.000Z",
-  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 01 November 2022"
+  "publishISODate": "2022-11-02T00:00:00.000Z",
+  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 02 November 2022"
 }
 </script>
 <link rel="stylesheet" href=
@@ -657,13 +657,13 @@ src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width=
 <p id="w3c-state"><a href=
 "https://www.w3.org/standards/types#CR">W3C Candidate
 Recommendation Snapshot</a> <time class="dt-published" datetime=
-"2022-11-01">01 November 2022</time></p>
+"2022-11-02">02 November 2022</time></p>
 <details open="">
 <summary>More details about this document</summary>
 <dl>
 <dt>This version:</dt>
 <dd><a class="u-url" href=
-"https://www.w3.org/TR/2022/CR-wot-thing-description11-20221101/">https://www.w3.org/TR/2022/CR-wot-thing-description11-20221101/</a></dd>
+"https://www.w3.org/TR/2022/CR-wot-thing-description11-20221102/">https://www.w3.org/TR/2022/CR-wot-thing-description11-20221102/</a></dd>
 <dt>Latest published version:</dt>
 <dd><a href=
 "https://www.w3.org/TR/wot-thing-description11/">https://www.w3.org/TR/wot-thing-description11/</a></dd>
@@ -874,12 +874,13 @@ statements.</p>
 highlighting.</p>
 <p>The Web of Things Working Group intends to submit this document
 for consideration as a <abbr title=
-"World Wide Web Consortium">W3C</abbr> Proposed Recommendation on
-Jan 11, 2023, as long as there are no formal objections. However,
+"World Wide Web Consortium">W3C</abbr> Proposed Recommendation
+after at least the minimum CR review period has passed. However,
 before PR transition is requested, any features or assertions
-currently marked as at-risk that do not have at least two
-implementations at that time will either be removed or converted
-into informative statements, as appropriate.</p>
+currently marked as at-risk that did not appear in the TD 1.0
+specification and do not have at least two implementations at that
+time will either be removed or converted into informative
+statements, as appropriate.</p>
 <p>This document was published by the <a href=
 "https://www.w3.org/groups/wg/wot">Web of Things Working Group</a>
 as a Candidate Recommendation Snapshot using the <a href=

--- a/publication/ver11/5-cr/index.html
+++ b/publication/ver11/5-cr/index.html
@@ -577,12 +577,35 @@ a[href].internalDFN {
     <li>Support for OAuth2 device flow.
         <a href="#td-security-oauth2-device-flow">td-security-oauth2-device-flow</a>.
     </li>
+    <li>Use of extensions for security vocabulary.
+        <a href="#td-security-extension">td-security-extension</a>.
+    </li>
     <li>Support for <code>queryallactions</code> operation.
         <a href="#td-vocab-op--Form">td-vocab-op--Form_queryallactions</a>.
     </li>
+    <li>Thing Model references and versioning.
+        <a href="#tm-tmRef1">tm-tmRef1</a>,
+        <a href="#tm-tmRef2">tm-tmRef2</a>,
+        <a href="#tm-versioning-1">tm-versioning-1</a>, and
+        <a href="#tm-derivation-validity">tm-derivation-validity</a>.
+    </li>
     </ul>
     <p>In addition, a number of assertions in the Privacy Considerations 
-    and Security Considerations sections are at risk.  These represent best
+    and Security Considerations sections are at risk:
+    </p>
+<ul>
+<li><a href="#privacy-immutable-id-as-property">privacy-immutable-id-as-property</a></li>
+<li><a href="#privacy-temp-id-metadata">privacy-temp-id-metadata</a></li>
+<li><a href="#security-context-secure-fetch">security-context-secure-fetch</a></li>
+<li><a href="#security-jsonld-expansion">security-jsonld-expansion</a></li>
+<li><a href="#security-mutual-auth-td">security-mutual-auth-td</a></li>
+<li><a href="#security-oauth-limits">security-oauth-limits</a></li>
+<li><a href="#security-remote-context">security-remote-context</a></li>
+<li><a href="#security-server-auth-td">security-server-auth-td</a></li>
+<li><a href="#security-static-context">security-static-context</a></li>
+</ul>
+    <p>
+    These represent best
     practices but often relate to deployment policy rather than implementations
     and in some cases are difficult to validate.  The intention is to complete
     as many of these as possible by PR; those that cannot be validated but

--- a/publication/ver11/5-cr/index.html
+++ b/publication/ver11/5-cr/index.html
@@ -614,10 +614,11 @@ a[href].internalDFN {
     <p class="at-risk">At-risk assertions are marked with yellow highlighting.</span></p>
     <p>
     The Web of Things Working Group intends to submit this document for
-    consideration as a W3C Proposed Recommendation on Jan 11, 2023,
-    as long as there are no formal objections.
+    consideration as a W3C Proposed Recommendation after at least the
+    minimum CR review period has passed.
     However, before PR transition is requested,
-    any features or assertions currently marked as at-risk that do not
+    any features or assertions currently marked as at-risk that did not
+    appear in the TD 1.0 specification and do not
     have at least two implementations at that time will either be
     removed or converted into informative statements, as appropriate.
     </p>

--- a/publication/ver11/5-cr/index.html
+++ b/publication/ver11/5-cr/index.html
@@ -589,6 +589,15 @@ a[href].internalDFN {
     that represent best-practice recommendations will be converted into
     informative statements.</p>
     <p class="at-risk">At-risk assertions are marked with yellow highlighting.</span></p>
+    <p>
+    The Web of Things Working Group intends to submit this document for
+    consideration as a W3C Proposed Recommendation on Jan 11, 2023,
+    as long as there are no formal objections.
+    However, before PR transition is requested,
+    any features or assertions currently marked as at-risk that do not
+    have at least two implementations at that time will either be
+    removed or converted into informative statements, as appropriate.
+    </p>
   </section>
 
   <section id="introduction" class="informative">

--- a/publication/ver11/5-cr/static.html
+++ b/publication/ver11/5-cr/static.html
@@ -657,20 +657,20 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       ]
     }
   ],
-  "publishISODate": "2022-11-01T00:00:00.000Z",
-  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 01 November 2022"
+  "publishISODate": "2022-11-02T00:00:00.000Z",
+  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 02 November 2022"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-CR"></head>
 <body class="h-entry toc-inline" data-cite="i18n-glossary"><div class="head">
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">Web of Things (WoT) Thing Description 1.1</h1> 
-    <p id="w3c-state"><a href="https://www.w3.org/standards/types#CR">W3C Candidate Recommendation Snapshot</a> <time class="dt-published" datetime="2022-11-01">01 November 2022</time></p>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#CR">W3C Candidate Recommendation Snapshot</a> <time class="dt-published" datetime="2022-11-02">02 November 2022</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
         <dt>This version:</dt><dd>
-                <a class="u-url" href="https://www.w3.org/TR/2022/CR-wot-thing-description11-20221101/">https://www.w3.org/TR/2022/CR-wot-thing-description11-20221101/</a>
+                <a class="u-url" href="https://www.w3.org/TR/2022/CR-wot-thing-description11-20221102/">https://www.w3.org/TR/2022/CR-wot-thing-description11-20221102/</a>
               </dd>
         <dt>Latest published version:</dt><dd>
                 <a href="https://www.w3.org/TR/wot-thing-description11/">https://www.w3.org/TR/wot-thing-description11/</a>
@@ -848,10 +848,11 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <p class="at-risk">At-risk assertions are marked with yellow highlighting.</p>
     <p>
     The Web of Things Working Group intends to submit this document for
-    consideration as a <abbr title="World Wide Web Consortium">W3C</abbr> Proposed Recommendation on Jan 11, 2023,
-    as long as there are no formal objections.
+    consideration as a <abbr title="World Wide Web Consortium">W3C</abbr> Proposed Recommendation after at least the
+    minimum CR review period has passed.
     However, before PR transition is requested,
-    any features or assertions currently marked as at-risk that do not
+    any features or assertions currently marked as at-risk that did not
+    appear in the TD 1.0 specification and do not
     have at least two implementations at that time will either be
     removed or converted into informative statements, as appropriate.
     </p>

--- a/publication/ver11/5-cr/static.html
+++ b/publication/ver11/5-cr/static.html
@@ -657,20 +657,20 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       ]
     }
   ],
-  "publishISODate": "2022-10-21T00:00:00.000Z",
-  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 21 October 2022"
+  "publishISODate": "2022-11-01T00:00:00.000Z",
+  "generatedSubtitle": "W3C Candidate Recommendation Snapshot 01 November 2022"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-CR"></head>
 <body class="h-entry toc-inline" data-cite="i18n-glossary"><div class="head">
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">Web of Things (WoT) Thing Description 1.1</h1> 
-    <p id="w3c-state"><a href="https://www.w3.org/standards/types#CR">W3C Candidate Recommendation Snapshot</a> <time class="dt-published" datetime="2022-10-21">21 October 2022</time></p>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#CR">W3C Candidate Recommendation Snapshot</a> <time class="dt-published" datetime="2022-11-01">01 November 2022</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
         <dt>This version:</dt><dd>
-                <a class="u-url" href="https://www.w3.org/TR/2022/CR-wot-thing-description11-20221021/">https://www.w3.org/TR/2022/CR-wot-thing-description11-20221021/</a>
+                <a class="u-url" href="https://www.w3.org/TR/2022/CR-wot-thing-description11-20221101/">https://www.w3.org/TR/2022/CR-wot-thing-description11-20221101/</a>
               </dd>
         <dt>Latest published version:</dt><dd>
                 <a href="https://www.w3.org/TR/wot-thing-description11/">https://www.w3.org/TR/wot-thing-description11/</a>
@@ -823,6 +823,15 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     that represent best-practice recommendations will be converted into
     informative statements.</p>
     <p class="at-risk">At-risk assertions are marked with yellow highlighting.</p>
+    <p>
+    The Web of Things Working Group intends to submit this document for
+    consideration as a <abbr title="World Wide Web Consortium">W3C</abbr> Proposed Recommendation on Jan 11, 2023,
+    as long as there are no formal objections.
+    However, before PR transition is requested,
+    any features or assertions currently marked as at-risk that do not
+    have at least two implementations at that time will either be
+    removed or converted into informative statements, as appropriate.
+    </p>
   <p>
     This document was published by the <a href="https://www.w3.org/groups/wg/wot">Web of Things Working Group</a> as
     a Candidate Recommendation Snapshot using the
@@ -8419,25 +8428,25 @@ instance.
             All TD examples: fix highlighting problems and improve formatting
         </li>
 		<li>
-			add security scheme auto, provide definition what "satisfying" a securityDefinition means and new wording of assertion (td-security-no-secrets) in Section <a href="#securityscheme"></a>
+			add security scheme auto, provide definition what "satisfying" a securityDefinition means and new wording of assertion (td-security-no-secrets) in Section <a href="#securityscheme" class="sec-ref"><bdi class="secno">5.3.3.1 </bdi><code>SecurityScheme</code></a>
 		</li>
 		<li>
-			Section <a href="#form-additionalResponses"></a> has been newly added.
+			Section <a href="#form-additionalResponses" class="sec-ref"><bdi class="secno">6.3.9.4 </bdi><code>additionalResponses</code></a> has been newly added.
 		</li>
         <li>
-            Remove TD Context Extensions CoAP example in Section <a href="#adding-protocol-bindings"></a>
+            Remove TD Context Extensions CoAP example in Section <a href="#adding-protocol-bindings" class="sec-ref"><bdi class="secno">7.2 </bdi>Adding Protocol Bindings</a>
         </li>
         <li>
-            Remove reference to Binding Document in assertion (bindings-requirements-scheme) in Section <a href="#protocol-bindings"></a>
+            Remove reference to Binding Document in assertion (bindings-requirements-scheme) in Section <a href="#protocol-bindings" class="sec-ref"><bdi class="secno">8.3 </bdi>Protocol Bindings</a>
         </li>
 		<li>
-			Chapter <a href="#thing-model"></a> moved before <a href="#sec-security-consideration"></a> and <a href="#sec-privacy-consideration"></a>
+			Chapter <a href="#thing-model" class="sec-ref"><bdi class="secno">9. </bdi>Thing Model</a> moved before <a href="#sec-security-consideration" class="sec-ref"><bdi class="secno">10. </bdi>Security Considerations</a> and <a href="#sec-privacy-consideration" class="sec-ref"><bdi class="secno">11. </bdi>Privacy Considerations</a>
 		</li>
 		<li>
-			The term <code>tm:required</code> changed to <a href="#thing-model-td-optional"></a>
+			The term <code>tm:required</code> changed to <a href="#thing-model-td-optional" class="sec-ref"><bdi class="secno">9.3.4 </bdi>tm:optional</a>
 		</li>
         <li>
-            Section <a href="#content-format-section"></a>: add CoAP Content-Format ID for Thing Model
+            Section <a href="#content-format-section" class="sec-ref"><bdi class="secno">12.3 </bdi>CoAP Content-Format Registration</a>: add CoAP Content-Format ID for Thing Model
         </li>
 	  </ul>
   </section>
@@ -8664,7 +8673,7 @@ section <a href="#stringschema" class="sec-ref"><bdi class="secno">5.3.2.7 </bdi
 <section id="references" class="appendix"><div class="header-wrapper"><h2 id="f-references"><bdi class="secno">F. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix F."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="f-1-normative-references"><bdi class="secno">F.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix F.1"></a></div>
     
     <dl class="bibliography"><dt id="bib-appmanifest">[APPMANIFEST]</dt><dd>
-      <a href="https://www.w3.org/TR/appmanifest/"><cite>Web Application Manifest</cite></a>. Marcos Caceres; Kenneth Christiansen; Matt Giuca; Aaron Gustafson; Daniel Murphy; Anssi Kostiainen.  W3C. 17 February 2022. W3C Working Draft. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
+      <a href="https://www.w3.org/TR/appmanifest/"><cite>Web Application Manifest</cite></a>. Marcos Caceres; Kenneth Christiansen; Matt Giuca; Aaron Gustafson; Daniel Murphy; Anssi Kostiainen.  W3C. 31 October 2022. W3C Working Draft. URL: <a href="https://www.w3.org/TR/appmanifest/">https://www.w3.org/TR/appmanifest/</a>
     </dd><dt id="bib-bcp47">[BCP47]</dt><dd>
       <a href="https://www.rfc-editor.org/rfc/rfc5646"><cite>Tags for Identifying Languages</cite></a>. A. Phillips, Ed.; M. Davis, Ed..  IETF. September 2009. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc5646">https://www.rfc-editor.org/rfc/rfc5646</a>
     </dd><dt id="bib-ecma-262">[ECMA-262]</dt><dd>

--- a/publication/ver11/5-cr/static.html
+++ b/publication/ver11/5-cr/static.html
@@ -811,12 +811,35 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     <li>Support for OAuth2 device flow.
         <a href="#td-security-oauth2-device-flow">td-security-oauth2-device-flow</a>.
     </li>
+    <li>Use of extensions for security vocabulary.
+        <a href="#td-security-extension">td-security-extension</a>.
+    </li>
     <li>Support for <code>queryallactions</code> operation.
         <a href="#td-vocab-op--Form">td-vocab-op--Form_queryallactions</a>.
     </li>
+    <li>Thing Model references and versioning.
+        <a href="#tm-tmRef1">tm-tmRef1</a>,
+        <a href="#tm-tmRef2">tm-tmRef2</a>,
+        <a href="#tm-versioning-1">tm-versioning-1</a>, and
+        <a href="#tm-derivation-validity">tm-derivation-validity</a>.
+    </li>
     </ul>
     <p>In addition, a number of assertions in the Privacy Considerations 
-    and Security Considerations sections are at risk.  These represent best
+    and Security Considerations sections are at risk:
+    </p>
+<ul>
+<li><a href="#privacy-immutable-id-as-property">privacy-immutable-id-as-property</a></li>
+<li><a href="#privacy-temp-id-metadata">privacy-temp-id-metadata</a></li>
+<li><a href="#security-context-secure-fetch">security-context-secure-fetch</a></li>
+<li><a href="#security-jsonld-expansion">security-jsonld-expansion</a></li>
+<li><a href="#security-mutual-auth-td">security-mutual-auth-td</a></li>
+<li><a href="#security-oauth-limits">security-oauth-limits</a></li>
+<li><a href="#security-remote-context">security-remote-context</a></li>
+<li><a href="#security-server-auth-td">security-server-auth-td</a></li>
+<li><a href="#security-static-context">security-static-context</a></li>
+</ul>
+    <p>
+    These represent best
     practices but often relate to deployment policy rather than implementations
     and in some cases are difficult to validate.  The intention is to complete
     as many of these as possible by PR; those that cannot be validated but

--- a/testing/inputs/templates/report.html
+++ b/testing/inputs/templates/report.html
@@ -465,9 +465,6 @@ Use of previous results does not imply support for the current specification fro
   </li>
   <li>
     The <b>Assertion</b> column specifies the constraint which must be met.
-    Note that this text may contain errors as it is automatically drawn
-    from the specification source before ReSpec processing, so automatic
-    content provided by ReSpec such as section headings will be missing.
     If the assertion is actually given in a tabular form in the
     specification, appropriate text is generated but this may not match the
     text in the specification itself.  To fully understand the assertion please
@@ -527,20 +524,20 @@ Use of previous results does not imply support for the current specification fro
 <table id="testresults" class="testlist" summary="assertions and tests" cellspacing="1" cellpadding="2" width="100%">
   <thead>
     <tr>
-      <th>ID</th>
-      <th>Category</th>
-      <th>Req</th>
-      <th>Context</th>
-      <th>Assertion</th>
-      <th>Parent</th>
+      <th title="Unique identifier for assertion, and link to assertion in context of the specification.">ID</th>
+      <th title="Functional groupings of assertions.">Category</th>
+      <th title="Required.  Y if the assertion is mandatory, N if it is optional.">Req</th>
+      <th title="Indicates if an assertion is only applicable in a specific context.">Context</th>
+      <th title="Text of the assertion from the specification.">Assertion</th>
+      <th title="For child assertion, which parent assertion they are included in.">Parent</th>
       <th colspan="4">Results</th>
     </tr>
     <tr>
       <th colspan="6"></th>
-      <th>P</th>
-      <th>F</th>
-      <th>N</th>
-      <th>T</th>
+      <th title="Pass">P</th>
+      <th title="Fail">F</th>
+      <th title="Not Implemented">N</th>
+      <th title="Total">T</th>
     </tr>
   </thead>
   <tbody>
@@ -559,20 +556,20 @@ Use of previous results does not imply support for the current specification fro
 <table id="manualresults" class="testlist" summary="manual assertions" cellspacing="1" cellpadding="2" width="100%">
   <thead>
     <tr>
-      <th>ID</th>
-      <th>Category</th>
-      <th>Req</th>
-      <th>Context</th>
-      <th>Assertion</th>
-      <th>Parent</th>
+      <th title="Unique identifier for assertion, and link to assertion in context of the specification.">ID</th>
+      <th title="Functional groupings of assertions.">Category</th>
+      <th title="Required.  Y if the assertion is mandatory, N if it is optional.">Req</th>
+      <th title="Indicates if an assertion is only applicable in a specific context.">Context</th>
+      <th title="Text of the assertion from the specification.">Assertion</th>
+      <th title="For child assertion, which parent assertion they are included in.">Parent</th>
       <th colspan="4">Results</th>
     </tr>
     <tr>
       <th colspan="6"></th>
-      <th>P</th>
-      <th>F</th>
-      <th>N</th>
-      <th>T</th>
+      <th title="Pass">P</th>
+      <th title="Fail">F</th>
+      <th title="Not Implemented">N</th>
+      <th title="Total">T</th>
     </tr>
   </thead>
   <tbody>

--- a/testing/report11.html
+++ b/testing/report11.html
@@ -119,7 +119,7 @@ pre.example {
     DRAFT Implementation Report
   </h1>
   <p>
-    <b>Version</b>: 26 Oct 2022
+    <b>Version</b>: 1 Nov 2022
   </p>
   <p>
     <b>Editors</b>:<br>
@@ -666,9 +666,6 @@ Use of previous results does not imply support for the current specification fro
   </li>
   <li>
     The <b>Assertion</b> column specifies the constraint which must be met.
-    Note that this text may contain errors as it is automatically drawn
-    from the specification source before ReSpec processing, so automatic
-    content provided by ReSpec such as section headings will be missing.
     If the assertion is actually given in a tabular form in the
     specification, appropriate text is generated but this may not match the
     text in the specification itself.  To fully understand the assertion please
@@ -728,20 +725,20 @@ Use of previous results does not imply support for the current specification fro
 <table id="testresults" class="testlist" summary="assertions and tests" cellspacing="1" cellpadding="2" width="100%">
   <thead>
     <tr>
-      <th>ID</th>
-      <th>Category</th>
-      <th>Req</th>
-      <th>Context</th>
-      <th>Assertion</th>
-      <th>Parent</th>
+      <th title="Unique identifier for assertion, and link to assertion in context of the specification.">ID</th>
+      <th title="Functional groupings of assertions.">Category</th>
+      <th title="Required.  Y if the assertion is mandatory, N if it is optional.">Req</th>
+      <th title="Indicates if an assertion is only applicable in a specific context.">Context</th>
+      <th title="Text of the assertion from the specification.">Assertion</th>
+      <th title="For child assertion, which parent assertion they are included in.">Parent</th>
       <th colspan="4">Results</th>
     </tr>
     <tr>
       <th colspan="6"></th>
-      <th>P</th>
-      <th>F</th>
-      <th>N</th>
-      <th>T</th>
+      <th title="Pass">P</th>
+      <th title="Fail">F</th>
+      <th title="Not Implemented">N</th>
+      <th title="Total">T</th>
     </tr>
   </thead>
   <tbody>
@@ -7911,20 +7908,20 @@ container. </td>
 <table id="manualresults" class="testlist" summary="manual assertions" cellspacing="1" cellpadding="2" width="100%">
   <thead>
     <tr>
-      <th>ID</th>
-      <th>Category</th>
-      <th>Req</th>
-      <th>Context</th>
-      <th>Assertion</th>
-      <th>Parent</th>
+      <th title="Unique identifier for assertion, and link to assertion in context of the specification.">ID</th>
+      <th title="Functional groupings of assertions.">Category</th>
+      <th title="Required.  Y if the assertion is mandatory, N if it is optional.">Req</th>
+      <th title="Indicates if an assertion is only applicable in a specific context.">Context</th>
+      <th title="Text of the assertion from the specification.">Assertion</th>
+      <th title="For child assertion, which parent assertion they are included in.">Parent</th>
       <th colspan="4">Results</th>
     </tr>
     <tr>
       <th colspan="6"></th>
-      <th>P</th>
-      <th>F</th>
-      <th>N</th>
-      <th>T</th>
+      <th title="Pass">P</th>
+      <th title="Fail">F</th>
+      <th title="Not Implemented">N</th>
+      <th title="Total">T</th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
- Add paragraph specifying CR exit criteria to sotd section in publication/ver11/5-cr
- List ALL statements at risk in sotd (overlooked some Thing Model ones, and added S&P ones)
- Updated IR template - tooltips
- Rerun index.html -(ReSpec export) -> static.html -(htmltidy)-> Overview.html processing

I also rebased before running this and seem to have picked up some edits to the change log.  Please check that the result is correct, it looks like just formatting changes.  Note that "static.html" and "Overview.html" get overwritten by the above processing so any edits should be made to "index.html".  The old version did not have the links filled in which should have happened with the ReSpec export above so I think "static.html" might have been mistakenly edited.

Update: Sebastian has checked and the change log looks to be ok.