### PR TITLE
Fix well known operation types only

### DIFF
--- a/index.html
+++ b/index.html
@@ -2298,8 +2298,7 @@ is provided in Appendix <a href="#json-schema-for-validation"></a>.
           Future versions of the standard may extend this list but
           <span class="rfc2119-assertion" id=
           "well-known-operation-types-only">operations types
-          SHOULD NOT be
-          arbitrarily set by servients and be restricted to the values in the
+          MUST be restricted to the values in the
           table below.</span></p>
 
         <div id="table-operation-types">

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -762,8 +762,7 @@
           Future versions of the standard may extend this list but
           <span class="rfc2119-assertion" id=
           "well-known-operation-types-only">operations types
-          SHOULD NOT be
-          arbitrarily set by servients and be restricted to the values in the
+          MUST be restricted to the values in the
           table below.</span></p>
 
         <div id="table-operation-types">


### PR DESCRIPTION
The assertion contains two conflicting statements, keep only the one
that matches the concept expressed few lines above:

```
    The list of possible operation types of a form is fixed.
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/luminem/wot-thing-description/pull/1843.html" title="Last updated on Jul 12, 2023, 3:20 PM UTC (2f6ced0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1843/a09239f...luminem:2f6ced0.html" title="Last updated on Jul 12, 2023, 3:20 PM UTC (2f6ced0)">Diff</a>