### PR TITLE
Desired namespaces for 1.0 and 1.1 resources

### DIFF
--- a/NAMESPACES.md
+++ b/NAMESPACES.md
@@ -1,4 +1,4 @@
-# Namespaces and Resources
+# [Draft] Namespaces and Resources
 
 The W3C WoT WG maintains a list of namespaces and the resources behind them in addition to the standardization documents.
 This file lists them together.

--- a/NAMESPACES.md
+++ b/NAMESPACES.md
@@ -28,7 +28,7 @@ For choosing new namespaces, please refer to <https://www.w3.org/2005/07/13-nsur
 
 | W3C URL | GitHub URL | Content Type |
 | ------- | ---------- | ------------ |
-| `https://www.w3.org/2019/wot/td/v1` | `http://w3c.github.io/wot-thing-description/context/td-context-1.1.jsonld` | `application/ld+json`|
+| `https://www.w3.org/2019/wot/td/v1` | `https://w3c.github.io/wot-thing-description/publication/rec/context/td-context-1.1.jsonld` | `application/ld+json`|
 | `https://www.w3.org/2019/wot/td` | `http://w3c.github.io/wot-thing-description/ontology/td.ttl` | `text/turtle` |
 | `https://www.w3.org/2019/wot/td` (same as above) | `http://w3c.github.io/wot-thing-description/ontology/td.html` | `text/html` |
 | `https://www.w3.org/2019/wot/json-schema` | `http://w3c.github.io/wot-thing-description/ontology/json-schema.ttl` | `text/turtle` |
@@ -37,16 +37,16 @@ For choosing new namespaces, please refer to <https://www.w3.org/2005/07/13-nsur
 | `https://www.w3.org/2019/wot/security` (same as above) | `http://w3c.github.io/wot-thing-description/ontology/wotsec.html` | `text/html`|
 | `https://www.w3.org/2019/wot/hypermedia` | `http://w3c.github.io/wot-thing-description/ontology/hypermedia.ttl` | `text/turtle`
 | `https://www.w3.org/2019/wot/hypermedia` (same as above)| `http://w3c.github.io/wot-thing-description/ontology/hyperm.html` | `text/html` |
-| `https://www.w3.org/2022/wot/td/v1.1` | `https://w3c.github.io/wot-thing-description/context/td-context-1.1.jsonld` | `application/ld+json`|
-| `https://www.w3.org/2022/wot/tm` (NEW) | `https://w3c.github.io/wot-thing-description/ontology/tm.ttl` | `text/turtle`|
+| `https://www.w3.org/2022/wot/td/v1.1` | `https://w3c.github.io/wot-thing-description/publication/rec11/context/td-context-1.1.jsonld` | `application/ld+json`|
+| `https://www.w3.org/2022/wot/tm` (NEW) | `https://w3c.github.io/wot-thing-description/publication/rec11/ontology/tm.ttl` | `text/turtle`|
 
 ### JSON Schemas
 
 | W3C URL | GitHub URL | Content Type |
 | ------- | ---------- | ------------ |
-| `https://www.w3.org/2019/wot/td-schema/v1` (NEW) | `https://raw.githubusercontent.com/w3c/wot-thing-description/REC1.0/validation/td-json-schema-validation.json` | `application/json` |
-| `https://www.w3.org/2022/wot/td-schema/v1.1` (NEW) | `https://raw.githubusercontent.com/w3c/wot-thing-description/TD11-PR/validation/td-json-schema-validation.json` | `application/json` |
-| `https://www.w3.org/2022/wot/tm-schema/v1.1` (NEW)  | `https://raw.githubusercontent.com/w3c/wot-thing-description/TD11-PR/validation/tm-json-schema-validation.json` | `application/json` |
+| `https://www.w3.org/2019/wot/td-schema/v1` (NEW) | `https://w3c.github.io/wot-thing-description/publication/rec/validation/td-json-schema-validation.json` | `application/json` |
+| `https://www.w3.org/2022/wot/td-schema/v1.1` (NEW) | `https://w3c.github.io/wot-thing-description/publication/rec11/validation/td-json-schema-validation.json` | `application/json` |
+| `https://www.w3.org/2022/wot/tm-schema/v1.1` (NEW)  | `https://w3c.github.io/wot-thing-description/publication/rec11/validation/tm-json-schema-validation.json` | `application/json` |
 
 ## Discussion so far
 

--- a/NAMESPACES.md
+++ b/NAMESPACES.md
@@ -37,16 +37,16 @@ For choosing new namespaces, please refer to <https://www.w3.org/2005/07/13-nsur
 | `https://www.w3.org/2019/wot/security` (same as above) | `http://w3c.github.io/wot-thing-description/ontology/wotsec.html` | `text/html`|
 | `https://www.w3.org/2019/wot/hypermedia` | `http://w3c.github.io/wot-thing-description/ontology/hypermedia.ttl` | `text/turtle`
 | `https://www.w3.org/2019/wot/hypermedia` (same as above)| `http://w3c.github.io/wot-thing-description/ontology/hyperm.html` | `text/html` |
-| `https://www.w3.org/2022/wot/td/v1.1` | `https://w3c.github.io/wot-thing-description/publication/rec11/context/td-context-1.1.jsonld` | `application/ld+json`|
-| `https://www.w3.org/2022/wot/tm` (NEW) | `https://w3c.github.io/wot-thing-description/publication/rec11/ontology/tm.ttl` | `text/turtle`|
+| `https://www.w3.org/2022/wot/td/v1.1` | `https://w3c.github.io/wot-thing-description/publication/ver11/7-rec/context/td-context-1.1.jsonld` | `application/ld+json`|
+| `https://www.w3.org/2022/wot/tm` (NEW) | `https://w3c.github.io/wot-thing-description/publication/ver11/7-rec/ontology/tm.ttl` | `text/turtle`|
 
 ### JSON Schemas
 
 | W3C URL | GitHub URL | Content Type |
 | ------- | ---------- | ------------ |
 | `https://www.w3.org/2019/wot/td-schema/v1` (NEW) | `https://w3c.github.io/wot-thing-description/publication/rec/validation/td-json-schema-validation.json` | `application/json` |
-| `https://www.w3.org/2022/wot/td-schema/v1.1` (NEW) | `https://w3c.github.io/wot-thing-description/publication/rec11/validation/td-json-schema-validation.json` | `application/json` |
-| `https://www.w3.org/2022/wot/tm-schema/v1.1` (NEW)  | `https://w3c.github.io/wot-thing-description/publication/rec11/validation/tm-json-schema-validation.json` | `application/json` |
+| `https://www.w3.org/2022/wot/td-schema/v1.1` (NEW) | `https://w3c.github.io/wot-thing-description/publication/ver11/7-rec/validation/td-json-schema-validation.json` | `application/json` |
+| `https://www.w3.org/2022/wot/tm-schema/v1.1` (NEW)  | `https://w3c.github.io/wot-thing-description/publication/ver11/7-rec/validation/tm-json-schema-validation.json` | `application/json` |
 
 ## Discussion so far
 


### PR DESCRIPTION
This assumes that we:
- Add resources to folder at 1.0 rec publication: `https://github.com/w3c/wot-thing-description/tree/main/publication/rec`
- Create a new folder at 1.1 rec publication: `https://github.com/w3c/wot-thing-description/tree/main/publication/rec11`