### PR TITLE
add lint-ignore

### DIFF
--- a/publication/ver11/5-cr/index.html
+++ b/publication/ver11/5-cr/index.html
@@ -3349,7 +3349,7 @@ In summary, this requires the following:
 
 
   <p>
-    Strings on the Web [[?STRING-META]] recommends the use of metadata to determine the <a>base 
+    Strings on the Web [[?STRING-META]] recommends the use of metadata to determine the <a class="lint-ignore">base 
     direction</a> of string values. 
 		<span class="rfc2119-assertion" id="td-text-at-direction"> 
 			Given that the Thing Description format is based on JSON-LD 1.1 


### PR DESCRIPTION
There was a ReSpec warning saying:
> Normative reference to "base direction" found but term is defined "informatively" in "i18n-glossary".
> How to fix: You can do one of the following...
> * Get the source definition to be made normative
> * Add a class="lint-ignore" attribute to the link.
> * Use a local normative proxy for the definition à la <dfn data-cite="spec">term</dfn>

And we've decided to add [[ class="lint-ignore" ]] attribute to "&lt;a&gt;" tag for "base direction".