### PR TITLE
Make response contentType required in JSON Schema, regenerate TM schema

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -327,7 +327,10 @@
         "contentType": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "contentType"
+      ]
     },
     "form_element_base": {
       "type": "object",

--- a/validation/tm-json-schema-validation.json
+++ b/validation/tm-json-schema-validation.json
@@ -160,7 +160,7 @@
           }
         },
         {
-          "$comment": "Only the new context URI",
+          "$comment": "Only the old context URI",
           "$ref": "#/definitions/thing-context-td-uri-v1"
         }
       ]


### PR DESCRIPTION
Dealing with Discovery from TDDs, I noticed that the Thing Description JSON Schema document does not treat the `contentType` in the `ExpectedResponse` class as mandatory at the moment (see [section 5.3.4.3](https://w3c.github.io/wot-thing-description/#expectedresponse)).

This PR aligns this part of the JSON Schema document with the specification. However, this change does have some implications for the discovery specification, as the [TDD Thing Model](https://w3c.github.io/wot-discovery/#directory-api-spec) contains `response` objects that do not specify a `contentType`. Therefore, to achieve a valid Directory Thing Description, you would actually need to additionally specify a `contentType` here during the TM to TD conversion. In general, I suppose it could make sense to make the `contentType` optional in TD 2.0, since there are cases where omitting the Content-Type is a valid choice (e.g., if no body/payload is supposed to be included in the response).

(Besides the TD Schema change, this PR also regenerates the TM schema and takes over a small change from 0bbcc5c.)