### PR TITLE
chore: enable dark mode support in TD document

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <!-- <link rel="stylesheet" href="testing/atrisk.css"> -->
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
     <title>Web of Things (WoT) Thing Description - Next</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">

--- a/index.template.html
+++ b/index.template.html
@@ -3,6 +3,7 @@
   <head>
     <!-- <link rel="stylesheet" href="testing/atrisk.css"> -->
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
     <title>Web of Things (WoT) Thing Description - Next</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">


### PR DESCRIPTION
This PR adds dark mode support for the document, as specified in the [ReSpec documentation](https://respec.org/docs/#dark-mode).

(For some reason, without this support explicitly enabled, only the examples have a dark background in dark mode, which was always a bit irritating to me until I found the reason for why it is happening. Therefore, this PR makes things a bit more consistent for dark mode users and the spec a bit more pleasant to read.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-thing-description/pull/2029.html" title="Last updated on Jul 4, 2024, 9:01 AM UTC (f9c2414)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/2029/a0c1565...JKRhb:f9c2414.html" title="Last updated on Jul 4, 2024, 9:01 AM UTC (f9c2414)">Diff</a>