### PR TITLE
Add work-items.md to the list 

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -3,6 +3,7 @@
 - [Presentation from Michael Koster](https://github.com/w3c/wot/blob/main/PRESENTATIONS/2023-31-05-tdnext.pdf)
 - Charter Draft: [Working Document](https://github.com/w3c/wot-charter-drafts/blob/main/wot-wg-2023-draft.html) | [Rendered Document](https://w3c.github.io/wot-charter-drafts/wot-wg-2023-draft.html)
 - Detailed Work Items: [Working Document](https://github.com/w3c/wot-charter-drafts/blob/main/wot-wg-2023-details.html) | [Rendered Document](https://w3c.github.io/wot-charter-drafts/wot-wg-2023-details.html)
+- TD Work Items in the main WoT repository: https://github.com/w3c/wot/blob/main/planning/ThingDescription/work-items.md
 - Pull Requests at https://github.com/w3c/wot-charter-drafts
 - Possibly Discussion in Issues in this repository
 


### PR DESCRIPTION
The planning document did not have the work items in the w3c/wot repository