### PR TITLE
Errata fixes

### DIFF
--- a/errata11.html
+++ b/errata11.html
@@ -29,7 +29,7 @@
         <dt>Latest errata update:</dt>
         <dd><span id="date"></span></dd>
         <dt>Number of recorded errata:</dt>
-        <dd><span id="number"></span></dd>
+        <dd><span id="number"></span>2</dd>
         <dt>Link to all errata:</dt>
         <dd><span id="errata_link"></span></dd>
       </dl>
@@ -43,7 +43,7 @@
           <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
           <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
           <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantive ones.</li>
-          <li>ALL substantive errata are generally expected to have corresponding test(s) (such as a pull request in <a href='https://github.com/web-platform-tests/wpt'>web-platform-tests</a>), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
+          <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
       </ul>
 
         <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the sections below. Each section collects the issues for a specific document, with a separate section for the issues not assigned to any.</p>
@@ -60,12 +60,11 @@
         <h1>Open Errata on the "WoT Thing Description 1.1" Recommendation</h1>
         <dl>
           <dt>Latest Published Version:</dt>
-          <dd><a href="https://www.w3.org/TR/wot-thing-description/">https://www.w3.org/TR/wot-thing-description/</a></dd>
+          <dd><a href="https://www.w3.org/TR/wot-thing-description11/">https://www.w3.org/TR/wot-thing-description/</a></dd>
           <dt>Editor’s draft:</dt>
           <dd><a href="https://w3c.github.io/wot-thing-description/">https://w3c.github.io/wot-thing-description/</a></dd>
           <dt>Latest Publication Date:</dt>
-          <dd>2 April 2020</dd>
-          <!-- TODO: Fix the date -->
+          <dd>05 December 2023</dd>
       </dl>
         <section id="first">
           <h2>Substantive Issues</h2>
@@ -88,7 +87,14 @@
 
     <footer>
       <address><a href="mailto:ashimura@w3.org" class=''>Kaz Ashimura</a>, &lt;ashimura@w3.org&gt;, (W3C)</address>
-      <p class="copyright"><a href="/Consortium/Legal/ipr-notice#Copyright" rel="Copyright">Copyright</a> © 2020 <a href="/"><abbr title="World Wide Web Consortium">W3C</abbr></a> <sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.org/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved.</p>
+    <div class="footer-copyright text-center ">
+      Copyright © {{ 'now' | date: "%Y" }} <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br /> <abbr
+        title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a
+        href="https://www.w3.org/policies/#disclaimers">liability</a>, <a
+        href="https://www.w3.org/policies/#trademarks">trademark</a> and <a rel="license"
+        href="https://www.w3.org/copyright/document-license/" title="W3C Document License">permissive license</a> rules
+      apply.
+    </div>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
I wanted to fix https://github.com/w3c/wot-thing-description/issues/2007 but I have noticed quite a bit of problems. We were not using the correct issue labels and now that I have changed to the correct ones, we have very long erratas. The automatically loaded w3c script assumes that a repo has one specification version. So now our errata is wrong: https://w3c.github.io/wot-thing-description/errata11.html

Some ways forward:
- Option 1. Do not use the official W3C labels and create the rendered version ourselves (do not include the script)
- Option 2. Create a new repo for each REC version
- Option 3. Fork that script and filter based on TD version etc. This seems the best approach at this point but we will need to agree together.
- Option 4. Use the official labels but do not include the script and create the rendered version ourselves
- Option 5. Contribute back to the script: https://github.com/w3c/display_errata/

Notes:
- Until we solve the issue, we will not use the labels that produce unwanted text in an official document
- https://www.w3.org/2023/Process-20230612/#erratum gives a high-level description of the process.
- The entire WG should be aware that they should not use Errata label without a TF resolution.
- This procedure should be replicated for Discovery and Architecture. We can agree and test it as the TD TF and show the results in the main call.

Screenshot of the errata document with correct labels:
![image](https://github.com/w3c/wot-thing-description/assets/20195407/845549fb-312e-4d57-a58b-cb231b27e1a2)

A PDF-print of the page to show the issues:
[Open Errata for the Web of Things (WoT) Thing Description 1.1 Specification.pdf](https://github.com/w3c/wot-thing-description/files/15162653/Open.Errata.for.the.Web.of.Things.WoT.Thing.Description.1.1.Specification.pdf)
