### PR TITLE
Adding publication folder to robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /proposals/
+Disallow: /publication/


### PR DESCRIPTION
Since that folder is just a preliminary area, crawlers should not show results from it.