### PR TITLE
Remove editor's notes and convert two to normal note

### DIFF
--- a/index.html
+++ b/index.html
@@ -7513,6 +7513,9 @@ instance.
           <dd>Not Applicable</dd>
           <dt>File extension(s):</dt>
           <dd>.jsontd
+        <p class="note" title="Other Extensions">
+            Please look at the current IANA registration; in the future .td.json and .td.jsonld may also be allowed.
+        </p>
 	  </dd>
           <dt>Macintosh file type code(s):</dt>
           <dd>TEXT</dd>

--- a/index.html
+++ b/index.html
@@ -466,6 +466,7 @@ a[href].internalDFN {
         specification and do not have at least two implementations at that
         time will either be removed or converted into informative
         statements, as appropriate.</p>
+
   </section>
 
   <section id="introduction" class="informative">
@@ -7190,7 +7191,7 @@ instance.
         function to be parsed.
 	</span></dd>
      </dl>
-     <p class="ednote" title="Other Injection Risks">
+     <p class="note" title="Other Injection Risks">
      There are additional code injection risks discussed in
      [[WOT-DISCOVERY]]. Other strings in TDs, such as the values given for
      <code>title</code> and <code>description</code>, should be sanitized before being
@@ -7470,10 +7471,6 @@ instance.
       <dd>None</dd>
       <dt>Encoding considerations:</dt>
       <dd>See <a href="https://datatracker.ietf.org/doc/html/rfc6839#section-3.1">RFC&nbsp;6839, section 3.1</a>.
-      <p class="ednote" title="Other Encoding Considerations">
-      The cited section allows UTF-16 and UTF-32. 
-      We probably should state that only UTF-8 is allowed (8-bit compatible, RFC2045).
-      </p>
       </dd>
       <dt>Security considerations:</dt>
       <dd>See 
@@ -7496,11 +7493,6 @@ instance.
         <a href="https://www.w3.org/TR/wot-thing-description11/">W3C 
         Web of Things (WoT) Thing Description 1.1: 
         https://www.w3.org/TR/wot-thing-description11/</a>
-        <p class="ednote" title="Versions">
-	This has been updated to point to the TD 1.1 specification.
-	Should we note that versions (and TDs vs. TMs) can be distinguished using
-	information interior to the content?
-	</p>
         </dd>
       <dt>Applications that use this media type:</dt>
       <dd>
@@ -7513,14 +7505,6 @@ instance.
       </dd>
       <dt>Fragment identifier considerations:</dt>
       <dd>See <a href="https://datatracker.ietf.org/doc/html/rfc6839#section-3.1">RFC&nbsp;6839, section 3.1</a>.
-      <p class="ednote" title="Other Fragment Identifier Considerations">
-      We may want to explictly allow use of JSON Pointer as a fragment identifier [[RFC6901]].
-      There is in fact an assertion requiring them in TMs for <code>tm:optional</code>.
-      These are internal references, however, so we <em>might</em> not have to allow
-      them for external references.
-      By default
-      the json media type does not support a fragment identifier but td+json could.
-      </p>
       </dd>
       <dt>Additional information:</dt>
       <dd>
@@ -7529,15 +7513,6 @@ instance.
           <dd>Not Applicable</dd>
           <dt>File extension(s):</dt>
           <dd>.jsontd
-	  <p class="ednote" title="Other Extensions">
-	  We have been using .td.jsonld and .tm.jsonld in testing.  
-	  Should we also define these formally? 
-	  If we are using the same media type for TMs, should we still have
-	  a distinct filename extension?  
-	  If so, should we (also?) define .jsontm for consistency?
-	  Note: the IANA Considerations for HTML allows multiple
-	  suffixes, html and htm.
-	  </p>
 	  </dd>
           <dt>Macintosh file type code(s):</dt>
           <dd>TEXT</dd>
@@ -7545,9 +7520,6 @@ instance.
       </dd>
       <dt>Person &amp; email address to contact for further information:</dt>
       <dd>Matthias Kovatsch &lt;w3c@kovatsch.net&gt;
-      <p class="ednote" title="Update Contact">
-      Should the contact be updated?
-      </p>
       </dd>
       <dt>Intended usage:</dt>
       <dd>COMMON</dd>

--- a/index.template.html
+++ b/index.template.html
@@ -6222,6 +6222,9 @@ instance.
           <dd>Not Applicable</dd>
           <dt>File extension(s):</dt>
           <dd>.jsontd
+        <p class="note" title="Other Extensions">
+            Please look at the current IANA registration; in the future .td.json and .td.jsonld may also be allowed.
+        </p>
 	  </dd>
           <dt>Macintosh file type code(s):</dt>
           <dd>TEXT</dd>

--- a/index.template.html
+++ b/index.template.html
@@ -5900,7 +5900,7 @@ instance.
         function to be parsed.
 	</span></dd>
      </dl>
-     <p class="ednote" title="Other Injection Risks">
+     <p class="note" title="Other Injection Risks">
      There are additional code injection risks discussed in
      [[WOT-DISCOVERY]]. Other strings in TDs, such as the values given for
      <code>title</code> and <code>description</code>, should be sanitized before being
@@ -6180,10 +6180,6 @@ instance.
       <dd>None</dd>
       <dt>Encoding considerations:</dt>
       <dd>See <a href="https://datatracker.ietf.org/doc/html/rfc6839#section-3.1">RFC&nbsp;6839, section 3.1</a>.
-      <p class="ednote" title="Other Encoding Considerations">
-      The cited section allows UTF-16 and UTF-32. 
-      We probably should state that only UTF-8 is allowed (8-bit compatible, RFC2045).
-      </p>
       </dd>
       <dt>Security considerations:</dt>
       <dd>See 
@@ -6206,11 +6202,6 @@ instance.
         <a href="https://www.w3.org/TR/wot-thing-description11/">W3C 
         Web of Things (WoT) Thing Description 1.1: 
         https://www.w3.org/TR/wot-thing-description11/</a>
-        <p class="ednote" title="Versions">
-	This has been updated to point to the TD 1.1 specification.
-	Should we note that versions (and TDs vs. TMs) can be distinguished using
-	information interior to the content?
-	</p>
         </dd>
       <dt>Applications that use this media type:</dt>
       <dd>
@@ -6223,14 +6214,6 @@ instance.
       </dd>
       <dt>Fragment identifier considerations:</dt>
       <dd>See <a href="https://datatracker.ietf.org/doc/html/rfc6839#section-3.1">RFC&nbsp;6839, section 3.1</a>.
-      <p class="ednote" title="Other Fragment Identifier Considerations">
-      We may want to explictly allow use of JSON Pointer as a fragment identifier [[RFC6901]].
-      There is in fact an assertion requiring them in TMs for <code>tm:optional</code>.
-      These are internal references, however, so we <em>might</em> not have to allow
-      them for external references.
-      By default
-      the json media type does not support a fragment identifier but td+json could.
-      </p>
       </dd>
       <dt>Additional information:</dt>
       <dd>
@@ -6239,15 +6222,6 @@ instance.
           <dd>Not Applicable</dd>
           <dt>File extension(s):</dt>
           <dd>.jsontd
-	  <p class="ednote" title="Other Extensions">
-	  We have been using .td.jsonld and .tm.jsonld in testing.  
-	  Should we also define these formally? 
-	  If we are using the same media type for TMs, should we still have
-	  a distinct filename extension?  
-	  If so, should we (also?) define .jsontm for consistency?
-	  Note: the IANA Considerations for HTML allows multiple
-	  suffixes, html and htm.
-	  </p>
 	  </dd>
           <dt>Macintosh file type code(s):</dt>
           <dd>TEXT</dd>
@@ -6255,9 +6229,6 @@ instance.
       </dd>
       <dt>Person &amp; email address to contact for further information:</dt>
       <dd>Matthias Kovatsch &lt;w3c@kovatsch.net&gt;
-      <p class="ednote" title="Update Contact">
-      Should the contact be updated?
-      </p>
       </dd>
       <dt>Intended usage:</dt>
       <dd>COMMON</dd>


### PR DESCRIPTION
fixes #1869 

All the editor's notes that I have removed are copied as issues that are linked below:
- #1876
- #1875
- #1874 
- #1873 
- #1872


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/1877.html" title="Last updated on Aug 23, 2023, 2:58 PM UTC (6b2ee54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/1877/c1f925b...6b2ee54.html" title="Last updated on Aug 23, 2023, 2:58 PM UTC (6b2ee54)">Diff</a>