### PR TITLE
Resolve security-context-secure-fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -7107,11 +7107,11 @@ instance.
 	      "plain" HTTP URLs.  
 	      However, the HTTP protocol is vulnerable to interception and modification if 
 	      used without first establishing a secure transport channel using TLS. 
-	      <span class="rfc2119-assertion" id="security-context-secure-fetch">
+	      <!-- <span class="rfc2119-assertion" id="security-context-secure-fetch"> -->
 	      If it is necessary to fetch a context definition file,
-	      an implementation SHOULD first attempt to use HTTP over TLS 
+	      an implementation should first attempt to use HTTP over TLS 
 	      even when only an HTTP URL is given.
-	      </span>
+	      <!-- </span> -->
       </dd></dl>
    </section>
    <section id="security-consideration-access-duration">

--- a/index.template.html
+++ b/index.template.html
@@ -5816,11 +5816,11 @@ instance.
 	      "plain" HTTP URLs.  
 	      However, the HTTP protocol is vulnerable to interception and modification if 
 	      used without first establishing a secure transport channel using TLS. 
-	      <span class="rfc2119-assertion" id="security-context-secure-fetch">
+	      <!-- <span class="rfc2119-assertion" id="security-context-secure-fetch"> -->
 	      If it is necessary to fetch a context definition file,
-	      an implementation SHOULD first attempt to use HTTP over TLS 
+	      an implementation should first attempt to use HTTP over TLS 
 	      even when only an HTTP URL is given.
-	      </span>
+	      <!-- </span> -->
       </dd></dl>
    </section>
    <section id="security-consideration-access-duration">


### PR DESCRIPTION
- Modifies at-risk assertion "security-context-secure-fetch" due to insufficient implementations (0/2)
- Downgrade to informative statement by converting "SHOULD" to "should" and commenting out assertion markup
- See https://github.com/w3c/wot-testing/tree/main/events/2023.03.Online