### PR TITLE
Add references to TD 1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,6 +186,15 @@
             },
             otherLinks: [
                 {
+                    key: "Previous Recommendation",
+                    data: [
+                        {
+                            value: "https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/",
+                            href: "https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/"
+                        }
+                    ]
+                },
+                {
                     key: "Contributors",
                     data: [
                     {
@@ -415,7 +424,7 @@ a[href].internalDFN {
   </p>
 
   <p>
-    This specification describes a superset of the features defined in Thing Description 1.0 [[WOT-THING-DESCRIPTION]]. 
+    This specification describes a superset of the features defined in Thing Description 1.0 [[WOT-THING-DESCRIPTION10]]. 
     Unless otherwise specified, documents created with version 1.0 of this specification remain
     compatible with Thing Description 1.1.
   </p>
@@ -1328,7 +1337,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           <li>
           <span class="rfc2119-assertion" id=
           "td-context-ns-td10-namespacev10"> 
-            TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0 [[wot-thing-description]] specification. 
+            TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0 [[wot-thing-description10]] specification. 
             </span>
           </li>
           <li>

--- a/index.template.html
+++ b/index.template.html
@@ -415,7 +415,7 @@ a[href].internalDFN {
   </p>
 
   <p>
-    This specification describes a superset of the features defined in Thing Description 1.0 [[WOT-THING-DESCRIPTION]]. 
+    This specification describes a superset of the features defined in Thing Description 1.0 [[WOT-THING-DESCRIPTION10]]. 
     Unless otherwise specified, documents created with version 1.0 of this specification remain
     compatible with Thing Description 1.1.
   </p>

--- a/index.template.html
+++ b/index.template.html
@@ -15,6 +15,7 @@
             //, processVersion: 2020
             //, wgPatentPolicy: "PP2017" // deprecated, "group" option sets this automatically
             shortName:      "wot-thing-description11",
+            prevRecShortname: "wot-thing-description10",
             copyrightStart: 2017,
             noLegacyStyle:  true,
             inlineCSS:      true,

--- a/index.template.html
+++ b/index.template.html
@@ -15,7 +15,6 @@
             //, processVersion: 2020
             //, wgPatentPolicy: "PP2017" // deprecated, "group" option sets this automatically
             shortName:      "wot-thing-description11",
-            prevRecShortname: "wot-thing-description10",
             copyrightStart: 2017,
             noLegacyStyle:  true,
             inlineCSS:      true,
@@ -186,6 +185,15 @@
                 }
             },
             otherLinks: [
+                {
+                    key: "Previous Recommendation",
+                    data: [
+                        {
+                            value: "https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/",
+                            href: "https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/"
+                        }
+                    ]
+                },
                 {
                     key: "Contributors",
                     data: [

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -213,7 +213,7 @@
           <li>
           <span class="rfc2119-assertion" id=
           "td-context-ns-td10-namespacev10"> 
-            TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0 [[wot-thing-description]] specification. 
+            TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0 [[wot-thing-description10]] specification. 
             </span>
           </li>
           <li>


### PR DESCRIPTION
I have added it to respec config and to some places in the text by making sure to use [wot-thing-description10] . Respec config says to use `prevRecURI: "https://www.w3.org/TR/2014/example-20140327/",` but this generates a link with name "Last Recommendation" which I find confusing. You can check the previous commits to see it.

fixes #1770

[JSON LD 1.1](https://www.w3.org/TR/json-ld11/) manages to do it but I get different behavior


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1791.html" title="Last updated on Apr 5, 2023, 12:30 PM UTC (29ede36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1791/31de580...29ede36.html" title="Last updated on Apr 5, 2023, 12:30 PM UTC (29ede36)">Diff</a>