### PR TITLE
Resolve privacy-immutable-id-as-property

### DIFF
--- a/index.html
+++ b/index.html
@@ -7364,11 +7364,12 @@ instance.
           of the change in identifier when a change is made.
           Note however that some classes of devices, e.g., medical devices,
           may require immutable IDs by law in some jurisdictions.
-          <span class="rfc2119-assertion" id="privacy-immutable-id-as-property">
-          Ideally, any required immutable identifiers SHOULD only be 
+          <!-- <span class="rfc2119-assertion" id="privacy-immutable-id-as-property"> -->
+          Ideally, any required immutable identifiers should only be 
           made available via affordances, such as a property, whose value can
           only be obtained after appropriate authentication and
-          authorization, and managed separately from the TD identifier.</span>
+          authorization, and managed separately from the TD identifier.
+          <!-- </span> -->
           If it is necessary to use an immutable identifier as the TD identifier, 
           extra attention should be paid to secure 
           access to files, such as Thing Descriptions, containing such

--- a/index.template.html
+++ b/index.template.html
@@ -6073,11 +6073,12 @@ instance.
           of the change in identifier when a change is made.
           Note however that some classes of devices, e.g., medical devices,
           may require immutable IDs by law in some jurisdictions.
-          <span class="rfc2119-assertion" id="privacy-immutable-id-as-property">
-          Ideally, any required immutable identifiers SHOULD only be 
+          <!-- <span class="rfc2119-assertion" id="privacy-immutable-id-as-property"> -->
+          Ideally, any required immutable identifiers should only be 
           made available via affordances, such as a property, whose value can
           only be obtained after appropriate authentication and
-          authorization, and managed separately from the TD identifier.</span>
+          authorization, and managed separately from the TD identifier.
+          <!-- </span> -->
           If it is necessary to use an immutable identifier as the TD identifier, 
           extra attention should be paid to secure 
           access to files, such as Thing Descriptions, containing such


### PR DESCRIPTION
- Modifies at-risk assertion "privacy-immutable-id-as-property" due to insufficient implementations (1/2)
- Downgrade to informative statement by converting "SHOULD" to "should" and commenting out assertion markup
- See https://github.com/w3c/wot-testing/tree/main/events/2023.03.Online


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-thing-description/pull/1826.html" title="Last updated on May 18, 2023, 3:43 PM UTC (29a72c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1826/6a676a0...mmccool:29a72c3.html" title="Last updated on May 18, 2023, 3:43 PM UTC (29a72c3)">Diff</a>