### PR TITLE
refactor: use proper ids for examples in Multiple Security Definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3451,7 +3451,7 @@
               configuration is overridden at the form level.
             </p>
 
-            <pre class="example">
+            <pre class="example" id="multiple-security-definitions1">
   {
       // ...
       "securityDefinitions": {
@@ -3498,7 +3498,7 @@
               activating multiple security definitions, the <code>security</code> member becomes an array.
             </p>
 
-            <pre class="example" id="security-digest-example">
+            <pre class="example" id="multiple-security-definitions2a">
 {
     // ...
     "securityDefinitions": {
@@ -3529,7 +3529,7 @@
               In the following example, which is exactly equivalent to the one above, this is demonstrated:
             </p>
 
-            <pre class="example" id="security-digest-example2">
+            <pre class="example" id="multiple-security-definitions2b">
 {
     // ...
     "securityDefinitions": {

--- a/index.template.html
+++ b/index.template.html
@@ -2161,7 +2161,7 @@
               configuration is overridden at the form level.
             </p>
 
-            <pre class="example">
+            <pre class="example" id="multiple-security-definitions1">
   {
       // ...
       "securityDefinitions": {
@@ -2208,7 +2208,7 @@
               activating multiple security definitions, the <code>security</code> member becomes an array.
             </p>
 
-            <pre class="example" id="security-digest-example">
+            <pre class="example" id="multiple-security-definitions2a">
 {
     // ...
     "securityDefinitions": {
@@ -2239,7 +2239,7 @@
               In the following example, which is exactly equivalent to the one above, this is demonstrated:
             </p>
 
-            <pre class="example" id="security-digest-example2">
+            <pre class="example" id="multiple-security-definitions2b">
 {
     // ...
     "securityDefinitions": {


### PR DESCRIPTION
Note: I added IDs if missing and aligned the naming across the examples in section [6.3.4.1 Multiple Security Definitions](https://w3c.github.io/wot-thing-description/#security-multiple)


fixes https://github.com/w3c/wot-thing-description/issues/1878


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/2015.html" title="Last updated on May 9, 2024, 8:25 AM UTC (a05673e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/2015/6b1b79d...danielpeintner:a05673e.html" title="Last updated on May 9, 2024, 8:25 AM UTC (a05673e)">Diff</a>