### PR TITLE
Update dates for JSON schema files for PR 1828

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -1,6 +1,6 @@
 {
   "title": "Thing Description",
-  "version": "1.1-23-March-2023",
+  "version": "1.1-24-May-2023",
   "description": "JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id":"https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",

--- a/validation/tm-json-schema-validation.json
+++ b/validation/tm-json-schema-validation.json
@@ -1,6 +1,6 @@
 {
   "title": "Thing Model",
-  "version": "1.1-23-March-2023",
+  "version": "1.1-24-May-2023",
   "description": "JSON Schema for validating Thing Models. This is automatically generated from the WoT TD Schema.",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/tm-json-schema-validation.json",


### PR DESCRIPTION
PR https://github.com/w3c/wot-thing-description/pull/1828 modified the JSON schema files and forgot about updating the dates which are necessary for the Scripting API that out of the JSON schema automatically generates TypeScript definitions.

