### PR TITLE
Update schema to not allow empty op array

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -1,6 +1,6 @@
 {
   "title": "Thing Description",
-  "version": "1.1-24-May-2023",
+  "version": "1.1-05-July-2023",
   "description": "JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id":"https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",
@@ -403,7 +403,8 @@
                   "observeproperty",
                   "unobserveproperty"
                 ]
-              }
+              },
+              "minItems": 1
             }
           ]
         }
@@ -433,7 +434,8 @@
                   "queryaction",
                   "cancelaction"
                 ]
-              }
+              },
+              "minItems": 1
             }
           ]
         }
@@ -461,7 +463,8 @@
                   "subscribeevent",
                   "unsubscribeevent"
                 ]
-              }
+              },
+              "minItems": 1
             }
           ]
         }
@@ -503,7 +506,8 @@
                   "subscribeallevents",
                   "unsubscribeallevents"
                 ]
-              }
+              },
+              "minItems": 1
             }
           ]
         }

--- a/validation/tm-json-schema-validation.json
+++ b/validation/tm-json-schema-validation.json
@@ -1,6 +1,6 @@
 {
   "title": "Thing Model",
-  "version": "1.1-24-May-2023",
+  "version": "1.1-05-July-2023",
   "description": "JSON Schema for validating Thing Models. This is automatically generated from the WoT TD Schema.",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/tm-json-schema-validation.json",
@@ -523,7 +523,8 @@
                     "$ref": "#/definitions/placeholder-pattern"
                   }
                 ]
-              }
+              },
+              "minItems": 1
             }
           ]
         },
@@ -579,7 +580,8 @@
                     "$ref": "#/definitions/placeholder-pattern"
                   }
                 ]
-              }
+              },
+              "minItems": 1
             }
           ]
         },
@@ -633,7 +635,8 @@
                     "$ref": "#/definitions/placeholder-pattern"
                   }
                 ]
-              }
+              },
+              "minItems": 1
             }
           ]
         },
@@ -701,7 +704,8 @@
                     "$ref": "#/definitions/placeholder-pattern"
                   }
                 ]
-              }
+              },
+              "minItems": 1
             }
           ]
         },


### PR DESCRIPTION
fixes #1841
This is a bug fix in my opinion.

Note: I have mirrored the changes in Playground at https://github.com/thingweb/thingweb-playground/pull/476 and verified that tests of valid and invalid TDs still pass. 