### PR TITLE
fix: ignore ReSpec warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -3233,7 +3233,7 @@ In summary, this requires the following:
 
 
   <p>
-    Strings on the Web [[?STRING-META]] recommends the use of metadata to determine the <a>base 
+    Strings on the Web [[?STRING-META]] recommends the use of metadata to determine the <a class="lint-ignore">base 
     direction</a> of string values. 
 		<span class="rfc2119-assertion" id="td-text-at-direction"> 
 			Given that the Thing Description format is based on JSON-LD 1.1 
@@ -3242,10 +3242,10 @@ In summary, this requires the following:
 			indicate the default text direction for the human readable strings in the entire TD document.
 		</span>
         <span class="rfc2119-assertion" id="td-text-direction-first-strong"> 
-            When metadata such as <code>@direction</code> is not present, TD Consumers SHOULD use [=first-strong detection=] as a fallback. 
+            When metadata such as <code>@direction</code> is not present, TD Consumers SHOULD use <a class="lint-ignore">first-strong detection</a> as a fallback. 
         </span>
         <span class="rfc2119-assertion" id="td-text-direction-language-tag">
-            For the MultiLanguage <a>Map</a>, TD Consumers MAY infer the [=base direction=] from the language tag of the individual strings.
+            For the MultiLanguage <a>Map</a>, TD Consumers MAY infer the <a class="lint-ignore">base direction</a> from the language tag of the individual strings.
         </span>
 		The example below illustrates the use of the <code>@direction</code> term. See [[?json-ld11]] and [[string-meta]] 
 		for more detailed information.

--- a/index.template.html
+++ b/index.template.html
@@ -1947,7 +1947,7 @@ In summary, this requires the following:
 
 
   <p>
-    Strings on the Web [[?STRING-META]] recommends the use of metadata to determine the <a>base 
+    Strings on the Web [[?STRING-META]] recommends the use of metadata to determine the <a class="lint-ignore">base 
     direction</a> of string values. 
 		<span class="rfc2119-assertion" id="td-text-at-direction"> 
 			Given that the Thing Description format is based on JSON-LD 1.1 
@@ -1956,10 +1956,10 @@ In summary, this requires the following:
 			indicate the default text direction for the human readable strings in the entire TD document.
 		</span>
         <span class="rfc2119-assertion" id="td-text-direction-first-strong"> 
-            When metadata such as <code>@direction</code> is not present, TD Consumers SHOULD use [=first-strong detection=] as a fallback. 
+            When metadata such as <code>@direction</code> is not present, TD Consumers SHOULD use <a class="lint-ignore">first-strong detection</a> as a fallback. 
         </span>
         <span class="rfc2119-assertion" id="td-text-direction-language-tag">
-            For the MultiLanguage <a>Map</a>, TD Consumers MAY infer the [=base direction=] from the language tag of the individual strings.
+            For the MultiLanguage <a>Map</a>, TD Consumers MAY infer the <a class="lint-ignore">base direction</a> from the language tag of the individual strings.
         </span>
 		The example below illustrates the use of the <code>@direction</code> term. See [[?json-ld11]] and [[string-meta]] 
 		for more detailed information.


### PR DESCRIPTION
"Normative reference defined in informative document"

This PR is similar to the CR updates (targeted for main branch)
- https://github.com/w3c/wot-thing-description/pull/1760
- https://github.com/w3c/wot-thing-description/pull/1761

fixes https://github.com/w3c/wot-thing-description/issues/1759


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/1762.html" title="Last updated on Jan 12, 2023, 2:34 PM UTC (a49563f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1762/2eec4db...danielpeintner:a49563f.html" title="Last updated on Jan 12, 2023, 2:34 PM UTC (a49563f)">Diff</a>