### PR TITLE
commit lint-ignore changes again

### DIFF
--- a/publication/ver11/5-cr/index.html
+++ b/publication/ver11/5-cr/index.html
@@ -3358,10 +3358,10 @@ In summary, this requires the following:
 			indicate the default text direction for the human readable strings in the entire TD document.
 		</span>
         <span class="rfc2119-assertion" id="td-text-direction-first-strong"> 
-            When metadata such as <code>@direction</code> is not present, TD Consumers SHOULD use [=first-strong detection=] as a fallback. 
+            When metadata such as <code>@direction</code> is not present, TD Consumers SHOULD use <a class="lint-ignore">first-strong detection</a> as a fallback. 
         </span>
         <span class="rfc2119-assertion" id="td-text-direction-language-tag">
-            For the MultiLanguage <a>Map</a>, TD Consumers MAY infer the [=base direction=] from the language tag of the individual strings.
+            For the MultiLanguage <a>Map</a>, TD Consumers MAY infer the <a class="lint-ignore">base direction</a> from the language tag of the individual strings.
         </span>
 		The example below illustrates the use of the <code>@direction</code> term. See [[?json-ld11]] and [[string-meta]] 
 		for more detailed information.


### PR DESCRIPTION
as discussed during the [TD call on 1 Jan 2023](https://www.w3.org/2023/01/11-wot-td-minutes.html#t03), changing the following two [[link]] references to &lt;a class="lint-ignore"&gt; notation:
* [=first-strong detection=]
* [=base direction=]