### PR TITLE
Fix examples with wrong context url

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,6 +466,7 @@ a[href].internalDFN {
         specification and do not have at least two implementations at that
         time will either be removed or converted into informative
         statements, as appropriate.</p>
+
   </section>
 
   <section id="introduction" class="informative">
@@ -4454,7 +4455,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 </p>
 <pre class="example">
     {
-        "@context": "http://www.w3.org/2022/wot/td/v1.1",
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
         // ...
         "properties": {
             "weather": {
@@ -4482,7 +4483,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 </p>
 <pre class="example">
     {
-        "@context": "http://www.w3.org/2022/wot/td/v1.1",
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
         // ...
         "properties": {
             "weather": {
@@ -7950,7 +7951,7 @@ instance.
   </div>
   <pre class="selected without exampleTab1 json">
     {
-        "@context": "http://www.w3.org/2022/wot/td/v1.1",
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
         "id": "urn:uuid:4778f80a-4c78-4cbb-a0e4-fa37b7d748df",
         "title": "WebhookThing",
         "description": "Webhook-based Event with subscription and unsubscribe form.",
@@ -8008,7 +8009,7 @@ instance.
   </pre>
   <pre class="with exampleTab1 json">
     {
-        "@context": "http://www.w3.org/2022/wot/td/v1.1",
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
         "id": "urn:uuid:3c1b4716-247f-4cda-ba53-d3307ac6feb0",
         "title": "WebhookThing",
         "description": "Webhook-based Event with subscription and unsubscribe form.",

--- a/index.template.html
+++ b/index.template.html
@@ -3164,7 +3164,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 </p>
 <pre class="example">
     {
-        "@context": "http://www.w3.org/2022/wot/td/v1.1",
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
         // ...
         "properties": {
             "weather": {
@@ -3192,7 +3192,7 @@ Example <a href="#webhook-example-serialization"></a> illustrates how Events can
 </p>
 <pre class="example">
     {
-        "@context": "http://www.w3.org/2022/wot/td/v1.1",
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
         // ...
         "properties": {
             "weather": {
@@ -6660,7 +6660,7 @@ instance.
   </div>
   <pre class="selected without exampleTab1 json">
     {
-        "@context": "http://www.w3.org/2022/wot/td/v1.1",
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
         "id": "urn:uuid:4778f80a-4c78-4cbb-a0e4-fa37b7d748df",
         "title": "WebhookThing",
         "description": "Webhook-based Event with subscription and unsubscribe form.",
@@ -6718,7 +6718,7 @@ instance.
   </pre>
   <pre class="with exampleTab1 json">
     {
-        "@context": "http://www.w3.org/2022/wot/td/v1.1",
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
         "id": "urn:uuid:3c1b4716-247f-4cda-ba53-d3307ac6feb0",
         "title": "WebhookThing",
         "description": "Webhook-based Event with subscription and unsubscribe form.",


### PR DESCRIPTION
There were examples without the `s` in `https` so the context was not passing json schema validation. Yet another reason why we need #1851 in the next version...

These are purely editorial and are considered bugs from my point of view.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1868.html" title="Last updated on Aug 8, 2023, 3:29 PM UTC (5fddd2c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1868/c1f925b...5fddd2c.html" title="Last updated on Aug 8, 2023, 3:29 PM UTC (5fddd2c)">Diff</a>