### PR TITLE
Render at-risk warning only if note is "at risk"

### DIFF
--- a/templates.sparql
+++ b/templates.sparql
@@ -44,9 +44,8 @@ template :classes(?ns) {
     bind (if(bound(?predefined), ?predefined, "1000"^^xsd:integer) as ?rank)
     optional {
         ?shape skos:editorialNote ?note .
-        # FIXME only if note is "at risk"
     }
-    bind (bound(?note) as ?atRisk)
+    bind (if(bound(?note), ?note = "at risk", false) as ?atRisk)
 } order by ?rank
 
 template :fields(?class ?ns) {


### PR DESCRIPTION
This PR addresses a "FIXME" comment I noticed in the `templates.sparql` file, demanding that at-risk notes should only be added to the resulting document if the corresponding `skos:editorialNote` exactly equals "at risk". The fix in the PR slightly adjusts the logic to implement this.

As this is not a critical change, I guess we could postpone this PR and not merge it right away.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-thing-description/pull/1859.html" title="Last updated on Jul 26, 2023, 11:13 AM UTC (290a00b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1859/7bf1c53...JKRhb:290a00b.html" title="Last updated on Jul 26, 2023, 11:13 AM UTC (290a00b)">Diff</a>