### PR TITLE
Update version td-json-schema-validation.json

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -1,6 +1,6 @@
 {
   "title": "Thing Description",
-  "version": "1.1-05-September-2022",
+  "version": "1.1-23-March-2023",
   "description": "JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id":"https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",


### PR DESCRIPTION
since https://github.com/w3c/wot-thing-description/pull/1776 updated the JSON schema we should also change the version term accordingly.

Note: in scripting we use use the JSON schema to generate the the according TypeScript definitions. Hence it is important to have a _unique_ version.

see https://github.com/w3c/wot-scripting-api/issues/468