### PR TITLE
Remove manually added rfc classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1320,8 +1320,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           "td-context-ns-thing-mandatory">
 
           The <code>@context</code>
-          name-value pair <em class="rfc2119" title=
-          "MUST">MUST</em> contain the anyURI
+          name-value pair MUST contain the anyURI
           <code>https://www.w3.org/2022/wot/td/v1.1</code>
           in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly introduced terms.
           </span>
@@ -1331,9 +1330,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           "td-context-ns-td10-namespace"> 
           When there are possibly TD 1.0 consumers the anyURI
           <code>https://www.w3.org/2019/wot/td/v1</code>
-          <em class="rfc2119" title=
-          "MUST">MUST</em> be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class="rfc2119" title=
-          "MUST">MUST</em> be the second entry.</span>
+          MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second entry.</span>
           </li>
           <li>
           <span class="rfc2119-assertion" id=
@@ -1350,8 +1347,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           "rfc2119" title="MAY">MAY</em> be followed by elements of
           type <code>anyURI</code> or type <a href="#dfn-map"
           class="internalDFN" data-link-type="dfn">Map</a> in any
-          order, while it is <em class="rfc2119" title=
-          "RECOMMENDED">RECOMMENDED</em> to include only one
+          order, while it is RECOMMENDED to include only one
           <a href="#dfn-map" class="internalDFN" data-link-type=
           "dfn">Map</a> with all the name-value pairs in the
           <code>@context</code> <a href="#dfn-array" class=
@@ -1363,7 +1359,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           "#dfn-map" class="internalDFN" data-link-type=
           "dfn">Maps</a> contained in an <code>@context</code>
           <a href="#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> <em class="rfc2119" title="MAY">MAY</em>
+          "dfn">Array</a> MAY
           contain name-value pairs, where the value is a namespace
           identifier of type <code>anyURI</code> and the name a
           <a href="#dfn-term" class="internalDFN" data-link-type=
@@ -1375,8 +1371,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           class="internalDFN" data-link-type="dfn">Map</a>
           contained in an <code>@context</code> <a href=
           "#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> <em class="rfc2119" title=
-          "SHOULD">SHOULD</em> contain a name-value pair that
+          "dfn">Array</a> SHOULD contain a name-value pair that
           defines the default language for the Thing Description,
           where the name is the <a href="#dfn-term" class=
           "internalDFN" data-link-type="dfn">Term</a>
@@ -1445,8 +1440,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           instances, it MUST contain <code>op</code> member with the string values assigned 
           to the name <code>op</code>, either directly or within an <a href=
           "#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a>, <em class="rfc2119" title=
-          "MUST">MUST</em> be one of the following <em>operation
+          "dfn">Array</a>, MUST be one of the following <em>operation
           types</em>: <code>readallproperties</code>,
           <code>writeallproperties</code>,
           <code>readmultipleproperties</code>,
@@ -1517,7 +1511,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           the <code>DataSchema</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
           <span class="rfc2119-assertion" id="td-op-for-property">When a Form instance is within a
           <code>PropertyAffordance</code> instance, the value
-          assigned to <code>op</code> <em class="rfc2119" title="MUST">MUST</em> be one of <code>readproperty</code>,
+          assigned to <code>op</code> MUST be one of <code>readproperty</code>,
           <code>writeproperty</code>, <code>observeproperty</code>,
           <code>unobserveproperty</code> or an <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
           containing a combination of these terms.</span></p><p class="note">
@@ -1552,7 +1546,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
           <span class="rfc2119-assertion" id="td-op-for-action">When a Form instance is within an
           <code>ActionAffordance</code> instance, the value
-          assigned to op <em class="rfc2119" title="MUST">MUST</em>
+          assigned to op MUST
           either be <code>invokeaction</code>, <code>queryaction</code>, 
           <code>cancelaction</code> or an 
           <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
@@ -1574,7 +1568,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           <span class="rfc2119-assertion" id="td-op-for-event">When
           a Form instance is within an <code>EventAffordance</code>
           instance, the value assigned to <code>op</code>
-          <em class="rfc2119" title="MUST">MUST</em> be either
+          MUST be either
           <code>subscribeevent</code>,
           <code>unsubscribeevent</code>, or both terms within an
           <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span></p><p class="note">
@@ -1715,11 +1709,11 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
 <li><a href="#nullschema"><code>NullSchema</code></a></li></ul><p>The <code>format</code> string values are known from a
           fixed set of values and their corresponding format rules
           defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]
-          (Section 7.3 Defined Formats in particular). <span class="rfc2119-assertion" id="td-format-validation-known-values">Servients <em class="rfc2119" title="MAY">MAY</em> use the
+          (Section 7.3 Defined Formats in particular). <span class="rfc2119-assertion" id="td-format-validation-known-values">Servients MAY use the
           <code>format</code> value to perform additional
           validation accordingly.</span> <span class="rfc2119-assertion" id="td-format-validation-other-values">When a value that is
           not found in the known set of values is assigned to
-          <code>format</code>, such a validation <em class="rfc2119" title="SHOULD">SHOULD</em> succeed.</span></p>
+          <code>format</code>, such a validation SHOULD succeed.</span></p>
           Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>, <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string, object, array, or null).
           <p class="note">The <code>format</code> term is not widely implemented by JSON Schema tools. 
           In addition, the term <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by another mechanism or removed in a future JSON Schema version.</p></section>
@@ -1817,7 +1811,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       <!-- rendered from RDF definitions -->
       <section><h3><code>SecurityScheme</code></h3><p><p>Metadata describing the configuration of a security
           mechanism. <span class="rfc2119-assertion" id="td-security-scheme-name">The value assigned to the name
-          <code>scheme</code> <em class="rfc2119" title="MUST">MUST</em> be defined within a 
+          <code>scheme</code> MUST be defined within a 
           <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
           included in the <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>,
           either in the standard <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined
@@ -1827,7 +1821,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           </p><p>
           <span class="rfc2119-assertion" id="td-security-no-secrets">For all security schemes,
           any keys, passwords, or other sensitive information directly providing access 
-          <em class="rfc2119" title="MUST NOT">MUST NOT</em> be stored in the TD and should instead
+          MUST NOT be stored in the TD and should instead
           be shared and stored out-of-band via other mechanisms.</span> 
           The purpose of a TD is to describe how to access a Thing if and only if a Consumer 
           already has authorization, and is not meant be used to grant that authorization.
@@ -1853,7 +1847,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             used provided by <code>name</code>.
             <span class="rfc2119-assertion" id="sec-body-name-json-pointer">When used in the context of a 
             <code>body</code> security information location, the value of <code>name</code> 
-            <em class="rfc2119" title="MUST">MUST</em> be in the form of a JSON pointer [[!RFC6901]] relative to 
+            MUST be in the form of a JSON pointer [[!RFC6901]] relative to 
             the root of the input <code>DataSchema</code> for each interaction it is used with.</span> 
             Since this value is not a fragment identifier, and is not relative to the root of the TD but
             to whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
@@ -1865,20 +1859,18 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
             every interaction.
             <span class="rfc2119-assertion" id="sec-body-name-json-pointer-creatable">When an element
             of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
-            does not already exist in the indicated schema, it
-            <em class="rfc2119" title="MUST">MUST</em> 
+            does not already exist in the indicated schema, it MUST
             be possible to insert the indicated element
             at the location indicated by the pointer.</span>
             <span class="rfc2119-assertion" id="sec-body-name-json-pointer-array">The JSON pointer
-            used in the <code>body</code> locator 
-            <em class="rfc2119" title="MAY">MAY</em> 
+            used in the <code>body</code> locator MAY
             use the "<code>-</code>" character to indicate a non-existent array element when 
             it is necessary to insert an element after the last element of an existing array.
             </span>
             <span class="rfc2119-assertion" id="sec-body-name-json-pointer-type">The element referenced
             (or created) by a 
             <code>body</code> security information location
-            <em class="rfc2119" title="MUST">MUST</em> be required and of type "<code>string</code>".</span> 
+            MUST be required and of type "<code>string</code>".</span> 
             If <code>name</code> is not given, it is assumed the entire body
             is to be used as the security parameter.
           </dd>
@@ -1891,12 +1883,12 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           relevant interaction using a URI template variable defined by the value of <code>name</code>.
           This is more general than the <code>query</code> mechanism but more complex. 
           <span class="rfc2119-assertion" id="td-security-in-query-over-uri">The value <code>uri</code> 
-          <em class="rfc2119" title="SHOULD">SHOULD</em> be specified 
+          SHOULD be specified 
           for the name <code>in</code> in a security scheme only if
           <code>query</code> is not applicable.</span>  
           <span class="rfc2119-assertion" id="td-security-in-uri-variable">The URIs provided
           in interactions where a security scheme using <code>uri</code> as the value for <code>in</code>
-          <em class="rfc2119" title="MUST">MUST</em> be a URI template including the defined variable.
+          MUST be a URI template including the defined variable.
           </span>  
           </dd>
           <dt><code>auto</code>:</dt>
@@ -1919,7 +1911,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           </p><p>
           <span class="rfc2119-assertion" id="td-security-uri-variables-distinct">The names of URI variables 
           declared in a <code>SecurityScheme</code> 
-          <em class="rfc2119" title="MUST">MUST</em> be distinct from all other URI variables 
+          MUST be distinct from all other URI variables 
           declared in the TD.</span></p></p><table class="def numbered"><caption>Vocabulary Terms in SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable)
                       information based on a default language.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
@@ -1993,7 +1985,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>], with
           values for <code>alg</code> interpreted consistently with
           those standards. <span class="rfc2119-assertion" id="td-security-bearer-format-extensions">Other formats and
-          algorithms for bearer tokens <em class="rfc2119" title="MAY">MAY</em> be specified in vocabulary
+          algorithms for bearer tokens MAY be specified in vocabulary
           extensions</span>.</p><table class="def numbered"><caption>Vocabulary Terms in BearerSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
 <tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
                parameters.</td><td>optional</td><td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
@@ -2343,7 +2335,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           Future versions of the standard may extend this list but
           <span class="rfc2119-assertion" id=
           "well-known-operation-types-only">operations types
-          <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be
+          SHOULD NOT be
           arbitrarily set by servients and be restricted to the values in the
           table below.</span></p>
 
@@ -2568,7 +2560,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           be applied. <span class="rfc2119-assertion" id=
           "td-expectedResponse-default-contentType">If no
           <code>response</code> name-value pair is provided, it
-          <em class="rfc2119" title="MUST">MUST</em> be assumed
+          MUST be assumed
           that the content type of the response is equal to the
           content type assigned to the Form instance.</span> Note
           that <code>contentType</code> within an
@@ -2669,8 +2661,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       <p><span class="rfc2119-assertion" id=
       "td-vocabulary-defaults">When assignments in a TD are
       missing, a <a href="#dfn-td-processor" class="internalDFN"
-      data-link-type="dfn">TD Processor</a> <em class="rfc2119"
-      title="MUST">MUST</em> follow the <a href=
+      data-link-type="dfn">TD Processor</a> MUST follow the <a href=
       "#dfn-default-value" class="internalDFN" data-link-type=
       "dfn">Default Value</a> assignments expressed in the table of
       <a href="#sec-default-values" class=

--- a/index.template.html
+++ b/index.template.html
@@ -1375,8 +1375,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
       <p><span class="rfc2119-assertion" id=
       "td-vocabulary-defaults">When assignments in a TD are
       missing, a <a href="#dfn-td-processor" class="internalDFN"
-      data-link-type="dfn">TD Processor</a> <em class="rfc2119"
-      title="MUST">MUST</em> follow the <a href=
+      data-link-type="dfn">TD Processor</a> MUST follow the <a href=
       "#dfn-default-value" class="internalDFN" data-link-type=
       "dfn">Default Value</a> assignments expressed in the table of
       <a href="#sec-default-values" class=

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -195,8 +195,7 @@
           "td-context-ns-thing-mandatory">
 
           The <code>@context</code>
-          name-value pair <em class="rfc2119" title=
-          "MUST">MUST</em> contain the anyURI
+          name-value pair MUST contain the anyURI
           <code>https://www.w3.org/2022/wot/td/v1.1</code>
           in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly introduced terms.
           </span>
@@ -206,9 +205,7 @@
           "td-context-ns-td10-namespace"> 
           When there are possibly TD 1.0 consumers the anyURI
           <code>https://www.w3.org/2019/wot/td/v1</code>
-          <em class="rfc2119" title=
-          "MUST">MUST</em> be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class="rfc2119" title=
-          "MUST">MUST</em> be the second entry.</span>
+          MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second entry.</span>
           </li>
           <li>
           <span class="rfc2119-assertion" id=
@@ -225,8 +222,7 @@
           "rfc2119" title="MAY">MAY</em> be followed by elements of
           type <code>anyURI</code> or type <a href="#dfn-map"
           class="internalDFN" data-link-type="dfn">Map</a> in any
-          order, while it is <em class="rfc2119" title=
-          "RECOMMENDED">RECOMMENDED</em> to include only one
+          order, while it is RECOMMENDED to include only one
           <a href="#dfn-map" class="internalDFN" data-link-type=
           "dfn">Map</a> with all the name-value pairs in the
           <code>@context</code> <a href="#dfn-array" class=
@@ -238,7 +234,7 @@
           "#dfn-map" class="internalDFN" data-link-type=
           "dfn">Maps</a> contained in an <code>@context</code>
           <a href="#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> <em class="rfc2119" title="MAY">MAY</em>
+          "dfn">Array</a> MAY
           contain name-value pairs, where the value is a namespace
           identifier of type <code>anyURI</code> and the name a
           <a href="#dfn-term" class="internalDFN" data-link-type=
@@ -250,8 +246,7 @@
           class="internalDFN" data-link-type="dfn">Map</a>
           contained in an <code>@context</code> <a href=
           "#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> <em class="rfc2119" title=
-          "SHOULD">SHOULD</em> contain a name-value pair that
+          "dfn">Array</a> SHOULD contain a name-value pair that
           defines the default language for the Thing Description,
           where the name is the <a href="#dfn-term" class=
           "internalDFN" data-link-type="dfn">Term</a>
@@ -320,8 +315,7 @@
           instances, it MUST contain <code>op</code> member with the string values assigned 
           to the name <code>op</code>, either directly or within an <a href=
           "#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a>, <em class="rfc2119" title=
-          "MUST">MUST</em> be one of the following <em>operation
+          "dfn">Array</a>, MUST be one of the following <em>operation
           types</em>: <code>readallproperties</code>,
           <code>writeallproperties</code>,
           <code>readmultipleproperties</code>,
@@ -415,7 +409,7 @@
           the <code>DataSchema</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
           <span class="rfc2119-assertion" id="td-op-for-property">When a Form instance is within a
           <code>PropertyAffordance</code> instance, the value
-          assigned to <code>op</code> <em class="rfc2119" title="MUST">MUST</em> be one of <code>readproperty</code>,
+          assigned to <code>op</code> MUST be one of <code>readproperty</code>,
           <code>writeproperty</code>, <code>observeproperty</code>,
           <code>unobserveproperty</code> or an <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
           containing a combination of these terms.</span></p><p class="note">
@@ -489,7 +483,7 @@
           <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
           <span class="rfc2119-assertion" id="td-op-for-action">When a Form instance is within an
           <code>ActionAffordance</code> instance, the value
-          assigned to op <em class="rfc2119" title="MUST">MUST</em>
+          assigned to op MUST
           either be <code>invokeaction</code>, <code>queryaction</code>, 
           <code>cancelaction</code> or an 
           <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
@@ -542,7 +536,7 @@
           <span class="rfc2119-assertion" id="td-op-for-event">When
           a Form instance is within an <code>EventAffordance</code>
           instance, the value assigned to <code>op</code>
-          <em class="rfc2119" title="MUST">MUST</em> be either
+          MUST be either
           <code>subscribeevent</code>,
           <code>unsubscribeevent</code>, or both terms within an
           <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span></p><p class="note">
@@ -766,7 +760,7 @@
           Future versions of the standard may extend this list but
           <span class="rfc2119-assertion" id=
           "well-known-operation-types-only">operations types
-          <em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em> be
+          SHOULD NOT be
           arbitrarily set by servients and be restricted to the values in the
           table below.</span></p>
 
@@ -991,7 +985,7 @@
           be applied. <span class="rfc2119-assertion" id=
           "td-expectedResponse-default-contentType">If no
           <code>response</code> name-value pair is provided, it
-          <em class="rfc2119" title="MUST">MUST</em> be assumed
+          MUST be assumed
           that the content type of the response is equal to the
           content type assigned to the Form instance.</span> Note
           that <code>contentType</code> within an
@@ -1362,7 +1356,7 @@
     sh:targetClass wotsec:SecurityScheme ;
     skos:definition """<p>Metadata describing the configuration of a security
           mechanism. <span class="rfc2119-assertion" id="td-security-scheme-name">The value assigned to the name
-          <code>scheme</code> <em class="rfc2119" title="MUST">MUST</em> be defined within a 
+          <code>scheme</code> MUST be defined within a 
           <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
           included in the <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>,
           either in the standard <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined
@@ -1372,7 +1366,7 @@
           </p><p>
           <span class="rfc2119-assertion" id="td-security-no-secrets">For all security schemes,
           any keys, passwords, or other sensitive information directly providing access 
-          <em class="rfc2119" title="MUST NOT">MUST NOT</em> be stored in the TD and should instead
+          MUST NOT be stored in the TD and should instead
           be shared and stored out-of-band via other mechanisms.</span> 
           The purpose of a TD is to describe how to access a Thing if and only if a Consumer 
           already has authorization, and is not meant be used to grant that authorization.
@@ -1398,7 +1392,7 @@
             used provided by <code>name</code>.
             <span class="rfc2119-assertion" id="sec-body-name-json-pointer">When used in the context of a 
             <code>body</code> security information location, the value of <code>name</code> 
-            <em class="rfc2119" title="MUST">MUST</em> be in the form of a JSON pointer [[!RFC6901]] relative to 
+            MUST be in the form of a JSON pointer [[!RFC6901]] relative to 
             the root of the input <code>DataSchema</code> for each interaction it is used with.</span> 
             Since this value is not a fragment identifier, and is not relative to the root of the TD but
             to whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
@@ -1410,20 +1404,18 @@
             every interaction.
             <span class="rfc2119-assertion" id="sec-body-name-json-pointer-creatable">When an element
             of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
-            does not already exist in the indicated schema, it
-            <em class="rfc2119" title="MUST">MUST</em> 
+            does not already exist in the indicated schema, it MUST
             be possible to insert the indicated element
             at the location indicated by the pointer.</span>
             <span class="rfc2119-assertion" id="sec-body-name-json-pointer-array">The JSON pointer
-            used in the <code>body</code> locator 
-            <em class="rfc2119" title="MAY">MAY</em> 
+            used in the <code>body</code> locator MAY
             use the "<code>-</code>" character to indicate a non-existent array element when 
             it is necessary to insert an element after the last element of an existing array.
             </span>
             <span class="rfc2119-assertion" id="sec-body-name-json-pointer-type">The element referenced
             (or created) by a 
             <code>body</code> security information location
-            <em class="rfc2119" title="MUST">MUST</em> be required and of type "<code>string</code>".</span> 
+            MUST be required and of type "<code>string</code>".</span> 
             If <code>name</code> is not given, it is assumed the entire body
             is to be used as the security parameter.
           </dd>
@@ -1436,12 +1428,12 @@
           relevant interaction using a URI template variable defined by the value of <code>name</code>.
           This is more general than the <code>query</code> mechanism but more complex. 
           <span class="rfc2119-assertion" id="td-security-in-query-over-uri">The value <code>uri</code> 
-          <em class="rfc2119" title="SHOULD">SHOULD</em> be specified 
+          SHOULD be specified 
           for the name <code>in</code> in a security scheme only if
           <code>query</code> is not applicable.</span>  
           <span class="rfc2119-assertion" id="td-security-in-uri-variable">The URIs provided
           in interactions where a security scheme using <code>uri</code> as the value for <code>in</code>
-          <em class="rfc2119" title="MUST">MUST</em> be a URI template including the defined variable.
+          MUST be a URI template including the defined variable.
           </span>  
           </dd>
           <dt><code>auto</code>:</dt>
@@ -1464,7 +1456,7 @@
           </p><p>
           <span class="rfc2119-assertion" id="td-security-uri-variables-distinct">The names of URI variables 
           declared in a <code>SecurityScheme</code> 
-          <em class="rfc2119" title="MUST">MUST</em> be distinct from all other URI variables 
+          MUST be distinct from all other URI variables 
           declared in the TD.</span></p>"""^^rdf:HTML ;
     sh:closed false ;
     sh:order 1 ;
@@ -1607,7 +1599,7 @@
           [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>], with
           values for <code>alg</code> interpreted consistently with
           those standards. <span class="rfc2119-assertion" id="td-security-bearer-format-extensions">Other formats and
-          algorithms for bearer tokens <em class="rfc2119" title="MAY">MAY</em> be specified in vocabulary
+          algorithms for bearer tokens MAY be specified in vocabulary
           extensions</span>."""^^rdf:HTML ;
     sh:closed false ;
     sh:order 8 ;
@@ -1858,11 +1850,11 @@
     skos:scopeNote """<p>The <code>format</code> string values are known from a
           fixed set of values and their corresponding format rules
           defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]
-          (Section 7.3 Defined Formats in particular). <span class="rfc2119-assertion" id="td-format-validation-known-values">Servients <em class="rfc2119" title="MAY">MAY</em> use the
+          (Section 7.3 Defined Formats in particular). <span class="rfc2119-assertion" id="td-format-validation-known-values">Servients MAY use the
           <code>format</code> value to perform additional
           validation accordingly.</span> <span class="rfc2119-assertion" id="td-format-validation-other-values">When a value that is
           not found in the known set of values is assigned to
-          <code>format</code>, such a validation <em class="rfc2119" title="SHOULD">SHOULD</em> succeed.</span></p>
+          <code>format</code>, such a validation SHOULD succeed.</span></p>
           Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>, <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string, object, array, or null).
           <p class="note">The <code>format</code> term is not widely implemented by JSON Schema tools. 
           In addition, the term <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by another mechanism or removed in a future JSON Schema version.</p>"""^^rdf:HTML .


### PR DESCRIPTION
fixes #1806

I have also did respec exports of the HTML (editors draft and this PR): https://diffy.org/diff/2f9d0076a9a42

My observations: 
- We were manually adding a title attribute which is not added by respec
- All capitalized forms are recognized, including MUST NOT etc.

I would still classify this as an editorial change. Just need a quick confirmation from @mmccool that his tool is not dependent on these manual additions. I guess it is not since it was not used everywhere, just some random locations.