### PR TITLE
PR Template: Remove Checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,10 +12,9 @@ Closes #
 
 ## Type of Change
 
-Check the correct box and add the corresponding label if you are an editor.
+Keep the correct line, remove the other and add the corresponding label if you are an editor.
 
 <!-- In this case, once the label is added and approved by an Editor, after 1 week the PR can be merged. -->
-
-- [ ] [Editorial (non-normative)](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Editorial Label](https://img.shields.io/github/labels/w3c/wot-thing-description/Editorial).
+- [Editorial (non-normative)](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Editorial Label](https://img.shields.io/github/labels/w3c/wot-thing-description/Editorial).
 <!-- In this case, two Editors who are not from the same organization or who are Invited Experts need to approve -->
-- [ ] [Normative](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Normative Label](https://img.shields.io/github/labels/w3c/wot-thing-description/normative%20change)
+- [Normative](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Normative Label](https://img.shields.io/github/labels/w3c/wot-thing-description/normative%20change)


### PR DESCRIPTION
(not using the template since it is about changing it)

I am doing this since the PRs now show with "tasks" due to checkboxes (see below). The PR submitter can simply delete a line instead.

<img width="924" alt="Screenshot 2025-03-05 at 15 51 17" src="https://github.com/user-attachments/assets/093a9a85-e0b6-4293-afa3-fb9a0f058a48" />
