### PR TITLE
Example 44 fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -5139,7 +5139,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
             "type": "number",
             "minimum": -32.5,
             "maximum": 55.2,
-            "unit": "om:degree_Celsius",
+            "unit": "om:degreeCelsius",
             "forms": [...]
         },
         // ...

--- a/index.template.html
+++ b/index.template.html
@@ -3849,7 +3849,7 @@ On the <a>Thing</a> side, <a>Thing</a> is expected to return readable (non <code
             "type": "number",
             "minimum": -32.5,
             "maximum": 55.2,
-            "unit": "om:degree_Celsius",
+            "unit": "om:degreeCelsius",
             "forms": [...]
         },
         // ...


### PR DESCRIPTION
there is a wrong semantic reference used in [Example 44](https://w3c.github.io/wot-thing-description/#example-44):

```json
"@context": [
...
      "om": "http://www.ontology-of-units-of-measure.org/resource/om-2/",
...
"unit": "om:degree_Celsius",
...
```

Correct should be:


```json
"@context": [
...
      "om": "http://www.ontology-of-units-of-measure.org/resource/om-2/",
...
"unit": "om:degreeCelsius",
...
```

Also see 

http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1845.html" title="Last updated on Jul 6, 2023, 10:32 AM UTC (43516ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1845/a09239f...43516ce.html" title="Last updated on Jul 6, 2023, 10:32 AM UTC (43516ce)">Diff</a>