### PR TITLE
fix: align JSON Schema with JSON-LD @context format

### DIFF
--- a/errata11.html
+++ b/errata11.html
@@ -15,9 +15,9 @@
   <h1 class="title">Open Errata for the Web of Things (WoT) Thing Description 1.1 Specification</h1>
   <dl>
     <dt>Latest errata update:</dt>
-    <dd><span id="date"></span>06 May 2024</dd>
+    <dd><span id="date"></span>12 March 2025</dd>
     <dt>Number of recorded errata:</dt>
-    <dd><span id="number"></span>3</dd>
+    <dd><span id="number"></span>4</dd>
   </dl>
 
   <section>
@@ -103,6 +103,10 @@
     <section>
       <h3>Editorial Issues</h3>
       <ul>
+        <li> <b>2025-03-12</b>: In the <a href="https://github.com/w3c/wot-thing-description/blob/main/validation/td-json-schema-validation.json">Thing
+            Description JSON Schema</a> and it's associated <a href="https://github.com/w3c/wot-thing-description/blob/main/validation/tm-json-schema-validation.json">TM Validation Schema</a>, the term <code>@context</code> was allowing adding maps (JSON objects) where the name-value pairs could contain a non-string value. Such JSON documents would be invalid JSON-LD documents, which the TD users should not create. As this only effects the resources, <a
+            href="https://www.w3.org/TR/wot-thing-description11/">WoT TD 1.1.</a> HTML specification is not effected. This is fixed in <a href="https://github.com/w3c/wot-thing-description/pull/2080">the Pull Request 2080</a>.
+        </li>
         <li> <b>2024-04-24</b>: In the <a href="https://w3c.github.io/wot-resources/td/v1.1/ontology/td.ttl">Thing
             Description ontology</a> and it's associated <a
             href="https://www.w3.org/2019/wot/td#hasConfigurationInstance">HTML page</a>, the term

--- a/errata11.html
+++ b/errata11.html
@@ -104,8 +104,8 @@
       <h3>Editorial Issues</h3>
       <ul>
         <li> <b>2025-03-12</b>: In the <a href="https://github.com/w3c/wot-thing-description/blob/main/validation/td-json-schema-validation.json">Thing
-            Description JSON Schema</a> and it's associated <a href="https://github.com/w3c/wot-thing-description/blob/main/validation/tm-json-schema-validation.json">TM Validation Schema</a>, the term <code>@context</code> was allowing adding maps (JSON objects) where the name-value pairs could contain a non-string value. Such JSON documents would be invalid JSON-LD documents, which the TD users should not create. As this only effects the resources, <a
-            href="https://www.w3.org/TR/wot-thing-description11/">WoT TD 1.1.</a> HTML specification is not effected. This is fixed in <a href="https://github.com/w3c/wot-thing-description/pull/2080">the Pull Request 2080</a>.
+            Description JSON Schema</a> and its associated <a href="https://github.com/w3c/wot-thing-description/blob/main/validation/tm-json-schema-validation.json">TM Validation Schema</a>, the term <code>@context</code> was allowing adding maps (JSON objects) where the name-value pairs could contain a non-string value. Such JSON documents would be invalid JSON-LD documents, which TD users should not create. As this only effects the resources, <a
+            href="https://www.w3.org/TR/wot-thing-description11/">WoT TD 1.1.</a> HTML specification is not affected. This is fixed in <a href="https://github.com/w3c/wot-thing-description/pull/2080">the Pull Request 2080</a>.
         </li>
         <li> <b>2024-04-24</b>: In the <a href="https://w3c.github.io/wot-resources/td/v1.1/ontology/td.ttl">Thing
             Description ontology</a> and it's associated <a

--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -85,7 +85,10 @@
                 "$ref": "#/definitions/anyUri"
               },
               {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             ],
             "not": {
@@ -110,7 +113,14 @@
           ],
           "minItems": 2,
           "contains": {
-            "$ref": "#/definitions/thing-context-td-uri-v1.1"
+            "allOf": [
+              {
+                "$ref": "#/definitions/thing-context-td-uri-v1.1"
+              },
+              {
+                "$ref": "#/definitions/thing-context-td-uri-v1"
+              }
+            ]
           },
           "additionalItems": {
             "anyOf": [
@@ -118,7 +128,10 @@
                 "$ref": "#/definitions/anyUri"
               },
               {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             ]
           }
@@ -141,7 +154,10 @@
                 "$ref": "#/definitions/anyUri"
               },
               {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             ]
           }

--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -1,6 +1,6 @@
 {
   "title": "Thing Description",
-  "version": "1.1-09-November-2023",
+  "version": "1.1-12-March-2025",
   "description": "JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",
@@ -103,7 +103,7 @@
         {
           "$comment": "Old context URI, followed by the new one and possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
           "type": "array",
-          "prefixItems": [
+          "items": [
             {
               "$ref": "#/definitions/thing-context-td-uri-v1"
             },
@@ -112,16 +112,6 @@
             }
           ],
           "minItems": 2,
-          "contains": {
-            "allOf": [
-              {
-                "$ref": "#/definitions/thing-context-td-uri-v1.1"
-              },
-              {
-                "$ref": "#/definitions/thing-context-td-uri-v1"
-              }
-            ]
-          },
           "additionalItems": {
             "anyOf": [
               {
@@ -139,15 +129,12 @@
         {
           "$comment": "Old context URI, followed by possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
           "type": "array",
-          "prefixItems": [
+          "items": [
             {
               "$ref": "#/definitions/thing-context-td-uri-v1"
             }
           ],
           "minItems": 1,
-          "contains": {
-            "$ref": "#/definitions/thing-context-td-uri-v1"
-          },
           "additionalItems": {
             "anyOf": [
               {

--- a/validation/tm-json-schema-validation.json
+++ b/validation/tm-json-schema-validation.json
@@ -1,6 +1,6 @@
 {
   "title": "Thing Model",
-  "version": "1.1-09-November-2023",
+  "version": "1.1-12-March-2025",
   "description": "JSON Schema for validating Thing Models. This is automatically generated from the WoT TD Schema.",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/tm-json-schema-validation.json",
@@ -98,7 +98,10 @@
                 "$ref": "#/definitions/anyUri"
               },
               {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             ],
             "not": {
@@ -113,7 +116,7 @@
         {
           "$comment": "Old context URI, followed by the new one and possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
           "type": "array",
-          "prefixItems": [
+          "items": [
             {
               "$ref": "#/definitions/thing-context-td-uri-v1"
             },
@@ -122,16 +125,16 @@
             }
           ],
           "minItems": 2,
-          "contains": {
-            "$ref": "#/definitions/thing-context-td-uri-v1.1"
-          },
           "additionalItems": {
             "anyOf": [
               {
                 "$ref": "#/definitions/anyUri"
               },
               {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             ]
           }
@@ -139,22 +142,22 @@
         {
           "$comment": "Old context URI, followed by possibly other vocabularies. minItems and contains are required since prefixItems does not say all items should be provided",
           "type": "array",
-          "prefixItems": [
+          "items": [
             {
               "$ref": "#/definitions/thing-context-td-uri-v1"
             }
           ],
           "minItems": 1,
-          "contains": {
-            "$ref": "#/definitions/thing-context-td-uri-v1"
-          },
           "additionalItems": {
             "anyOf": [
               {
                 "$ref": "#/definitions/anyUri"
               },
               {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             ]
           }


### PR DESCRIPTION
This PR fixes https://github.com/w3c/wot-thing-description/issues/2022 by specifying an explicit type of `string` for the `additionalProperties` in a TD's `@context` definition.

While resolving the issue, I noticed a small bug in the schema related to `@context`s that contain both the old and the new TD context URL. To resolve it, I adjusted the `contains` definition that is present in the corresponding "subschema".

With the changes from this PR, the following invalid TDs are now rejected by a JSON Schema validator, as the specification intends it.

#### TD with new @context URL only

```json
{
  "@context": [
    "https://www.w3.org/2022/wot/td/v1.1",
    {
      "foo": 42,
      "bar": "baz"
    }
  ],
  "title": "Test-Thing",
  "securityDefinitions": {
    "nosec_sc": {"scheme": "nosec"}
  },
  "security": "nosec_sc"
}
```

#### TD with old @context URL

```json
{
  "@context": [
    "https://www.w3.org/2022/wot/td/v1.1",
      "https://www.w3.org/2022/wot/td/v1",
    {
      "foo": 42,
      "bar": "baz"
    }
  ],
  "title": "Test-Thing",
  "securityDefinitions": {
    "nosec_sc": {"scheme": "nosec"}
  },
  "security": "nosec_sc"
}
```