### PR TITLE
Fix schema links to static ones

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,6 +466,7 @@ a[href].internalDFN {
         specification and do not have at least two implementations at that
         time will either be removed or converted into informative
         statements, as appropriate.</p>
+
   </section>
 
   <section id="introduction" class="informative">
@@ -5878,11 +5879,9 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         For example, the value of <code>minimum</code> needs to be an <code>integer</code>, unless a placeholder is used.
     </p>
     <p>
-        You can use <a href="https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/tm-json-schema-validation.json">the JSON Schema in the GitHub repository</a> to validate TM instances that are serialized as JSON.
+        You can use <a target="_blank" href="https://www.w3.org/2022/wot/tm-schema/v1.1">the JSON Schema</a> to validate TM instances that are serialized as JSON.
     </p>
-    <p class="note">
-        The link for the TM needs to be updated to a permanent one before publication.
-      </p>
+
   </section>
   <section id="thing-model-declaration" class="normative">
     <h2>Thing Model Declaration</h2>
@@ -8076,7 +8075,7 @@ instance.
   <section id="json-schema-for-validation" class="appendix informative">
   <h1>JSON Schema for TD Instance Validation</h1>
     <p>
-        A JSON Schema [[?JSON-SCHEMA]] document for syntactically validating Thing Description instances serialized in JSON based format is available in <a href="https://github.com/w3c/wot-thing-description/blob/main/validation/td-json-schema-validation.json">the GitHub repository</a>.
+        A JSON Schema [[?JSON-SCHEMA]] document for syntactically validating Thing Description instances serialized in JSON based format is available at <a target="_blank" href="https://www.w3.org/2022/wot/td-schema/v1.1">https://www.w3.org/2022/wot/td-schema/v1.1</a>.
         This JSON Schema does not require the terms with <a>Default Values</a> to be present. Thus, the terms with <a>Default Values</a> are optional. (see also <a href="#sec-default-values"></a>)
     </p>
 
@@ -8088,9 +8087,6 @@ instance.
         regard. You can replace the value of <code>additionalProperties</code> schema 
         property <code>true</code> with <code>false</code> in different scopes/levels in 
         order to perform a stricter validation in case no external vocabularies are used.
-    </p>
-
-    <p class="note"> The <code>$id</code> field in the JSON Schemas need to be updated to a static URL before publication, as well as the actual link pointing to the schema.
     </p>
 
   </section>

--- a/index.template.html
+++ b/index.template.html
@@ -4588,11 +4588,9 @@ in a WoT Thing Description MUST accurately describe the <a>WoT Interface</a> of 
         For example, the value of <code>minimum</code> needs to be an <code>integer</code>, unless a placeholder is used.
     </p>
     <p>
-        You can use <a href="https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/tm-json-schema-validation.json">the JSON Schema in the GitHub repository</a> to validate TM instances that are serialized as JSON.
+        You can use <a target="_blank" href="https://www.w3.org/2022/wot/tm-schema/v1.1">the JSON Schema</a> to validate TM instances that are serialized as JSON.
     </p>
-    <p class="note">
-        The link for the TM needs to be updated to a permanent one before publication.
-      </p>
+
   </section>
   <section id="thing-model-declaration" class="normative">
     <h2>Thing Model Declaration</h2>
@@ -6786,7 +6784,7 @@ instance.
   <section id="json-schema-for-validation" class="appendix informative">
   <h1>JSON Schema for TD Instance Validation</h1>
     <p>
-        A JSON Schema [[?JSON-SCHEMA]] document for syntactically validating Thing Description instances serialized in JSON based format is available in <a href="https://github.com/w3c/wot-thing-description/blob/main/validation/td-json-schema-validation.json">the GitHub repository</a>.
+        A JSON Schema [[?JSON-SCHEMA]] document for syntactically validating Thing Description instances serialized in JSON based format is available at <a target="_blank" href="https://www.w3.org/2022/wot/td-schema/v1.1">https://www.w3.org/2022/wot/td-schema/v1.1</a>.
         This JSON Schema does not require the terms with <a>Default Values</a> to be present. Thus, the terms with <a>Default Values</a> are optional. (see also <a href="#sec-default-values"></a>)
     </p>
 
@@ -6798,9 +6796,6 @@ instance.
         regard. You can replace the value of <code>additionalProperties</code> schema 
         property <code>true</code> with <code>false</code> in different scopes/levels in 
         order to perform a stricter validation in case no external vocabularies are used.
-    </p>
-
-    <p class="note"> The <code>$id</code> field in the JSON Schemas need to be updated to a static URL before publication, as well as the actual link pointing to the schema.
     </p>
 
   </section>


### PR DESCRIPTION
We should fix these notes. My proposal is to merge this and https://github.com/w3c/wot-thing-description/pull/1861 together and decide on where to serve the content from. It doesn't matter if the schemas come from a new repo, a GitHub release or the publication folder but these links should appear in the REC.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1870.html" title="Last updated on Aug 8, 2023, 10:43 PM UTC (6e88bb5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1870/c1f925b...6e88bb5.html" title="Last updated on Aug 8, 2023, 10:43 PM UTC (6e88bb5)">Diff</a>