### PR TITLE
Reorganize Versioning document

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -2,44 +2,84 @@
 
 In addition to the specifications, there are other resources that are managed in this repository.
 This file documents the discussion on how the versioning should be.
-Once there is an agreement, the rules will be moved to [wot-resources](https://github.com/w3c/wot-resources) repository.
-The points below present a summary, but you can scroll to the bottom of the page to find the original input from the meetings.
+Once there is an agreement, the rules will be moved to [wot-resources](https://github.com/w3c/wot-resources) repository with a corresponding policy.
+
+## Versioning for 1.0 and 1.1 Specifications
 
 - With each REC, we publish the following files:
   - Ontology files in form of TTL and HTML. These are TD, Security, hypermedia controls, JSON Schema, and soon the TM
   - JSON-LD Context file
   - JSON Schemas for TD and TM
-- We do not publish different versions of these files until we see the need (e.g. a bug that also has breaking changes to current implementations).
-- Initial thoughts on versioning
-  - When a user wants to get a resource and does not specify the version, they get the latest version.
-  - We prefer semantic versioning with the following rules (also see <https://github.com/json-schema-org/website/issues/197#issuecomment-1883270213>):
-    - Patch: English typos etc.
-    - Minor: Relaxing a constraint (longer strings, more oneof) so that more TDs can pass the schema.
-    - Major: Adding or restricting constraints
+- DECISION: We do not publish different versions of these files until we see the need (e.g. a bug that also has breaking changes to current implementations).
+
+## Versioning for next Release
+
+### Big Picture Versioning Timeline
+
+Do we version anything until a REC release, i.e. for TD.next, do we want to publish resources with each publication (WD, CR, PR etc, even each PR merged) or not?
+  - ( @relu91 ) An unofficial version increment for WG members (not for outside): E.g. an alpha prefix and then a number. Beta etc. can be used when going into CR. Or we just tag/prefix/suffix with CR, PR or nightly
   - ( @egekorkan ) The versioning rules do not apply to different versions of a specification, e.g. TD 1.1 schema should be treated like a new release, not a next iteration of the 1.0 schema
-  - Do we version anything until a REC release
-    - ( @relu91 ) An unofficial version increment for WG members (not for outside): E.g. an alpha prefix and then a number. Beta etc. can be used when going into CR. Or we just tag/prefix/suffix with CR, PR or nightly
-    - ( @lu-zero ) A date afterward would be good "enough" for implementers. A release every month (in addition to semver) would be also good. We can also pipeline it and tag each resource exposed to github.io.
-    - ( @mjkoster ) Short commit hash would be fine. Monthly release may not make sense (unless there is a need)
-  - We need a policy (when to change a version for example.
-  - We need to be careful since each artifact has its own version, which will complicate CD pipeline.
 
-## Original Input
+### Meaning of Changes
 
-Text copied from <https://www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf>
+Which changes are bugfixes, which are new features etc. For each type of artifact we need to agree on the meaning. Then, these meanings can be reflected on the version information.
 
-- What do we mean by versioning?
-  - Pointing to the most recent version but also older versions should be available
-  - Semver with Major, Minor, Patch at semver.org
-  - For TD.next, do we want to publish resources with each publication (WD, CR, PR etc) or not?
-- Which changes are bugfixes, new features (TD 2.0 keywords)
+File types in question:
   - JSON Schemas
-    - Patch: English typos etc. Minor: Relaxing a constraint (longer strings, more oneof) so that more TDs can pass the schema. Major: Adding or restricting constraints
+    - Original Input:
+      - Patch: English typos etc. Minor: Relaxing a constraint (longer strings, more oneof) so that more TDs can pass the schema. Major: Adding or restricting constraints
+    - Learning from JSON Schema Discussion (also see <https://github.com/json-schema-org/website/issues/197#issuecomment-1883270213>):
+      - Patch: English typos etc.
+      - Minor: Relaxing a constraint (longer strings, more oneof) so that more TDs can pass the schema.
+      - Major: Adding or restricting constraints
   - JSON-LD Context
   - Ontology files
     - TTL
     - HTML
-- How much time to invest in maintaining 1.1 resources?
-  – Maintaining multiple files or not: xxx.v1.1.0.ttl xxx.v1.1.1.ttl
-- Decision so far: Do not dig into 1.1 versioning until we have the need.
-- TM resources (tm.ttl and tm.html) will not be versioned for the first changes since HTML doesn't exist and TTL is not usable.
+  - TypeScript types
+  - UML Diagrams
+
+Notes: 
+- @mahdanoura : Also, the deprecation of terms needs to be considered, i.e. not removing but marking as deprecated.
+- Best practices for RDF versioning should be studied. See https://www.w3.org/TR/prov-primer/
+
+#### Reflecting Meaning on Version Information
+
+How do we reflect a patch change on the artifacts. Do we use semantic versioning, use date and ignore semantic versioning, do we use alpha, beta etc.
+
+- ( @lu-zero ) A date afterward would be good "enough" for implementers. A release every month (in addition to semver) would be also good. We can also pipeline it and tag each resource exposed to github.io. 
+- ( @mjkoster ) Short commit hash would be fine. Monthly release may not make sense (unless there is a need)
+- ( @mmccool ) To make things easy we should map our directories to the url structure. We should make all URLs are versioned
+
+#### Synchronisation of Changes
+
+Relevant to points above, we need to decide whether we version each artifact separately or together.
+
+Notes:
+- We need to be careful since if each artifact has its own version, the CD pipeline will get complicated.
+- @egekorkan : Matching the versions of files would mean that breaking changes in one file would increment the version in the other ones.
+- @mmccool : we can version the folder and let git show what file has changed between versions
+
+### Tooling
+
+- @egekorkan : Maybe there are options other than manually updating specific files and redirection.
+- Changelog point below is related to this
+
+### User Point of View
+
+Who is targeted by each change and how are they affect.
+
+- @mahdanoura : we should communicate the reason for the change and what the change was. We also need to define what we mean by major, minor, and patch.
+- Pointing to the most recent version but also older versions should be available. When a user wants to get a resource and does not specify the version, they get the latest version.
+- @relu91 : There are Developers who try out the specs so there is no version "just for us".
+
+Note: We should write a user story per persona about this aspect of the discussion.
+
+#### Changelog
+
+- @mmccool : Discovery TF did a changelog "test". We should let git/GitHub do the work for us, if possible. Tagging etc.
+- @relu91 : commit messages to drive the changelog. There are tools for that but may not work for "documents". We need to define guidelines as well, e.g. using "chore" when doing a small fix.
+- @mjkoster : docstrings in commit messages can be used to automate changelog
+
+
+

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -19,10 +19,11 @@ Once there is an agreement, the rules will be moved to [wot-resources](https://g
 Do we version anything until a REC release, i.e. for TD.next, do we want to publish resources with each publication (WD, CR, PR etc, even each PR merged) or not?
   - ( @relu91 ) An unofficial version increment for WG members (not for outside): E.g. an alpha prefix and then a number. Beta etc. can be used when going into CR. Or we just tag/prefix/suffix with CR, PR or nightly
   - ( @egekorkan ) The versioning rules do not apply to different versions of a specification, e.g. TD 1.1 schema should be treated like a new release, not a next iteration of the 1.0 schema
+  - @mmccool : We need specific snapshots for testing and plugfest purposes where we ask implementors to use a certain (pre-release) version of the resources. Better to name these versions with a word that reflects this (e.g. plugfest september 2025 version)
 
 ### Meaning of Changes
 
-Which changes are bugfixes, which are new features etc. For each type of artifact we need to agree on the meaning. Then, these meanings can be reflected on the version information.
+Which changes are bugfixes, which are new features etc. For each type of artifact, we need to agree on the meaning. Then, these meanings can be reflected on the version information.
 
 File types in question:
   - JSON Schemas
@@ -45,31 +46,32 @@ Notes:
 
 #### Reflecting Meaning on Version Information
 
-How do we reflect a patch change on the artifacts. Do we use semantic versioning, use date and ignore semantic versioning, do we use alpha, beta etc.
+How do we reflect a patch change on the artifacts? Do we use semantic versioning, use date, and ignore semantic versioning, do we use alpha, beta etc.
 
-- ( @lu-zero ) A date afterward would be good "enough" for implementers. A release every month (in addition to semver) would be also good. We can also pipeline it and tag each resource exposed to github.io. 
+- ( @lu-zero ) A date afterward would be good "enough" for implementers. A release every month (in addition to semver) would also be good. We can also pipeline it and tag each resource exposed to github.io. 
 - ( @mjkoster ) Short commit hash would be fine. Monthly release may not make sense (unless there is a need)
 - ( @mmccool ) To make things easy we should map our directories to the url structure. We should make all URLs are versioned
 - @mahdanoura : According to OWL2 specification, for every ontology we can define an Ontology IRI (generic reference, should stay the same through versions) and a Ontology Version IRI. The difference is during dereferencing of the IRIs, the ontology IRI should redirect to the most recent version and the version IRI to the specific version.
 
 #### Synchronisation of Changes
 
-Relevant to points above, we need to decide whether we version each artifact separately or together.
+Relevant to the points above, we need to decide whether we version each artifact separately or together.
 
 Notes:
 
 - We need to be careful since if each artifact has its own version, the CD pipeline will get complicated.
 - @egekorkan : Matching the versions of files would mean that breaking changes in one file would increment the version in the other ones.
 - @mmccool : we can version the folder and let git show what file has changed between versions
+- @danielpeintner : If all resources are synced, we will be talking about a certain spec version (pre-release)
 
 ### Tooling
 
 - @egekorkan : Maybe there are options other than manually updating specific files and redirection.
-- Changelog point below is related to this
+- The changelog point below is related to this
 
 ### User Point of View
 
-Who is targeted by each change and how are they affect.
+Who is targeted by each change and how are they affected?
 
 - @mahdanoura : we should communicate the reason for the change and what the change was. We also need to define what we mean by major, minor, and patch.
 - Pointing to the most recent version but also older versions should be available. When a user wants to get a resource and does not specify the version, they get the latest version.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -50,12 +50,14 @@ How do we reflect a patch change on the artifacts. Do we use semantic versioning
 - ( @lu-zero ) A date afterward would be good "enough" for implementers. A release every month (in addition to semver) would be also good. We can also pipeline it and tag each resource exposed to github.io. 
 - ( @mjkoster ) Short commit hash would be fine. Monthly release may not make sense (unless there is a need)
 - ( @mmccool ) To make things easy we should map our directories to the url structure. We should make all URLs are versioned
+- @mahdanoura : According to OWL2 specification, for every ontology we can define an Ontology IRI (generic reference, should stay the same through versions) and a Ontology Version IRI. The difference is during dereferencing of the IRIs, the ontology IRI should redirect to the most recent version and the version IRI to the specific version.
 
 #### Synchronisation of Changes
 
 Relevant to points above, we need to decide whether we version each artifact separately or together.
 
 Notes:
+
 - We need to be careful since if each artifact has its own version, the CD pipeline will get complicated.
 - @egekorkan : Matching the versions of files would mean that breaking changes in one file would increment the version in the other ones.
 - @mmccool : we can version the folder and let git show what file has changed between versions
@@ -81,5 +83,11 @@ Note: We should write a user story per persona about this aspect of the discussi
 - @relu91 : commit messages to drive the changelog. There are tools for that but may not work for "documents". We need to define guidelines as well, e.g. using "chore" when doing a small fix.
 - @mjkoster : docstrings in commit messages can be used to automate changelog
 
+### Metadata
 
+Different resources need different types of metadata within them.
 
+#### Ontologies
+
+- @mahdanoura: There needs to be also some supplementary metadata that needs to be provided in versioned ontologies like `dct:created`, `dct:modified`, `dct:valid`, `vann:changes`, and the relation between the ontology versions. [Section 7.4](https://www.w3.org/TR/owl-ref/#VersionInformation) details ontology versioning. It states that the `owl:versionInfo` is an annotation property, `owl:priorVersion`, `owl:backwardCompatibleWith` and `owl:incompatibleWith` are ontology properties, where `owl:Ontology` is considered as the `domain `and `range`. Therefore, this shows that OWL requires different versions of an ontology to have different URIs.
+  - There is also a proposed standard, [MOD2.0](https://github.com/FAIR-IMPACT/MOD) specification for describing ontology metada and semantic artifacts. It has some metadata we could reuse for our versioned ontologies. 


### PR DESCRIPTION
I am updating the versioning document by trying to categorize types of discussions that are documented in:
- This document
- Wiki page (which was copied into this document)
- https://github.com/w3c/wot/issues/1166
- Minutes of last week (https://www.w3.org/2024/01/25-wot-td-minutes.html)

This was a bit of a messy process. I think that this PR can be easily merged since I have kept everyone's opinion with their names. The next steps are:
- Writing user stories from the user point of view. 
- Agreeing on the content (ideally by removing names and representing TF opinion)