### PR TITLE
Fixes to Errata Documents

### DIFF
--- a/errata.html
+++ b/errata.html
@@ -4,7 +4,7 @@
     The data-githubrepo attribute provides the owner/repo name on github. For W3C repositories most of those are of the
     form 'w3c/XXX', although there are groups that have their own owner for their repository.
   -->
-  <head data-githubrepo="w3c/wot-thing-description">
+  <head>
     <meta charset="UTF-8">
     <title>Open Errata for the Web of Things (WoT) Thing Description Specification</title>
     <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css"/>

--- a/errata.html
+++ b/errata.html
@@ -16,36 +16,46 @@
       <h1 class="title">Open Errata for the Web of Things (WoT) Thing Description Specification</h1>
       <dl>
         <dt>Latest errata update:</dt>
-        <dd><span id="date"></span></dd>
+        <dd><span id="date"></span>24 March 2020</dd>
         <dt>Number of recorded errata:</dt>
-        <dd><span id="number"></span></dd>
-        <dt>Link to all errata:</dt>
-        <dd><span id="errata_link"></span></dd>
+        <dd><span id="number"></span>0</dd>
       </dl>
 
-      <section data-notoc>
+      <section>
         <h1>How to Submit an Erratum?</h1>
-        <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue list for the WoT Thing Description GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
+        <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue
+            list for the WoT Thing Description GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
         <ul>
-           <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels. In some, exceptional, cases, i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
-           <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial errata from substantive ones.</li>
-          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
+          <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to
+            “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels. In some, exceptional, cases,
+            i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
+          <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate
+            editorial errata from substantive ones.</li>
+          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>”
+            is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new
+            comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on
+            the discussion).</li>
           <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
-          <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantive ones.</li>
-          <li>ALL substantive errata are generally expected to have corresponding test(s) (such as a pull request in <a href='https://github.com/web-platform-tests/wpt'>web-platform-tests</a>), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
-      </ul>
-
-        <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the sections below. Each section collects the issues for a specific document, with a separate section for the issues not assigned to any.</p>
-
-        <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact the staff contact of the Web of Things Working Group, <a href="mailto:ashimura@w3.org">Kaz Ashimura</a>.</p>
+          <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the
+            substantive ones.</li>
+          <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests
+            or modifications to existing tests, or must include the rationale for why test updates are not required for
+            the erratum.</li>
+        </ul>
+      
+        <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the
+          sections below. Each section collects the issues for a specific document, with a separate section for the issues
+          not assigned to any.</p>
+      
+        <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact
+          the staff contact of the Web of Things Working Group, <a href="mailto:ashimura@w3.org">Kaz Ashimura</a>.</p>
       </section>
+
     </header>
 
-    <div class="toc" id="toc"></div>
-
     <main>
-      <!-- The data-erratalabel should include one label that filters the errata -->
-      <section data-nolabel>
+
+      <section>
         <h1>Open Errata on the "WoT Thing Description" Recommendation</h1>
         <dl>
           <dt>Latest Published Version:</dt>

--- a/errata.html
+++ b/errata.html
@@ -21,35 +21,42 @@
         <dd><span id="number"></span>0</dd>
       </dl>
 
-      <section>
-        <h1>How to Submit an Erratum?</h1>
-        <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue
-            list for the WoT Thing Description GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
-        <ul>
-          <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to
-            “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels. In some, exceptional, cases,
-            i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
-          <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate
-            editorial errata from substantive ones.</li>
-          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>”
-            is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new
-            comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on
-            the discussion).</li>
-          <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
-          <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the
-            substantive ones.</li>
-          <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests
-            or modifications to existing tests, or must include the rationale for why test updates are not required for
-            the erratum.</li>
-        </ul>
-      
-        <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the
-          sections below. Each section collects the issues for a specific document, with a separate section for the issues
-          not assigned to any.</p>
-      
-        <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact
-          the staff contact of the Web of Things Working Group, <a href="mailto:ashimura@w3.org">Kaz Ashimura</a>.</p>
-      </section>
+    <section>
+      <h2>How to Submit an Erratum?</h2>
+      <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue list for the WoT Thing Description GitHub repository</a>.
+        The workflow to add a new erratum is as follows:</p>
+      <ul>
+        <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to
+          <code>ErratumRaised</code>. It is o.k. for an erratum to have several labels. In some, exceptional, cases, i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
+        <li>Issues labeled as <code>Editorial</code> are displayed separately, to make it easier to differentiate editorial errata from substantive ones.</li>
+        <li>The community discusses the issue. If it is accepted as a genuine erratum, the label <code>Errata</code>
+          is added to the entry and the <code>ErratumRaised</code> label should be removed. Additionally, a new
+          comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on
+          the discussion).</li>
+        <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
+        <li>Each errata may be labelled as <code>Editorial</code>; editorial errata are listed separately from the
+          substantive ones.</li>
+        <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
+      </ul>
+
+      <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the
+        sections below. Each section collects the issues for a specific document, with a separate section for the issues not assigned to any.</p>
+
+      <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact
+        the staff contact of the Web of Things Working Group, <a href="mailto:ashimura@w3.org">Kaz Ashimura</a>.</p>
+    </section>
+    
+    <section>
+      <h2>How to maintain this Document</h2>
+      <p>
+        When an errata is accepted, it should be added to this document. When doing so, the maintainers of this document should follow the steps below:
+      </p>
+      <ol>
+        <li>Add the errata to the bottom of the list at the end of the document that corresponds to the nature of the errata.</li>
+        <li>Increment the number of recorded errata at the top of the document.</li>
+        <li>Update the value of latest errata update at the top of the document</li>
+      </ol>
+    </section>
 
     </header>
 

--- a/errata.html
+++ b/errata.html
@@ -8,17 +8,6 @@
     <meta charset="UTF-8">
     <title>Open Errata for the Web of Things (WoT) Thing Description Specification</title>
     <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css"/>
-    <script src="https://www.w3.org/scripts/jquery/1.11/jquery.min.js"></script>
-    <script src="https://w3c.github.io/display_errata/assets/moment.min.js" type="text/javascript"></script>
-    <script src="https://w3c.github.io/display_errata/assets/errata.js" type="text/javascript"></script>
-    <script src="https://www.w3.org/scripts/underscore/1.8/underscore-min.js" type="text/javascript"></script>
-    <script src="https://w3c.github.io/display_errata/assets/toc.js" type="text/javascript"></script>
-
-    <style type="text/css">
-      .todo {
-        background-color: yellow
-      }
-    </style>
   </head>
   <body>
     <header>

--- a/errata.html
+++ b/errata.html
@@ -1,34 +1,41 @@
 <!DOCTYPE html>
 <html>
-  <!--
+<!--
     The data-githubrepo attribute provides the owner/repo name on github. For W3C repositories most of those are of the
     form 'w3c/XXX', although there are groups that have their own owner for their repository.
   -->
-  <head>
-    <meta charset="UTF-8">
-    <title>Open Errata for the Web of Things (WoT) Thing Description Specification</title>
-    <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css"/>
-  </head>
-  <body>
-    <header>
-      <p class="banner"><a accesskey="W" href="/"><img width="72" height="48" alt="W3C" src="https://www.w3.org/Icons/w3c_home" /></a> </p>
-      <br />
-      <h1 class="title">Open Errata for the Web of Things (WoT) Thing Description Specification</h1>
-      <dl>
-        <dt>Latest errata update:</dt>
-        <dd><span id="date"></span>24 March 2020</dd>
-        <dt>Number of recorded errata:</dt>
-        <dd><span id="number"></span>0</dd>
-      </dl>
+
+<head>
+  <meta charset="UTF-8">
+  <title>Open Errata for the Web of Things (WoT) Thing Description Specification</title>
+  <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css" />
+</head>
+
+<body>
+  <header>
+    <p class="banner"><a accesskey="W" href="/"><img width="72" height="48" alt="W3C"
+          src="https://www.w3.org/Icons/w3c_home" /></a> </p>
+    <br />
+    <h1 class="title">Open Errata for the Web of Things (WoT) Thing Description Specification</h1>
+    <dl>
+      <dt>Latest errata update:</dt>
+      <dd><span id="date"></span>24 March 2020</dd>
+      <dt>Number of recorded errata:</dt>
+      <dd><span id="number"></span>0</dd>
+    </dl>
 
     <section>
       <h2>How to Submit an Erratum?</h2>
-      <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue list for the WoT Thing Description GitHub repository</a>.
+      <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue
+          list for the WoT Thing Description GitHub repository</a>.
         The workflow to add a new erratum is as follows:</p>
       <ul>
         <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to
-          <code>ErratumRaised</code>. It is o.k. for an erratum to have several labels. In some, exceptional, cases, i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
-        <li>Issues labeled as <code>Editorial</code> are displayed separately, to make it easier to differentiate editorial errata from substantive ones.</li>
+          <code>ErratumRaised</code>. It is o.k. for an erratum to have several labels. In some, exceptional, cases,
+          i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.
+        </li>
+        <li>Issues labeled as <code>Editorial</code> are displayed separately, to make it easier to differentiate
+          editorial errata from substantive ones.</li>
         <li>The community discusses the issue. If it is accepted as a genuine erratum, the label <code>Errata</code>
           is added to the entry and the <code>ErratumRaised</code> label should be removed. Additionally, a new
           comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on
@@ -36,61 +43,67 @@
         <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
         <li>Each errata may be labelled as <code>Editorial</code>; editorial errata are listed separately from the
           substantive ones.</li>
-        <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
+        <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests
+          or modifications to existing tests, or must include the rationale for why test updates are not required for
+          the erratum.</li>
       </ul>
 
       <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the
-        sections below. Each section collects the issues for a specific document, with a separate section for the issues not assigned to any.</p>
+        sections below. Each section collects the issues for a specific document, with a separate section for the issues
+        not assigned to any.</p>
 
       <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact
         the staff contact of the Web of Things Working Group, <a href="mailto:ashimura@w3.org">Kaz Ashimura</a>.</p>
     </section>
-    
+
     <section>
       <h2>How to maintain this Document</h2>
       <p>
-        When an errata is accepted, it should be added to this document. When doing so, the maintainers of this document should follow the steps below:
+        When an errata is accepted, it should be added to this document. When doing so, the maintainers of this document
+        should follow the steps below:
       </p>
       <ol>
-        <li>Add the errata to the bottom of the list at the end of the document that corresponds to the nature of the errata.</li>
+        <li>Add the errata to the bottom of the list at the end of the document that corresponds to the nature of the
+          errata.</li>
         <li>Increment the number of recorded errata at the top of the document.</li>
         <li>Update the value of latest errata update at the top of the document</li>
       </ol>
     </section>
 
-    </header>
+  </header>
 
-    <main>
+  <main>
 
-      <section>
-        <h1>Open Errata on the "WoT Thing Description" Recommendation</h1>
-        <dl>
-          <dt>Latest Published Version:</dt>
-          <dd><a href="https://www.w3.org/TR/wot-thing-description/">https://www.w3.org/TR/wot-thing-description/</a></dd>
-          <dt>Editor's draft:</dt>
-          <dd><a href="https://w3c.github.io/wot-thing-description/">https://w3c.github.io/wot-thing-description/</a></dd>
-          <dt>Latest Publication Date:</dt>
-          <dd>2 April 2020</dd>
+    <section>
+      <h1>Open Errata on the "WoT Thing Description" Recommendation</h1>
+      <dl>
+        <dt>Latest Published Version:</dt>
+        <dd><a href="https://www.w3.org/TR/wot-thing-description/">https://www.w3.org/TR/wot-thing-description/</a></dd>
+        <dt>Editor's draft:</dt>
+        <dd><a href="https://w3c.github.io/wot-thing-description/">https://w3c.github.io/wot-thing-description/</a></dd>
+        <dt>Latest Publication Date:</dt>
+        <dd>2 April 2020</dd>
       </dl>
-        <section id="first">
-          <h2>Substantive Issues</h2>
-        </section>
-        <section id="last">
-          <h2>Editorial Issues</h2>
-        </section>
+      <section id="first">
+        <h2>Substantive Issues</h2>
       </section>
-    </main>
+      <section id="last">
+        <h2>Editorial Issues</h2>
+      </section>
+    </section>
+  </main>
 
-    <footer>
-      <address><a href="mailto:ashimura@w3.org" class=''>Kaz Ashimura</a>, &lt;ashimura@w3.org&gt;, (W3C)</address>
-      <div class="footer-copyright text-center ">
-        Copyright © {{ 'now' | date: "%Y" }} <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br /> <abbr
-          title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a
-          href="https://www.w3.org/policies/#disclaimers">liability</a>, <a
-          href="https://www.w3.org/policies/#trademarks">trademark</a> and <a rel="license"
-          href="https://www.w3.org/copyright/document-license/" title="W3C Document License">permissive license</a> rules
-        apply.
-      </div>
-    </footer>
-  </body>
+  <footer>
+    <address><a href="mailto:ashimura@w3.org" class=''>Kaz Ashimura</a>, &lt;ashimura@w3.org&gt;, (W3C)</address>
+    <div class="footer-copyright text-center ">
+      Copyright © {{ 'now' | date: "%Y" }} <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br /> <abbr
+        title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a
+        href="https://www.w3.org/policies/#disclaimers">liability</a>, <a
+        href="https://www.w3.org/policies/#trademarks">trademark</a> and <a rel="license"
+        href="https://www.w3.org/copyright/document-license/" title="W3C Document License">permissive license</a> rules
+      apply.
+    </div>
+  </footer>
+</body>
+
 </html>

--- a/errata.html
+++ b/errata.html
@@ -50,7 +50,7 @@
         <dl>
           <dt>Latest Published Version:</dt>
           <dd><a href="https://www.w3.org/TR/wot-thing-description/">https://www.w3.org/TR/wot-thing-description/</a></dd>
-          <dt>Editor’s draft:</dt>
+          <dt>Editor's draft:</dt>
           <dd><a href="https://w3c.github.io/wot-thing-description/">https://w3c.github.io/wot-thing-description/</a></dd>
           <dt>Latest Publication Date:</dt>
           <dd>2 April 2020</dd>
@@ -66,7 +66,14 @@
 
     <footer>
       <address><a href="mailto:ashimura@w3.org" class=''>Kaz Ashimura</a>, &lt;ashimura@w3.org&gt;, (W3C)</address>
-      <p class="copyright"><a href="/Consortium/Legal/ipr-notice#Copyright" rel="Copyright">Copyright</a> © 2020 <a href="/"><abbr title="World Wide Web Consortium">W3C</abbr></a> <sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.org/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved.</p>
+      <div class="footer-copyright text-center ">
+        Copyright © {{ 'now' | date: "%Y" }} <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br /> <abbr
+          title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a
+          href="https://www.w3.org/policies/#disclaimers">liability</a>, <a
+          href="https://www.w3.org/policies/#trademarks">trademark</a> and <a rel="license"
+          href="https://www.w3.org/copyright/document-license/" title="W3C Document License">permissive license</a> rules
+        apply.
+      </div>
     </footer>
   </body>
 </html>

--- a/errata11.html
+++ b/errata11.html
@@ -9,17 +9,6 @@
   <meta charset="UTF-8">
   <title>Open Errata for the Web of Things (WoT) Thing Description 1.1 Specification</title>
   <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css" />
-  <script src="https://www.w3.org/scripts/jquery/1.11/jquery.min.js"></script>
-  <script src="https://w3c.github.io/display_errata/assets/moment.min.js" type="text/javascript"></script>
-  <script src="https://w3c.github.io/display_errata/assets/errata.js" type="text/javascript"></script>
-  <script src="https://www.w3.org/scripts/underscore/1.8/underscore-min.js" type="text/javascript"></script>
-  <script src="https://w3c.github.io/display_errata/assets/toc.js" type="text/javascript"></script>
-
-  <style type="text/css">
-    .todo {
-      background-color: yellow
-    }
-  </style>
 </head>
 
 <body>

--- a/errata11.html
+++ b/errata11.html
@@ -5,7 +5,7 @@
     form 'w3c/XXX', although there are groups that have their own owner for their repository.
   -->
 
-<head data-githubrepo="w3c/wot-thing-description">
+<head>
   <meta charset="UTF-8">
   <title>Open Errata for the Web of Things (WoT) Thing Description 1.1 Specification</title>
   <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css" />

--- a/errata11.html
+++ b/errata11.html
@@ -19,14 +19,12 @@
     <h1 class="title">Open Errata for the Web of Things (WoT) Thing Description 1.1 Specification</h1>
     <dl>
       <dt>Latest errata update:</dt>
-      <dd><span id="date"></span></dd>
+      <dd><span id="date"></span>06 May 2024</dd>
       <dt>Number of recorded errata:</dt>
-      <dd><span id="number"></span>2</dd>
-      <dt>Link to all errata:</dt>
-      <dd><span id="errata_link"></span></dd>
+      <dd><span id="number"></span>3</dd>
     </dl>
 
-    <section data-notoc>
+    <section>
       <h1>How to Submit an Erratum?</h1>
       <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue
           list for the WoT Thing Description GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
@@ -57,17 +55,15 @@
     </section>
   </header>
 
-  <div class="toc" id="toc"></div>
-
   <main>
-    <!-- The data-erratalabel should include one label that filters the errata -->
-    <section data-nolabel>
+
+    <section>
       <h1>Open Errata on the "WoT Thing Description 1.1" Recommendation</h1>
       <dl>
         <dt>Latest Published Version:</dt>
         <dd><a href="https://www.w3.org/TR/wot-thing-description11/">https://www.w3.org/TR/wot-thing-description/</a>
         </dd>
-        <dt>Editor’s draft:</dt>
+        <dt>Editor's draft:</dt>
         <dd><a href="https://w3c.github.io/wot-thing-description/">https://w3c.github.io/wot-thing-description/</a></dd>
         <dt>Latest Publication Date:</dt>
         <dd>05 December 2023</dd>

--- a/errata11.html
+++ b/errata11.html
@@ -1,9 +1,5 @@
 <!DOCTYPE html>
 <html>
-<!--
-    The data-githubrepo attribute provides the owner/repo name on github. For W3C repositories most of those are of the
-    form 'w3c/XXX', although there are groups that have their own owner for their repository.
-  -->
 
 <head>
   <meta charset="UTF-8">
@@ -25,40 +21,48 @@
     </dl>
 
     <section>
-      <h1>How to Submit an Erratum?</h1>
-      <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue
-          list for the WoT Thing Description GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
+      <h2>How to Submit an Erratum?</h2>
+      <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue list for the WoT Thing Description GitHub repository</a>.
+        The workflow to add a new erratum is as follows:</p>
       <ul>
         <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to
-          “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels. In some, exceptional, cases,
-          i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
-        <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate
-          editorial errata from substantive ones.</li>
-        <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>”
-          is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new
+          <code>ErratumRaised</code>. It is o.k. for an erratum to have several labels. In some, exceptional, cases, i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
+        <li>Issues labeled as <code>Editorial</code> are displayed separately, to make it easier to differentiate editorial errata from substantive ones.</li>
+        <li>The community discusses the issue. If it is accepted as a genuine erratum, the label <code>Errata</code>
+          is added to the entry and the <code>ErratumRaised</code> label should be removed. Additionally, a new
           comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on
           the discussion).</li>
         <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
-        <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the
+        <li>Each errata may be labelled as <code>Editorial</code>; editorial errata are listed separately from the
           substantive ones.</li>
-        <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests
-          or modifications to existing tests, or must include the rationale for why test updates are not required for
-          the erratum.</li>
+        <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
       </ul>
 
       <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the
-        sections below. Each section collects the issues for a specific document, with a separate section for the issues
-        not assigned to any.</p>
+        sections below. Each section collects the issues for a specific document, with a separate section for the issues not assigned to any.</p>
 
       <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact
         the staff contact of the Web of Things Working Group, <a href="mailto:ashimura@w3.org">Kaz Ashimura</a>.</p>
     </section>
+    
+    <section>
+      <h2>How to maintain this Document</h2>
+      <p>
+        When an errata is accepted, it should be added to this document. When doing so, the maintainers of this document should follow the steps below:
+      </p>
+      <ol>
+        <li>Add the errata to the bottom of the list at the end of the document that corresponds to the nature of the errata.</li>
+        <li>Increment the number of recorded errata at the top of the document.</li>
+        <li>Update the value of latest errata update at the top of the document</li>
+      </ol>
+    </section>
+  
   </header>
 
   <main>
 
     <section>
-      <h1>Open Errata on the "WoT Thing Description 1.1" Recommendation</h1>
+      <h2>Open Errata on the "WoT Thing Description 1.1" Recommendation</h2>
       <dl>
         <dt>Latest Published Version:</dt>
         <dd><a href="https://www.w3.org/TR/wot-thing-description11/">https://www.w3.org/TR/wot-thing-description/</a>
@@ -68,11 +72,11 @@
         <dt>Latest Publication Date:</dt>
         <dd>05 December 2023</dd>
       </dl>
-      <section id="first">
-        <h2>Substantive Issues</h2>
+      <section>
+        <h3>Substantive Issues</h3>
       </section>
-      <section id="last">
-        <h2>Editorial Issues</h2>
+      <section>
+        <h3>Editorial Issues</h3>
         <ul>
           <li> <b>2024-04-24</b>: In the <a href="https://w3c.github.io/wot-resources/td/v1.1/ontology/td.ttl">Thing
               Description ontology</a> and it's associated <a

--- a/errata11.html
+++ b/errata11.html
@@ -22,12 +22,16 @@
 
     <section>
       <h2>How to Submit an Erratum?</h2>
-      <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue list for the WoT Thing Description GitHub repository</a>.
+      <p>Errata are introduced and stored in the <a href="https://github.com/w3c/wot-thing-description/issues/">issue
+          list for the WoT Thing Description GitHub repository</a>.
         The workflow to add a new erratum is as follows:</p>
       <ul>
         <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to
-          <code>ErratumRaised</code>. It is o.k. for an erratum to have several labels. In some, exceptional, cases, i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
-        <li>Issues labeled as <code>Editorial</code> are displayed separately, to make it easier to differentiate editorial errata from substantive ones.</li>
+          <code>ErratumRaised</code>. It is o.k. for an erratum to have several labels. In some, exceptional, cases,
+          i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.
+        </li>
+        <li>Issues labeled as <code>Editorial</code> are displayed separately, to make it easier to differentiate
+          editorial errata from substantive ones.</li>
         <li>The community discusses the issue. If it is accepted as a genuine erratum, the label <code>Errata</code>
           is added to the entry and the <code>ErratumRaised</code> label should be removed. Additionally, a new
           comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on
@@ -35,28 +39,33 @@
         <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
         <li>Each errata may be labelled as <code>Editorial</code>; editorial errata are listed separately from the
           substantive ones.</li>
-        <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
+        <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests
+          or modifications to existing tests, or must include the rationale for why test updates are not required for
+          the erratum.</li>
       </ul>
 
       <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the
-        sections below. Each section collects the issues for a specific document, with a separate section for the issues not assigned to any.</p>
+        sections below. Each section collects the issues for a specific document, with a separate section for the issues
+        not assigned to any.</p>
 
       <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact
         the staff contact of the Web of Things Working Group, <a href="mailto:ashimura@w3.org">Kaz Ashimura</a>.</p>
     </section>
-    
+
     <section>
       <h2>How to maintain this Document</h2>
       <p>
-        When an errata is accepted, it should be added to this document. When doing so, the maintainers of this document should follow the steps below:
+        When an errata is accepted, it should be added to this document. When doing so, the maintainers of this document
+        should follow the steps below:
       </p>
       <ol>
-        <li>Add the errata to the bottom of the list at the end of the document that corresponds to the nature of the errata.</li>
+        <li>Add the errata to the bottom of the list at the end of the document that corresponds to the nature of the
+          errata.</li>
         <li>Increment the number of recorded errata at the top of the document.</li>
         <li>Update the value of latest errata update at the top of the document</li>
       </ol>
     </section>
-  
+
   </header>
 
   <main>


### PR DESCRIPTION
What is done in this PR:
- Removed JS to dynamically generate the list. Removed anything related to it, e.g., specific ids etc.
- Remove "Link to all errata":
- Update the latest update date
- Recorded errata count changed to 3
- Copy paste submission text from errata11.html to errata.html
- Added a small section on "how to maintain this document" which says that each new errata should be added at the bottom of the list, number of errata and the latest date should be updated.