### PR TITLE
Add semantic annotation def and use it

### DIFF
--- a/index.html
+++ b/index.html
@@ -806,7 +806,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
   <dl>
     <dt>
-        <dfn id="dfn-semantic-tag">Semantic Tag</dfn>
+        <dfn id="dfn-semantic-tag">Semantic Tag</dfn>, <dfn id="dfn-semantic-annotation">Semantic Annotation</dfn>
     </dt>
     <dd>
         A JSON-LD mechanism that links definitions in a <a>Thing Descriptions</a> document to concepts in an (RDF) ontology. 
@@ -820,7 +820,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
     </dt>
     <dd>
         A mechanism to extend <a>Thing Descriptions</a> with additional <a>Vocabulary
-        Terms</a>. It is the basis for semantic annotations and extensions to core
+        Terms</a>. It is the basis for <a>semantic annotations</a> and extensions to core
         mechanisms such as Protocol Bindings, Security Schemes, and Data Schemas.
     </dd>
     <dt>
@@ -7856,7 +7856,7 @@ instance.
               To unsubscribe, the <a>Consumer</a> has to submit the <code>unsubscribeevent</code> form with the <code>subscriptionID</code> as described in <code>cancellation</code>.
               Alternatively, <code>uriVariables</code> approache can be used that informs the <a>Consumer</a> to include the <code>subscriptionID</code> string 
               into the URI that have to be called with the delete method (see tab 'With uriVariables'). In such setup, the <code>cancellation</code> container can be obmitted.
-              In general, this example can be further automated by using a <a>TD Context Extension</a> to include proper semantic annotations.
+              In general, this example can be further automated by using a <a>TD Context Extension</a> to include proper <a>semantic annotations</a>.
           </li>
       </ul>
 

--- a/index.template.html
+++ b/index.template.html
@@ -806,7 +806,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 
   <dl>
     <dt>
-        <dfn id="dfn-semantic-tag">Semantic Tag</dfn>
+        <dfn id="dfn-semantic-tag">Semantic Tag</dfn>, <dfn id="dfn-semantic-annotation">Semantic Annotation</dfn>
     </dt>
     <dd>
         A JSON-LD mechanism that links definitions in a <a>Thing Descriptions</a> document to concepts in an (RDF) ontology. 
@@ -820,7 +820,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
     </dt>
     <dd>
         A mechanism to extend <a>Thing Descriptions</a> with additional <a>Vocabulary
-        Terms</a>. It is the basis for semantic annotations and extensions to core
+        Terms</a>. It is the basis for <a>semantic annotations</a> and extensions to core
         mechanisms such as Protocol Bindings, Security Schemes, and Data Schemas.
     </dd>
     <dt>
@@ -6562,7 +6562,7 @@ instance.
               To unsubscribe, the <a>Consumer</a> has to submit the <code>unsubscribeevent</code> form with the <code>subscriptionID</code> as described in <code>cancellation</code>.
               Alternatively, <code>uriVariables</code> approache can be used that informs the <a>Consumer</a> to include the <code>subscriptionID</code> string 
               into the URI that have to be called with the delete method (see tab 'With uriVariables'). In such setup, the <code>cancellation</code> container can be obmitted.
-              In general, this example can be further automated by using a <a>TD Context Extension</a> to include proper semantic annotations.
+              In general, this example can be further automated by using a <a>TD Context Extension</a> to include proper <a>semantic annotations</a>.
           </li>
       </ul>
 


### PR DESCRIPTION
fixes #1687 

That issue was almost fixed but not closed. I found another small thing to address


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1820.html" title="Last updated on May 17, 2023, 9:45 AM UTC (e17916f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1820/d4639d8...e17916f.html" title="Last updated on May 17, 2023, 9:45 AM UTC (e17916f)">Diff</a>