### PR TITLE
change to td 2.0 and fix broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,9 +386,10 @@
   <body>
     <section id="abstract">
       <p>
-        This document describes a formal information model and a common representation for a Web of Things (WoT) Thing Description (TD), Version 2.0. A Thing Description describes the metadata and interfaces of <a>Things</a>, where a
-        <a>Thing</a> is an abstraction of a physical or virtual entity that provides interactions to and participates in
-        the Web of Things. Thing Descriptions provide a set of interactions based on a small vocabulary that makes it
+        This document describes a formal information model and a common representation for a Web of Things (WoT) Thing
+        Description (TD), Version 2.0. A Thing Description describes the metadata and interfaces of <a>Things</a>, where
+        a <a>Thing</a> is an abstraction of a physical or virtual entity that provides interactions to and participates
+        in the Web of Things. Thing Descriptions provide a set of interactions based on a small vocabulary that makes it
         possible both to integrate diverse devices and to allow diverse applications to interoperate. Thing
         Descriptions, by default, are encoded in a JSON format that also allows JSON-LD processing. The latter provides
         a powerful foundation to represent knowledge about <a>Things</a> in a machine-understandable way. A Thing
@@ -1122,363 +1123,862 @@
           <h2>Core Vocabulary Definitions</h2>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>Thing</code></h3><p>An abstraction of a physical or a virtual entity whose
-          metadata and interfaces are described by a WoT Thing
-          Description, whereas a virtual entity is the composition
-          of one or more Things.</p><table class="def numbered"><caption>Vocabulary Terms in Thing Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing"><td><code>@context</code></td><td>JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-id--Thing"><td><code>id</code></td><td>Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI, URI with local IP address, URN, etc.).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--Thing"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
-                a text for UI representation) based on a default
-                language.</td><td>mandatory</td><td>any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing"><td><code>titles</code></td><td>Provides multi-language human-readable titles
-                (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-description--Thing"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-version--Thing"><td><code>version</code></td><td>Provides version information.</td><td>optional</td><td><a href="#versioninfo"><code>VersionInfo</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-created--Thing"><td><code>created</code></td><td>Provides information when the TD instance was
-                created.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing"><td><code>modified</code></td><td>Provides information when the TD instance was
-                last modified.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-support--Thing"><td><code>support</code></td><td>Provides information about the TD maintainer as
-                URI scheme (e.g., <code>mailto</code> [[RFC6068]],
-                <code>tel</code> [[RFC3966]],
-                <code>https</code> [[RFC9112]]).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-base--Thing"><td><code>base</code></td><td>Define the base URI that is used for all
-                relative URI references throughout a TD document.
-                In TD instances, all relative URIs are resolved
-                relative to the base URI using the algorithm
-                defined in [<cite><a class="bibref" data-link-type=
-                "biblio" href='#bib-rfc3986' title=
-                "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>].<br>
-                <br>
-                <code>base</code> does not affect the URIs used in
-                <code>@context</code> and the IRIs used within
-                Linked Data [<cite><a class="bibref"
-                data-link-type="biblio" href='#bib-linked-data'
-                title=
-                "Linked Data Design Issues">LINKED-DATA</a></cite>]
-                graphs that are relevant when semantic processing
-                is applied to TD instances.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing"><td><code>properties</code></td><td>All Property-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#propertyaffordance"><code>PropertyAffordance</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing"><td><code>actions</code></td><td>All Action-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#actionaffordance"><code>ActionAffordance</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-events--Thing"><td><code>events</code></td><td>All Event-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#eventaffordance"><code>EventAffordance</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-links--Thing"><td><code>links</code></td><td>Provides Web links to arbitrary resources that
-                relate to the specified Thing Description.</td><td>optional</td><td><a>Array</a> of <a href="#link"><code>Link</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing"><td><code>forms</code></td><td>Set of form hypermedia controls that describe how 
-                  an operation can be performed. Forms are
-                  serializations of Protocol Bindings. <a>Thing level</a> forms are used to describe endpoints for a group of interaction affordances.</td><td>optional</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-security--Thing"><td><code>security</code></td><td>Set of security definition names, chosen from
-                those defined in <code>securityDefinitions</code>.
-                These must all be satisfied for access to resources.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing"><td><code>securityDefinitions</code></td><td>Set of named security configurations
-                (definitions only). Not actually applied unless
-                names are used in a <code>security</code>
-                name-value pair.</td><td>mandatory</td><td><a>Map</a> of <a href="#securityscheme"><code>SecurityScheme</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-profile--Thing"><td><code>profile</code></td><td>Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing implementation.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-schemaDefinitions--Thing"><td><code>schemaDefinitions</code></td><td>Set of named data schemas.
-                To be used in a <code>schema</code>
-                name-value pair inside an 
-                <code>AdditionalExpectedResponse</code> object.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
-                based on DataSchema declarations. The <a>Thing level</a> <code>uriVariables</code> can be used in <a>Thing level</a> 
-                <code>forms</code> or in Interaction Affordances.
-                The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
-                to be serialized to a string inside the <code>href</code> upon the execution of the operation.
-                If the same variable is both declared in <a>Thing level</a> <code>uriVariables</code> and in Interaction Affordance level,
-                 the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>
-              For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:
-              </p>
-        <ul>
-            <li>
-    <span class="rfc2119-assertion" id=
-          "td-context-ns-thing-mandatory">
+          <section>
+            <h3><code>Thing</code></h3>
+            <p>
+              An abstraction of a physical or a virtual entity whose metadata and interfaces are described by a WoT
+              Thing Description, whereas a virtual entity is the composition of one or more Things.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in Thing Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing">
+                  <td><code>@context</code></td>
+                  <td>
+                    JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or
+                    <a>Array</a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-id--Thing">
+                  <td><code>id</code></td>
+                  <td>
+                    Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI,
+                    URI with local IP address, URN, etc.).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-title--Thing">
+                  <td><code>title</code></td>
+                  <td>
+                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
+                    language.
+                  </td>
+                  <td>mandatory</td>
+                  <td>any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing">
+                  <td><code>titles</code></td>
+                  <td>
+                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
+                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--Thing">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-version--Thing">
+                  <td><code>version</code></td>
+                  <td>Provides version information.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#versioninfo"><code>VersionInfo</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-created--Thing">
+                  <td><code>created</code></td>
+                  <td>Provides information when the TD instance was created.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing">
+                  <td><code>modified</code></td>
+                  <td>Provides information when the TD instance was last modified.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-support--Thing">
+                  <td><code>support</code></td>
+                  <td>
+                    Provides information about the TD maintainer as URI scheme (e.g., <code>mailto</code> [[RFC6068]],
+                    <code>tel</code> [[RFC3966]], <code>https</code> [[RFC9112]]).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-base--Thing">
+                  <td><code>base</code></td>
+                  <td>
+                    Define the base URI that is used for all relative URI references throughout a TD document. In TD
+                    instances, all relative URIs are resolved relative to the base URI using the algorithm defined in
+                    [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc3986"
+                        title="Uniform Resource Identifier (URI): Generic Syntax"
+                        >RFC3986</a
+                      ></cite
+                    >].<br />
+                    <br />
+                    <code>base</code> does not affect the URIs used in <code>@context</code> and the IRIs used within
+                    Linked Data [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-linked-data"
+                        title="Linked Data Design Issues"
+                        >LINKED-DATA</a
+                      ></cite
+                    >] graphs that are relevant when semantic processing is applied to TD instances.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing">
+                  <td><code>properties</code></td>
+                  <td>
+                    All Property-based
+                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
+                      >Interaction Affordances</a
+                    >
+                    of the Thing.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#propertyaffordance"><code>PropertyAffordance</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing">
+                  <td><code>actions</code></td>
+                  <td>
+                    All Action-based
+                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
+                      >Interaction Affordances</a
+                    >
+                    of the Thing.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#actionaffordance"><code>ActionAffordance</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-events--Thing">
+                  <td><code>events</code></td>
+                  <td>
+                    All Event-based
+                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
+                      >Interaction Affordances</a
+                    >
+                    of the Thing.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#eventaffordance"><code>EventAffordance</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-links--Thing">
+                  <td><code>links</code></td>
+                  <td>Provides Web links to arbitrary resources that relate to the specified Thing Description.</td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#link"><code>Link</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing">
+                  <td><code>forms</code></td>
+                  <td>
+                    Set of form hypermedia controls that describe how an operation can be performed. Forms are
+                    serializations of Protocol Bindings. <a>Thing level</a> forms are used to describe endpoints for a
+                    group of interaction affordances.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#form"><code>Form</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-security--Thing">
+                  <td><code>security</code></td>
+                  <td>
+                    Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.
+                    These must all be satisfied for access to resources.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing">
+                  <td><code>securityDefinitions</code></td>
+                  <td>
+                    Set of named security configurations (definitions only). Not actually applied unless names are used
+                    in a <code>security</code> name-value pair.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Map</a> of <a href="#securityscheme"><code>SecurityScheme</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-profile--Thing">
+                  <td><code>profile</code></td>
+                  <td>
+                    Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing
+                    implementation.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-schemaDefinitions--Thing">
+                  <td><code>schemaDefinitions</code></td>
+                  <td>
+                    Set of named data schemas. To be used in a <code>schema</code>
+                    name-value pair inside an
+                    <code>AdditionalExpectedResponse</code> object.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing">
+                  <td><code>uriVariables</code></td>
+                  <td>
+                    Define URI template variables according to [[RFC6570]] as collection based on DataSchema
+                    declarations. The <a>Thing level</a> <code>uriVariables</code> can be used in <a>Thing level</a>
+                    <code>forms</code> or in Interaction Affordances. The individual variables DataSchema cannot be an
+                    ObjectSchema or an ArraySchema since each variable needs to be serialized to a string inside the
+                    <code>href</code> upon the execution of the operation. If the same variable is both declared in
+                    <a>Thing level</a> <code>uriVariables</code> and in Interaction Affordance level, the Interaction
+                    Affordance level variable takes precedence.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:</p>
+            <ul>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-thing-mandatory">
+                  The <code>@context</code>
+                  name-value pair MUST contain the anyURI
+                  <code>https://www.w3.org/2022/wot/td/v1.1</code>
+                  in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly
+                  introduced terms.
+                </span>
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-td10-namespace">
+                  When there are possibly TD 1.0 consumers the anyURI
+                  <code>https://www.w3.org/2019/wot/td/v1</code>
+                  MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second
+                  entry.</span
+                >
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-td10-namespacev10">
+                  TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0
+                  [[wot-thing-description10]] specification.
+                </span>
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-thing-optional"
+                  >When <code>@context</code> is an
+                  <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>, the anyURI
+                  <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class="rfc2119" title="MAY">MAY</em> be followed
+                  by elements of type <code>anyURI</code> or type
+                  <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> in any order, while it is
+                  RECOMMENDED to include only one
+                  <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> with all the name-value pairs in
+                  the <code>@context</code>
+                  <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span
+                >
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-thing-map-of-namespaces"
+                  ><a href="#dfn-map" class="internalDFN" data-link-type="dfn">Maps</a> contained in an
+                  <code>@context</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> MAY
+                  contain name-value pairs, where the value is a namespace identifier of type <code>anyURI</code> and
+                  the name a <a href="#dfn-term" class="internalDFN" data-link-type="dfn">Term</a> or prefix denoting
+                  that namespace.</span
+                >
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-default-language"
+                  >One <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> contained in an
+                  <code>@context</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> SHOULD
+                  contain a name-value pair that defines the default language for the Thing Description, where the name
+                  is the <a href="#dfn-term" class="internalDFN" data-link-type="dfn">Term</a>
+                  <code>@language</code> and the value is a well-formed language tag as defined by [<cite
+                    ><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages"
+                      >BCP47</a
+                    ></cite
+                  >] (e.g., <code>en</code>, <code>de-AT</code>, <code>gsw-CH</code>, <code>zh-Hans</code>,
+                  <code>zh-Hant-HK</code>, <code>sl-nedis</code>).</span
+                >
+              </li>
+            </ul>
 
-          The <code>@context</code>
-          name-value pair MUST contain the anyURI
-          <code>https://www.w3.org/2022/wot/td/v1.1</code>
-          in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly introduced terms.
-          </span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-td10-namespace"> 
-          When there are possibly TD 1.0 consumers the anyURI
-          <code>https://www.w3.org/2019/wot/td/v1</code>
-          MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second entry.</span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-td10-namespacev10"> 
-            TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0 [[wot-thing-description10]] specification. 
-            </span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-thing-optional">When <code>@context</code>
-          is an <a href="#dfn-array" class="internalDFN"
-          data-link-type="dfn">Array</a>, the anyURI
-          <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class=
-          "rfc2119" title="MAY">MAY</em> be followed by elements of
-          type <code>anyURI</code> or type <a href="#dfn-map"
-          class="internalDFN" data-link-type="dfn">Map</a> in any
-          order, while it is RECOMMENDED to include only one
-          <a href="#dfn-map" class="internalDFN" data-link-type=
-          "dfn">Map</a> with all the name-value pairs in the
-          <code>@context</code> <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a>.</span>
-          </li>
-        <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-thing-map-of-namespaces"><a href=
-          "#dfn-map" class="internalDFN" data-link-type=
-          "dfn">Maps</a> contained in an <code>@context</code>
-          <a href="#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> MAY
-          contain name-value pairs, where the value is a namespace
-          identifier of type <code>anyURI</code> and the name a
-          <a href="#dfn-term" class="internalDFN" data-link-type=
-          "dfn">Term</a> or prefix denoting that namespace.</span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-default-language">One <a href="#dfn-map"
-          class="internalDFN" data-link-type="dfn">Map</a>
-          contained in an <code>@context</code> <a href=
-          "#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> SHOULD contain a name-value pair that
-          defines the default language for the Thing Description,
-          where the name is the <a href="#dfn-term" class=
-          "internalDFN" data-link-type="dfn">Term</a>
-          <code>@language</code> and the value is a well-formed
-          language tag as defined by [<cite><a class="bibref"
-          data-link-type="biblio" href="#bib-bcp47" title=
-          "Tags for Identifying Languages">BCP47</a></cite>] (e.g.,
-          <code>en</code>, <code>de-AT</code>, <code>gsw-CH</code>,
-          <code>zh-Hans</code>, <code>zh-Hant-HK</code>,
-          <code>sl-nedis</code>).</span>
-          </li>
-          </ul>
+            <p>
+              To determine the base direction of all human-readable text in <a>Thing Description</a> and
+              <a>Thing Model</a> instances this specification recommends to follow the [[STRING-META]] guideline about
+              <a href="https://www.w3.org/TR/string-meta/#string_specific_direction"
+                >string-specific directional information</a
+              >
+              when no built-in mechanism for associating base direction metadata is available.
+            </p>
 
-          
-          <p>To determine the base direction of all
-          human-readable text in <a>Thing Description</a> 
-          and <a>Thing Model</a> instances this specification 
-           recommends to follow the [[STRING-META]] guideline about 
-           <a href="https://www.w3.org/TR/string-meta/#string_specific_direction">string-specific directional information</a>
-           when no built-in mechanism for associating base direction metadata
-           is available.
-           </p>
-
-          <p><a href="#dfn-td-processor" class="internalDFN"
-          data-link-type="dfn">TD Processors</a> should be aware of
-          certain special cases when processing bidirectional text.
-          <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
-          <a href="#dfn-td-processor" class="internalDFN"
-          data-link-type="dfn">TD Processors</a> SHOULD take care to use bidi isolation when
-          presenting strings to users, particularly when embedding
-          in surrounding text (e.g., for Web user interface)</span>. 
-          Mixed direction text can occur in any language, even when the
-          language is properly identified.</p>
-          <p><span class="rfc2119-assertion" id="td-producer-mixed-direction">
-          TD <a>producers</a> SHOULD attempt to provide mixed direction
-          strings in a way that can be displayed successfully by a
-          naive user agent. </span>
-          For example, if an RTL string begins
-          with an LTR run (such as a number or a brand or trade
-          name in Latin script), including an RLM character at the
-          start of the string or wrapping opposite direction runs
-          in bidi controls can assist in proper display.</p>
-          <p><em>Strings on the Web: Language and Direction
-          Metadata</em> [<cite><a class="bibref" data-link-type=
-          "biblio" href="#bib-string-meta" title=
-          "Strings on the Web: Language and Direction Metadata">string-meta</a></cite>]
-          provides some guidance and illustrates a number of
-          pitfalls when using bidirectional text.</p>
-          <p id="meta-interactions-of-thing">In addition to the
-          explicitly provided <a href="#dfn-interaction-affordance"
-          class="internalDFN" data-link-type="dfn">Interaction
-          Affordances</a> in the <code>properties</code>,
-          <code>actions</code>, and <code>events</code> <a href=
-          "#dfn-map" class="internalDFN" data-link-type=
-          "dfn">Maps</a>, a <a href="#dfn-thing" class=
-          "internalDFN" data-link-type="dfn">Thing</a> can also
-          provide meta-interactions, which are indicated by
-          <code>Form</code> instances in its optional
-          <code>forms</code> <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a>.
-          <span class="rfc2119-assertion" id="td-op-for-thing">When
-          the <code>forms</code> <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a> of a
-          <a href="#dfn-thing" class="internalDFN" data-link-type=
-          "dfn">Thing</a> instance contains <code>Form</code>
-          instances, it MUST contain <code>op</code> member with the string values assigned 
-          to the name <code>op</code>, either directly or within an <a href=
-          "#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a>, MUST be one of the following <em>operation
-          types</em>: <code>readallproperties</code>,
-          <code>writeallproperties</code>,
-          <code>readmultipleproperties</code>,
-          <code>writemultipleproperties</code>, <code>observeallproperties</code>,
-          <code>unobserveallproperties</code>, <code>queryallactions</code>, 
-          <code>subscribeallevents</code>, or
-          <code>unsubscribeallevents</code>.</span> (See
-          <a href="#td-forms-readall-example">an example</a> for an
-          usage of <code>form</code> in a Thing instance.)</p>
-          <p>The data schema for each of the property meta-interactions is
-          constructed by combining the data schemas of each
-          <code>PropertyAffordance</code> instance in a single
-          <code>ObjectSchema</code> instance, where the
-          <code>properties</code> <a href="#dfn-map" class=
-          "internalDFN" data-link-type="dfn">Map</a> of the
-          <code>ObjectSchema</code> instance contains each data
-          schema of the <code>PropertyAffordances</code> identified
-          by the name of the corresponding
-          <code>PropertyAffordances</code> instance.</p>
-          <p>If not specified otherwise (e.g., through a <a href=
-          "#dfn-context-ext" class="internalDFN" data-link-type=
-          "dfn">TD Context Extension</a>), the request data of the
-          <code>readmultipleproperties</code> operation is an
-          <a href="#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> that contains the intended
-          <code>PropertyAffordances</code> instance names, which is
-          serialized to the content type specified by the
-          <code>Form</code> instance.</p></section>
-<section><h3><code>InteractionAffordance</code></h3><p>Metadata of a Thing that shows the possible choices to
-          <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a>, thereby suggesting
-          how <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> may interact with the
-          Thing. There are many types of potential affordances, but
-          <abbr title="World Wide Web Consortium">W3C</abbr> WoT
-          defines three types of Interaction Affordances:
-          Properties, Actions, and Events.</p><table class="def numbered"><caption>Vocabulary Terms in InteractionAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
-                a text for UI representation) based on a default
-                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance"><td><code>titles</code></td><td>Provides multi-language human-readable titles
-                (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance"><td><code>forms</code></td><td>Set of form hypermedia controls that describe
-                how an operation can be performed. Forms are
-                serializations of Protocol Bindings. The array cannot be empty.</td><td>mandatory</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
-                based on DataSchema declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
-                to be serialized to a string inside the <code>href</code> upon the execution of the operation. 
-                If the same variable is both declared in <a>Thing level</a> <code>uriVariables</code>and in Interaction Affordance level, 
-                the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>The class <code>InteractionAffordance</code> has the following subclasses:</p><ul><li><a href="#propertyaffordance"><code>PropertyAffordance</code></a></li>
-<li><a href="#actionaffordance"><code>ActionAffordance</code></a></li>
-<li><a href="#eventaffordance"><code>EventAffordance</code></a></li></ul></section>
-<section><h3><code>PropertyAffordance</code></h3><p>An Interaction Affordance that exposes state of the
-          Thing. This state can then be retrieved (read) and/or updated (write).
-           Things can also choose to
-          make Properties observable by pushing the new state after
-          a change.</p><table class="def numbered"><caption>Vocabulary Terms in PropertyAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance"><td><code>observable</code></td><td>A hint that indicates whether Servients hosting
-                the Thing and Intermediaries should provide a
-                Protocol Binding that supports the <code>observeproperty</code> and <code>unobserveproperty</code> operations 
-                for this Property.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table><p class="note">Property instances are also instances of
-            the class <a href="#dataschema" class="sec-ref">DataSchema</a>. Therefore, it can contain the
-            <code>type</code>, <code>unit</code>,
-            <code>readOnly</code> and <code>writeOnly</code>
-            members, among others.</p><p><code>PropertyAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> and
-          the <code>DataSchema</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-          <span class="rfc2119-assertion" id="td-op-for-property">When a Form instance is within a
-          <code>PropertyAffordance</code> instance, the value
-          assigned to <code>op</code> MUST be one of <code>readproperty</code>,
-          <code>writeproperty</code>, <code>observeproperty</code>,
-          <code>unobserveproperty</code> or an <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
-          containing a combination of these terms.</span></p><p class="note">
-		  It is considered to be good practice that each <code>observeproperty</code> has a corresponding
-		  <code>unobserveproperty</code> unless the protocol supports implicit unsubscription mechanisms
-		  (e.g., heartbeat to detect connection loss).</p><p class="note">
-		  The observation mechanism depends on the underlying protocol or sub-protocol. Having said that, it is not 
-          guaranteed that the current <a>Property</a> value will be provided once the subscription is initiated. Hence, it may be 
-          necessary to read the current <a>Property</a> value before/after the subscription to get a first value. 
-          </p></section>
-<section><h3><code>ActionAffordance</code></h3><p>An Interaction Affordance that allows to invoke a
-          function of the Thing, which manipulates state (e.g.,
-          toggling a lamp on or off) or triggers a process on the
-          Thing (e.g., dim a lamp over time).</p><table class="def numbered"><caption>Vocabulary Terms in ActionAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance"><td><code>input</code></td><td>Used to define the input data schema of the
-                Action.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance"><td><code>output</code></td><td>Used to define the output data schema of the
-                Action.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance"><td><code>safe</code></td><td>Signals if the Action is safe (=true) or not.
-                Used to signal if there is no internal state (cf.
-                resource state) is changed when invoking an Action.
-                In that case responses can be cached as
-                example.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance"><td><code>idempotent</code></td><td>Indicates whether the Action is idempotent
-                (=true) or not. Informs whether the Action can be
-                called repeatedly with the same result, if present,
-                based on the same input.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-synchronous--ActionAffordance"><td><code>synchronous</code></td><td>Indicates whether the action is synchronous (=true) or not. 
-                A synchronous action means that the response of action contains all the information 
-                about the result of the action and no further querying about the status of the action 
-                is needed. Lack of this keyword means that no claim on the synchronicity of the 
-                action can be made.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table><p><code>ActionAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-          <span class="rfc2119-assertion" id="td-op-for-action">When a Form instance is within an
-          <code>ActionAffordance</code> instance, the value
-          assigned to op MUST
-          either be <code>invokeaction</code>, <code>queryaction</code>, 
-          <code>cancelaction</code> or an 
-          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
-          containing a combination of these terms.
-          </span></p></section>
-<section><h3><code>EventAffordance</code></h3><p>An Interaction Affordance that describes an event
-          source, which asynchronously pushes event data to
-          <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating
-          alerts).</p><table class="def numbered"><caption>Vocabulary Terms in EventAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance"><td><code>subscription</code></td><td>Defines data that needs to be passed upon
-                subscription, e.g., filters or message format for
-                setting up Webhooks.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance"><td><code>data</code></td><td>Defines the data schema of the Event instance
-                messages pushed by the Thing.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-dataResponse--EventAffordance"><td><code>dataResponse</code></td><td>Defines the data schema of the Event response messages sent by the consumer in a response to a data message.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance"><td><code>cancellation</code></td><td>Defines any data that needs to be passed to
-                cancel a subscription, e.g., a specific message to
-                remove a Webhook.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p><code>EventAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-          <span class="rfc2119-assertion" id="td-op-for-event">When
-          a Form instance is within an <code>EventAffordance</code>
-          instance, the value assigned to <code>op</code>
-          MUST be either
-          <code>subscribeevent</code>,
-          <code>unsubscribeevent</code>, or both terms within an
-          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span></p><p class="note">
-		  It is considered to be good practice that each <code>subscribeevent</code> has a corresponding <code>unsubscribeevent</code> unless the protocol
-		  supports implicit unsubscription mechanisms (e.g., heartbeat to detect connection loss).</p>
-          <p>
-            EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs interested Consumers about state changes.
-            However, a main difference of EventAffordances is that not every change of the associated resource needs to trigger an event message to be emitted, e.g. a critical threshold for a numeric value.
-        Furthermore, EventAffordances allow for more complex subscribing and unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and <code>cancellation</code> DataSchema definitions.
-            Not all protocols might support these more advanced mechanisms, however, which is why in some scenarios, events may be very similar to observable PropertyAffordances.
-            In these cases, the choice between a Property and a Event for modelling the Affordance should be made based on the semantics of the underlying resource; for example, if the state of the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the appropriate choice.
-          </p>
+            <p>
+              <a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TD Processors</a> should be aware of
+              certain special cases when processing bidirectional text.
+              <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
+                <a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TD Processors</a> SHOULD take care
+                to use bidi isolation when presenting strings to users, particularly when embedding in surrounding text
+                (e.g., for Web user interface)</span
+              >. Mixed direction text can occur in any language, even when the language is properly identified.
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-producer-mixed-direction">
+                TD <a>producers</a> SHOULD attempt to provide mixed direction strings in a way that can be displayed
+                successfully by a naive user agent.
+              </span>
+              For example, if an RTL string begins with an LTR run (such as a number or a brand or trade name in Latin
+              script), including an RLM character at the start of the string or wrapping opposite direction runs in bidi
+              controls can assist in proper display.
+            </p>
+            <p>
+              <em>Strings on the Web: Language and Direction Metadata</em> [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-string-meta"
+                  title="Strings on the Web: Language and Direction Metadata"
+                  >string-meta</a
+                ></cite
+              >] provides some guidance and illustrates a number of pitfalls when using bidirectional text.
+            </p>
+            <p id="meta-interactions-of-thing">
+              In addition to the explicitly provided
+              <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
+              in the <code>properties</code>, <code>actions</code>, and <code>events</code>
+              <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Maps</a>, a
+              <a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a> can also provide
+              meta-interactions, which are indicated by <code>Form</code> instances in its optional <code>forms</code>
+              <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.
+              <span class="rfc2119-assertion" id="td-op-for-thing"
+                >When the <code>forms</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> of
+                a <a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a> instance contains
+                <code>Form</code> instances, it MUST contain <code>op</code> member with the string values assigned to
+                the name <code>op</code>, either directly or within an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>, MUST be one of the following
+                <em>operation types</em>: <code>readallproperties</code>, <code>writeallproperties</code>,
+                <code>readmultipleproperties</code>, <code>writemultipleproperties</code>,
+                <code>observeallproperties</code>, <code>unobserveallproperties</code>, <code>queryallactions</code>,
+                <code>subscribeallevents</code>, or <code>unsubscribeallevents</code>.</span
+              >
+              (See <a href="#td-forms-readall-example">an example</a> for an usage of <code>form</code> in a Thing
+              instance.)
+            </p>
+            <p>
+              The data schema for each of the property meta-interactions is constructed by combining the data schemas of
+              each <code>PropertyAffordance</code> instance in a single <code>ObjectSchema</code> instance, where the
+              <code>properties</code> <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> of the
+              <code>ObjectSchema</code> instance contains each data schema of the
+              <code>PropertyAffordances</code> identified by the name of the corresponding
+              <code>PropertyAffordances</code> instance.
+            </p>
+            <p>
+              If not specified otherwise (e.g., through a
+              <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>), the request
+              data of the <code>readmultipleproperties</code> operation is an
+              <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> that contains the intended
+              <code>PropertyAffordances</code> instance names, which is serialized to the content type specified by the
+              <code>Form</code> instance.
+            </p>
           </section>
-<section><h3><code>VersionInfo</code></h3><p>Metadata of a Thing that provides version information
-          about the TD document. If required, additional version
-          information such as firmware and hardware version (term
-          definitions outside of the TD namespace) can be extended
-          via the <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>
-          mechanism.</p><table class="def numbered"><caption>Vocabulary Terms in VersionInfo Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo"><td><code>instance</code></td><td>Provides a version indicator of this TD.
-                </td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-model--VersionInfo"><td><code>model</code></td><td>Provides a version indicator of the underlying TM.
-                </td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><p>It is recommended that the values within <code>instances</code> and <code>model</code> of
-          the <code>VersionInfo</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> follow the
-          semantic versioning pattern, where a sequence of three
-          numbers separated by a dot indicates the major version,
-          minor version, and patch version, respectively. See
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0">SEMVER</a></cite>] for
-          details.</p></section>
-<section><h3><code>MultiLanguage</code></h3><p><p>A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
-            <p><span class="rfc2119-assertion" id="td-multilanguage-language-tag">Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in [[!BCP47]].</span>
-            <span class="rfc2119-assertion" id="td-multilanguage-value"> Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>. </span> 
-            </p></section>
+          <section>
+            <h3><code>InteractionAffordance</code></h3>
+            <p>
+              Metadata of a Thing that shows the possible choices to
+              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a>, thereby suggesting how
+              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> may interact with the
+              Thing. There are many types of potential affordances, but
+              <abbr title="World Wide Web Consortium">W3C</abbr> WoT defines three types of Interaction Affordances:
+              Properties, Actions, and Events.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in InteractionAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance">
+                  <td><code>title</code></td>
+                  <td>
+                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
+                    language.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance">
+                  <td><code>titles</code></td>
+                  <td>
+                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
+                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance">
+                  <td><code>forms</code></td>
+                  <td>
+                    Set of form hypermedia controls that describe how an operation can be performed. Forms are
+                    serializations of Protocol Bindings. The array cannot be empty.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Array</a> of <a href="#form"><code>Form</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance">
+                  <td><code>uriVariables</code></td>
+                  <td>
+                    Define URI template variables according to [[RFC6570]] as collection based on DataSchema
+                    declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since
+                    each variable needs to be serialized to a string inside the <code>href</code> upon the execution of
+                    the operation. If the same variable is both declared in <a>Thing level</a>
+                    <code>uriVariables</code>and in Interaction Affordance level, the Interaction Affordance level
+                    variable takes precedence.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>The class <code>InteractionAffordance</code> has the following subclasses:</p>
+            <ul>
+              <li>
+                <a href="#propertyaffordance"><code>PropertyAffordance</code></a>
+              </li>
+              <li>
+                <a href="#actionaffordance"><code>ActionAffordance</code></a>
+              </li>
+              <li>
+                <a href="#eventaffordance"><code>EventAffordance</code></a>
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3><code>PropertyAffordance</code></h3>
+            <p>
+              An Interaction Affordance that exposes state of the Thing. This state can then be retrieved (read) and/or
+              updated (write). Things can also choose to make Properties observable by pushing the new state after a
+              change.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in PropertyAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance">
+                  <td><code>observable</code></td>
+                  <td>
+                    A hint that indicates whether Servients hosting the Thing and Intermediaries should provide a
+                    Protocol Binding that supports the <code>observeproperty</code> and
+                    <code>unobserveproperty</code> operations for this Property.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="note">
+              Property instances are also instances of the class <a href="#dataschema" class="sec-ref">DataSchema</a>.
+              Therefore, it can contain the <code>type</code>, <code>unit</code>, <code>readOnly</code> and
+              <code>writeOnly</code> members, among others.
+            </p>
+            <p>
+              <code>PropertyAffordance</code> is a
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+              <code>InteractionAffordance</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> and the <code>DataSchema</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+              <span class="rfc2119-assertion" id="td-op-for-property"
+                >When a Form instance is within a <code>PropertyAffordance</code> instance, the value assigned to
+                <code>op</code> MUST be one of <code>readproperty</code>, <code>writeproperty</code>,
+                <code>observeproperty</code>, <code>unobserveproperty</code> or an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> containing a combination of
+                these terms.</span
+              >
+            </p>
+            <p class="note">
+              It is considered to be good practice that each <code>observeproperty</code> has a corresponding
+              <code>unobserveproperty</code> unless the protocol supports implicit unsubscription mechanisms (e.g.,
+              heartbeat to detect connection loss).
+            </p>
+            <p class="note">
+              The observation mechanism depends on the underlying protocol or sub-protocol. Having said that, it is not
+              guaranteed that the current <a>Property</a> value will be provided once the subscription is initiated.
+              Hence, it may be necessary to read the current <a>Property</a> value before/after the subscription to get
+              a first value.
+            </p>
+          </section>
+          <section>
+            <h3><code>ActionAffordance</code></h3>
+            <p>
+              An Interaction Affordance that allows to invoke a function of the Thing, which manipulates state (e.g.,
+              toggling a lamp on or off) or triggers a process on the Thing (e.g., dim a lamp over time).
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ActionAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance">
+                  <td><code>input</code></td>
+                  <td>Used to define the input data schema of the Action.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance">
+                  <td><code>output</code></td>
+                  <td>Used to define the output data schema of the Action.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance">
+                  <td><code>safe</code></td>
+                  <td>
+                    Signals if the Action is safe (=true) or not. Used to signal if there is no internal state (cf.
+                    resource state) is changed when invoking an Action. In that case responses can be cached as example.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance">
+                  <td><code>idempotent</code></td>
+                  <td>
+                    Indicates whether the Action is idempotent (=true) or not. Informs whether the Action can be called
+                    repeatedly with the same result, if present, based on the same input.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-synchronous--ActionAffordance">
+                  <td><code>synchronous</code></td>
+                  <td>
+                    Indicates whether the action is synchronous (=true) or not. A synchronous action means that the
+                    response of action contains all the information about the result of the action and no further
+                    querying about the status of the action is needed. Lack of this keyword means that no claim on the
+                    synchronicity of the action can be made.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              <code>ActionAffordance</code> is a
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+              <code>InteractionAffordance</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+              <span class="rfc2119-assertion" id="td-op-for-action"
+                >When a Form instance is within an <code>ActionAffordance</code> instance, the value assigned to op MUST
+                either be <code>invokeaction</code>, <code>queryaction</code>, <code>cancelaction</code> or an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
+                containing a combination of these terms.
+              </span>
+            </p>
+          </section>
+          <section>
+            <h3><code>EventAffordance</code></h3>
+            <p>
+              An Interaction Affordance that describes an event source, which asynchronously pushes event data to
+              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating alerts).
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in EventAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance">
+                  <td><code>subscription</code></td>
+                  <td>
+                    Defines data that needs to be passed upon subscription, e.g., filters or message format for setting
+                    up Webhooks.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance">
+                  <td><code>data</code></td>
+                  <td>Defines the data schema of the Event instance messages pushed by the Thing.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-dataResponse--EventAffordance">
+                  <td><code>dataResponse</code></td>
+                  <td>
+                    Defines the data schema of the Event response messages sent by the consumer in a response to a data
+                    message.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance">
+                  <td><code>cancellation</code></td>
+                  <td>
+                    Defines any data that needs to be passed to cancel a subscription, e.g., a specific message to
+                    remove a Webhook.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              <code>EventAffordance</code> is a
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+              <code>InteractionAffordance</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+              <span class="rfc2119-assertion" id="td-op-for-event"
+                >When a Form instance is within an <code>EventAffordance</code> instance, the value assigned to
+                <code>op</code>
+                MUST be either
+                <code>subscribeevent</code>, <code>unsubscribeevent</code>, or both terms within an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span
+              >
+            </p>
+            <p class="note">
+              It is considered to be good practice that each <code>subscribeevent</code> has a corresponding
+              <code>unsubscribeevent</code> unless the protocol supports implicit unsubscription mechanisms (e.g.,
+              heartbeat to detect connection loss).
+            </p>
+            <p>
+              EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs
+              interested Consumers about state changes. However, a main difference of EventAffordances is that not every
+              change of the associated resource needs to trigger an event message to be emitted, e.g. a critical
+              threshold for a numeric value. Furthermore, EventAffordances allow for more complex subscribing and
+              unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and
+              <code>cancellation</code> DataSchema definitions. Not all protocols might support these more advanced
+              mechanisms, however, which is why in some scenarios, events may be very similar to observable
+              PropertyAffordances. In these cases, the choice between a Property and a Event for modelling the
+              Affordance should be made based on the semantics of the underlying resource; for example, if the state of
+              the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the
+              appropriate choice.
+            </p>
+          </section>
+          <section>
+            <h3><code>VersionInfo</code></h3>
+            <p>
+              Metadata of a Thing that provides version information about the TD document. If required, additional
+              version information such as firmware and hardware version (term definitions outside of the TD namespace)
+              can be extended via the
+              <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a> mechanism.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in VersionInfo Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo">
+                  <td><code>instance</code></td>
+                  <td>Provides a version indicator of this TD.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-model--VersionInfo">
+                  <td><code>model</code></td>
+                  <td>Provides a version indicator of the underlying TM.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              It is recommended that the values within <code>instances</code> and <code>model</code> of the
+              <code>VersionInfo</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> follow
+              the semantic versioning pattern, where a sequence of three numbers separated by a dot indicates the major
+              version, minor version, and patch version, respectively. See [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0"
+                  >SEMVER</a
+                ></cite
+              >] for details.
+            </p>
+          </section>
+          <section>
+            <h3><code>MultiLanguage</code></h3>
+            <p></p>
+            <p>
+              A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags
+              described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of
+              this container in a Thing Description instance.
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-multilanguage-language-tag"
+                >Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in
+                [[!BCP47]].</span
+              >
+              <span class="rfc2119-assertion" id="td-multilanguage-value">
+                Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>.
+              </span>
+            </p>
+          </section>
         </section>
 
         <section id="sec-data-schema-vocabulary-definition">
@@ -1544,122 +2044,579 @@
           </table>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>DataSchema</code></h3><p>Metadata that describes the data format used. It can
-          be used for validation.</p><table class="def numbered"><caption>Vocabulary Terms in DataSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
-                a text for UI representation) based on a default
-                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema"><td><code>titles</code></td><td>Provides multi-language human-readable titles
-                (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema"><td><code>const</code></td><td>Provides a constant value.</td><td>optional</td><td>any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema"><td><code>default</code></td><td>Supply a default value. The value SHOULD validate against the data schema in which it resides.</td><td>optional</td><td>any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema"><td><code>unit</code></td><td>Provides unit information that is used, e.g.,
-                in international science, engineering, and
-                business. To preserve uniqueness, it is recommended that 
-                the value of the unit points to a semantic definition (also see Section <a href="#semantic-annotations-example-version-units"
-          class="internalDFN" data-link-type="dfn">Semantic Annotations</a>).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema"><td><code>oneOf</code></td><td>Used to ensure that the data is valid against
-                one of the specified schemas in the array.  This can be used to describe multiple input or output schemas.</td><td>optional</td><td><a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema"><td><code>enum</code></td><td>Restricted set of values provided as an
-                array.</td><td>optional</td><td><a>Array</a> of any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema"><td><code>readOnly</code></td><td>Boolean value that is a hint to indicate
-                whether a property interaction / value is read only
-                (=true) or not (=false).</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema"><td><code>writeOnly</code></td><td>Boolean value that is a hint to indicate
-                whether a property interaction / value is write
-                only (=true) or not (=false).</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema"><td><code>format</code></td><td>Allows validation based on a format pattern
-                such as "date-time", "email", "uri", etc. (Also see
-                below.)</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-type--DataSchema"><td><code>type</code></td><td>Assignment of JSON-based data types compatible
-                with JSON Schema (one of boolean, integer, number,
-                string, object, array, or null).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> (one of <code>object</code>, <code>array</code>, <code>string</code>, <code>number</code>, <code>integer</code>, <code>boolean</code>, or <code>null</code>)</td></tr></tbody></table><p>The class <code>DataSchema</code> has the following subclasses:</p><ul><li><a href="#arrayschema"><code>ArraySchema</code></a></li>
-<li><a href="#booleanschema"><code>BooleanSchema</code></a></li>
-<li><a href="#numberschema"><code>NumberSchema</code></a></li>
-<li><a href="#integerschema"><code>IntegerSchema</code></a></li>
-<li><a href="#objectschema"><code>ObjectSchema</code></a></li>
-<li><a href="#stringschema"><code>StringSchema</code></a></li>
-<li><a href="#nullschema"><code>NullSchema</code></a></li></ul><p>The <code>format</code> string values are known from a
-          fixed set of values and their corresponding format rules
-          defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]
-          (Section 7.3 Defined Formats in particular). <span class="rfc2119-assertion" id="td-format-validation-known-values">Servients MAY use the
-          <code>format</code> value to perform additional
-          validation accordingly.</span> <span class="rfc2119-assertion" id="td-format-validation-other-values">When a value that is
-          not found in the known set of values is assigned to
-          <code>format</code>, such a validation SHOULD succeed.</span></p>
-          Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>, <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string, object, array, or null).
-          <p class="note">The <code>format</code> term is not widely implemented by JSON Schema tools. 
-          In addition, the term <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by another mechanism or removed in a future JSON Schema version.</p></section>
-<section><h3><code>ArraySchema</code></h3><p>Metadata describing data of type <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>. This
-          <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>array</code> assigned to <code>type</code> in
-          <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in ArraySchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema"><td><code>items</code></td><td>Used to define the characteristics of an
-                array.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a> or <a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema"><td><code>minItems</code></td><td>Defines the minimum number of items that have
-                to be in the array.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema"><td><code>maxItems</code></td><td>Defines the maximum number of items that have
-                to be in the array.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr></tbody></table></section>
-<section><h3><code>BooleanSchema</code></h3><p>Metadata describing data of type <code>boolean</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>boolean</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p></section>
-<section><h3><code>NumberSchema</code></h3><p>Metadata describing data of type <code>number</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>number</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in NumberSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema"><td><code>minimum</code></td><td>Specifies a minimum numeric value, representing an inclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--NumberSchema"><td><code>exclusiveMinimum</code></td><td>Specifies a minimum numeric value, representing an exclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema"><td><code>maximum</code></td><td>Specifies a maximum numeric value, representing an inclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--NumberSchema"><td><code>exclusiveMaximum</code></td><td>Specifies a maximum numeric value, representing an exclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--NumberSchema"><td><code>multipleOf</code></td><td>Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr></tbody></table></section>
-<section><h3><code>IntegerSchema</code></h3><p>Metadata describing data of type <code>integer</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>integer</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in IntegerSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema"><td><code>minimum</code></td><td>Specifies a minimum numeric value, representing an inclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--IntegerSchema"><td><code>exclusiveMinimum</code></td><td>Specifies a minimum numeric value, representing an exclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema"><td><code>maximum</code></td><td>Specifies a maximum numeric value, representing an inclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--IntegerSchema"><td><code>exclusiveMaximum</code></td><td>Specifies a maximum numeric value, representing an exclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--IntegerSchema"><td><code>multipleOf</code></td><td>Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr></tbody></table></section>
-<section><h3><code>ObjectSchema</code></h3><p>Metadata describing data of type <a href="#dfn-object" class="internalDFN" data-link-type="dfn">Object</a>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>object</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in ObjectSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema"><td><code>properties</code></td><td>Data schema nested definitions.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema"><td><code>required</code></td><td>Defines which members of the object type are mandatory, i.e. which members are mandatory in the payload that is to be sent (e.g. input of <code>invokeaction</code>, <code>writeproperty</code>) and what members will be definitely delivered in the payload that is being received (e.g. output of <code>invokeaction</code>, <code>readproperty</code>)</td><td>optional</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>StringSchema</code></h3><p>Metadata describing data of type <code>string</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>string</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in StringSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minLength--StringSchema"><td><code>minLength</code></td><td>Specifies the minimum length of a string. Only applicable for associated string types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maxLength--StringSchema"><td><code>maxLength</code></td><td>Specifies the maximum length of a string. Only applicable for associated string types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-pattern--StringSchema"><td><code>pattern</code></td><td>Provides a regular expression to express constraints of the string value. The regular expression must follow the [[ECMA-262]] dialect.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentEncoding--StringSchema"><td><code>contentEncoding</code></td><td>Specifies the encoding used to store the contents, as specified in [[RFC2045]] (Section 6.1) and [[RFC4648]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>7bit</code>, <code>8bit</code>, <code>binary</code>, <code>quoted-printable</code>, <code>base16</code>, <code>base32</code>, or <code>base64</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentMediaType--StringSchema"><td><code>contentMediaType</code></td><td>Specifies the MIME type of the contents of a string value, as described in [[RFC2046]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>image/png</code>, or <code>audio/mpeg</code>)</td></tr></tbody></table><p class="note">The length of a string (i.e., <code>minLength</code> and
-        <code>maxLength</code>) is defined as the number
-        of Unicode code points, as defined by [[RFC8259]].
-		Note that some <a href="https://www.w3.org/TR/i18n-glossary/#dfn-grapheme" target="_blank">user-perceived characters</a> are composed of more than one Unicode code point. Arbitrary index values might not fall on these grapheme boundaries, so truncation according to <code>maxLength</code> might alter the appearance or meaning of the string.
-		</p></section>
-<section><h3><code>NullSchema</code></h3><p>Metadata describing data of type <code>null</code>. This subclass is indicated by the value <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. 
-    This Subclass describes only one acceptable value, namely <code>null</code>. 
-    It is important to note that <code>null</code> does not mean the absence of a value. It is analogous to <code>null</code> in JavaScript, <code>None</code> in Python, <code>null</code> in Java and <code>nil</code> in Ruby programming languages. 
-    It can be used as part of a <code>oneOf</code> declaration, where it is used to indicate, that the data can also be <code>null</code>.</p></section>
+          <section>
+            <h3><code>DataSchema</code></h3>
+            <p>Metadata that describes the data format used. It can be used for validation.</p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in DataSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema">
+                  <td><code>title</code></td>
+                  <td>
+                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
+                    language.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema">
+                  <td><code>titles</code></td>
+                  <td>
+                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
+                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema">
+                  <td><code>const</code></td>
+                  <td>Provides a constant value.</td>
+                  <td>optional</td>
+                  <td>any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema">
+                  <td><code>default</code></td>
+                  <td>
+                    Supply a default value. The value SHOULD validate against the data schema in which it resides.
+                  </td>
+                  <td>optional</td>
+                  <td>any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema">
+                  <td><code>unit</code></td>
+                  <td>
+                    Provides unit information that is used, e.g., in international science, engineering, and business.
+                    To preserve uniqueness, it is recommended that the value of the unit points to a semantic definition
+                    (also see Section
+                    <a href="#semantic-annotations-example-version-units" class="internalDFN" data-link-type="dfn"
+                      >Semantic Annotations</a
+                    >).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema">
+                  <td><code>oneOf</code></td>
+                  <td>
+                    Used to ensure that the data is valid against one of the specified schemas in the array. This can be
+                    used to describe multiple input or output schemas.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema">
+                  <td><code>enum</code></td>
+                  <td>Restricted set of values provided as an array.</td>
+                  <td>optional</td>
+                  <td><a>Array</a> of any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema">
+                  <td><code>readOnly</code></td>
+                  <td>
+                    Boolean value that is a hint to indicate whether a property interaction / value is read only (=true)
+                    or not (=false).
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema">
+                  <td><code>writeOnly</code></td>
+                  <td>
+                    Boolean value that is a hint to indicate whether a property interaction / value is write only
+                    (=true) or not (=false).
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema">
+                  <td><code>format</code></td>
+                  <td>
+                    Allows validation based on a format pattern such as "date-time", "email", "uri", etc. (Also see
+                    below.)
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-type--DataSchema">
+                  <td><code>type</code></td>
+                  <td>
+                    Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number,
+                    string, object, array, or null).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> (one
+                    of <code>object</code>, <code>array</code>, <code>string</code>, <code>number</code>,
+                    <code>integer</code>, <code>boolean</code>, or <code>null</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>The class <code>DataSchema</code> has the following subclasses:</p>
+            <ul>
+              <li>
+                <a href="#arrayschema"><code>ArraySchema</code></a>
+              </li>
+              <li>
+                <a href="#booleanschema"><code>BooleanSchema</code></a>
+              </li>
+              <li>
+                <a href="#numberschema"><code>NumberSchema</code></a>
+              </li>
+              <li>
+                <a href="#integerschema"><code>IntegerSchema</code></a>
+              </li>
+              <li>
+                <a href="#objectschema"><code>ObjectSchema</code></a>
+              </li>
+              <li>
+                <a href="#stringschema"><code>StringSchema</code></a>
+              </li>
+              <li>
+                <a href="#nullschema"><code>NullSchema</code></a>
+              </li>
+            </ul>
+            <p>
+              The <code>format</code> string values are known from a fixed set of values and their corresponding format
+              rules defined in [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-json-schema"
+                  title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
+                  >JSON-SCHEMA</a
+                ></cite
+              >] (Section 7.3 Defined Formats in particular).
+              <span class="rfc2119-assertion" id="td-format-validation-known-values"
+                >Servients MAY use the <code>format</code> value to perform additional validation accordingly.</span
+              >
+              <span class="rfc2119-assertion" id="td-format-validation-other-values"
+                >When a value that is not found in the known set of values is assigned to <code>format</code>, such a
+                validation SHOULD succeed.</span
+              >
+            </p>
+            Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>,
+            <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string,
+            object, array, or null).
+            <p class="note">
+              The <code>format</code> term is not widely implemented by JSON Schema tools. In addition, the term
+              <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by
+              another mechanism or removed in a future JSON Schema version.
+            </p>
+          </section>
+          <section>
+            <h3><code>ArraySchema</code></h3>
+            <p>
+              Metadata describing data of type <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.
+              This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+              value <code>array</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ArraySchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema">
+                  <td><code>items</code></td>
+                  <td>Used to define the characteristics of an array.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a> or <a>Array</a> of
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema">
+                  <td><code>minItems</code></td>
+                  <td>Defines the minimum number of items that have to be in the array.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema">
+                  <td><code>maxItems</code></td>
+                  <td>Defines the maximum number of items that have to be in the array.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>BooleanSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>boolean</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>boolean</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+          </section>
+          <section>
+            <h3><code>NumberSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>number</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>number</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in NumberSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema">
+                  <td><code>minimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--NumberSchema">
+                  <td><code>exclusiveMinimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema">
+                  <td><code>maximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--NumberSchema">
+                  <td><code>exclusiveMaximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--NumberSchema">
+                  <td><code>multipleOf</code></td>
+                  <td>
+                    Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>IntegerSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>integer</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>integer</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in IntegerSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema">
+                  <td><code>minimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--IntegerSchema">
+                  <td><code>exclusiveMinimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema">
+                  <td><code>maximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--IntegerSchema">
+                  <td><code>exclusiveMaximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--IntegerSchema">
+                  <td><code>multipleOf</code></td>
+                  <td>
+                    Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>ObjectSchema</code></h3>
+            <p>
+              Metadata describing data of type
+              <a href="#dfn-object" class="internalDFN" data-link-type="dfn">Object</a>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>object</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ObjectSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema">
+                  <td><code>properties</code></td>
+                  <td>Data schema nested definitions.</td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema">
+                  <td><code>required</code></td>
+                  <td>
+                    Defines which members of the object type are mandatory, i.e. which members are mandatory in the
+                    payload that is to be sent (e.g. input of <code>invokeaction</code>, <code>writeproperty</code>) and
+                    what members will be definitely delivered in the payload that is being received (e.g. output of
+                    <code>invokeaction</code>, <code>readproperty</code>)
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>StringSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>string</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>string</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in StringSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minLength--StringSchema">
+                  <td><code>minLength</code></td>
+                  <td>Specifies the minimum length of a string. Only applicable for associated string types.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maxLength--StringSchema">
+                  <td><code>maxLength</code></td>
+                  <td>Specifies the maximum length of a string. Only applicable for associated string types.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-pattern--StringSchema">
+                  <td><code>pattern</code></td>
+                  <td>
+                    Provides a regular expression to express constraints of the string value. The regular expression
+                    must follow the [[ECMA-262]] dialect.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentEncoding--StringSchema">
+                  <td><code>contentEncoding</code></td>
+                  <td>
+                    Specifies the encoding used to store the contents, as specified in [[RFC2045]] (Section 6.1) and
+                    [[RFC4648]].
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>7bit</code>, <code>8bit</code>, <code>binary</code>, <code>quoted-printable</code>,
+                    <code>base16</code>, <code>base32</code>, or <code>base64</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentMediaType--StringSchema">
+                  <td><code>contentMediaType</code></td>
+                  <td>Specifies the MIME type of the contents of a string value, as described in [[RFC2046]].</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>image/png</code>, or <code>audio/mpeg</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="note">
+              The length of a string (i.e., <code>minLength</code> and <code>maxLength</code>) is defined as the number
+              of Unicode code points, as defined by [[RFC8259]]. Note that some
+              <a href="https://www.w3.org/TR/i18n-glossary/#dfn-grapheme" target="_blank">user-perceived characters</a>
+              are composed of more than one Unicode code point. Arbitrary index values might not fall on these grapheme
+              boundaries, so truncation according to <code>maxLength</code> might alter the appearance or meaning of the
+              string.
+            </p>
+          </section>
+          <section>
+            <h3><code>NullSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>null</code>. This subclass is indicated by the value
+              <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. This Subclass
+              describes only one acceptable value, namely <code>null</code>. It is important to note that
+              <code>null</code> does not mean the absence of a value. It is analogous to <code>null</code> in
+              JavaScript, <code>None</code> in Python, <code>null</code> in Java and <code>nil</code> in Ruby
+              programming languages. It can be used as part of a <code>oneOf</code> declaration, where it is used to
+              indicate, that the data can also be <code>null</code>.
+            </p>
+          </section>
         </section>
 
         <section id="sec-security-vocabulary-definition">
@@ -1683,229 +2640,713 @@
           </p>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>SecurityScheme</code></h3><p><p>Metadata describing the configuration of a security
-          mechanism. <span class="rfc2119-assertion" id="td-security-scheme-name">The value assigned to the name
-          <code>scheme</code> MUST be defined within a 
-          <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
-          included in the <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>,
-          either in the standard <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined
-          in <a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD
-          Information Model</a> or in a <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context
-          Extension</a>.</span>
-          </p><p>
-          <span class="rfc2119-assertion" id="td-security-no-secrets">For all security schemes,
-          any keys, passwords, or other sensitive information directly providing access 
-          MUST NOT be stored in the TD and should instead
-          be shared and stored out-of-band via other mechanisms.</span> 
-          The purpose of a TD is to describe how to access a Thing if and only if a Consumer 
-          already has authorization, and is not meant be used to grant that authorization.
-          </p><p>Each security scheme object used in a TD defines a set of requirements to be met before access can be granted.
-          We say a security scheme is <em>satisfied</em> when all its requirements are met.
-          In some cases requirements from multiple security schemes will have to be met before access can be granted.
-          </p><p>
-          Security schemes generally may require additional authentication
-          parameters, such as a password or key.
-          The location of this information is indicated by the
-          value associated with the name <code>in</code>, often in combination with the value associated with <code>name</code>.
-          The value associated with <code>in</code> can take one of the following values:
-          </p>
-          <dl>
-          <dt><code>header</code>:</dt>
-          <dd>The parameter will be given
-            in a header provided by the protocol, with the name of the header
-            provided by the value of <code>name</code>.</dd>
-          <dt><code>query</code>:</dt>
-          <dd>The parameter will be appended to the URI as a query parameter, with the name of the 
-            query parameter provided by <code>name</code>.</dd>
-          <dt><code>body</code>:</dt>
-          <dd>The parameter will be provided in the body of the request payload, with the data schema element  
-            used provided by <code>name</code>.
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer">When used in the context of a 
-            <code>body</code> security information location, the value of <code>name</code> 
-            MUST be in the form of a JSON pointer [[!RFC6901]] relative to 
-            the root of the input <code>DataSchema</code> for each interaction it is used with.</span> 
-            Since this value is not a fragment identifier, and is not relative to the root of the TD but
-            to whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
-            it is a "pure" JSON pointer.
-            Since this value is not a fragment identifier, it also does not
-            need to URL-encode special characters.
-            The targeted element may or may not already exist at the specified location in the referenced object or array schema (consequently the mechanism is not applicable to simple types).
-            If it does not, it will be inserted. This avoids having to duplicate definitions in the data schemas of
-            every interaction.
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-creatable">When an element
-            of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
-            does not already exist in the indicated schema, it MUST
-            be possible to insert the indicated element
-            at the location indicated by the pointer.</span>
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-array">The JSON pointer
-            used in the <code>body</code> locator MAY
-            use the "<code>-</code>" character to indicate a non-existent array element when 
-            it is necessary to insert an element after the last element of an existing array.
-            </span>
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-type">The element referenced
-            (or created) by a 
-            <code>body</code> security information location
-            MUST be required and of type "<code>string</code>".</span> 
-            If <code>name</code> is not given, it is assumed the entire body
-            is to be used as the security parameter.
-          </dd>
-          <dt><code>cookie</code>:</dt>
-          <dd>The parameter is stored in a cookie identified by the value of   
-            <code>name</code>.
-          </dd>
-          <dt><code>uri</code>:</dt>
-          <dd>The parameter is embedded in the URI itself, which is encoded in the
-          relevant interaction using a URI template variable defined by the value of <code>name</code>.
-          This is more general than the <code>query</code> mechanism but more complex. 
-          <span class="rfc2119-assertion" id="td-security-in-query-over-uri">The value <code>uri</code> 
-          SHOULD be specified 
-          for the name <code>in</code> in a security scheme only if
-          <code>query</code> is not applicable.</span>  
-          <span class="rfc2119-assertion" id="td-security-in-uri-variable">The URIs provided
-          in interactions where a security scheme using <code>uri</code> as the value for <code>in</code>
-          MUST be a URI template including the defined variable.
-          </span>  
-          </dd>
-          <dt><code>auto</code>:</dt>
-          <dd>The location is determined as part of the protocol, or negotiated. 
-          <span class="rfc2119-assertion" id="td-security-security-vocab-auto-in-no-name">If a value of <code>auto</code> 
-          is set for the <code>in</code> field of a <code>SecurityScheme</code>, 
-          then the <code>name</code> field SHOULD NOT be set.</span> 
-          In this case, the application of the <code>SecurityScheme</code> is subject to 
-          the respective specification for the given protocol (e.g. [[!RFC8288]] when using the 
-          <code>BasicSecurityScheme</code> with HTTP).
-          </dd>
-          </dl>
-          <p>
-          If multiple parameters are needed for a security scheme, repeat the security scheme definition for
-          each parameter and combine them using a <code>combo</code> security scheme and <code>allOf</code>.
-          In some cases parameters may not actually be secret but a user may wish to leave them
-          out of the TD to help protect privacy.  As an example of this, some security mechanisms
-          require both a client identifier and a secret key.  In theory, the client identifier is 
-          public however it may be hard to update and pose a tracking risk.  In such a case it can
-          be provided as an additional security parameter so it does not appear in the TD.
-          </p><p>
-          <span class="rfc2119-assertion" id="td-security-uri-variables-distinct">The names of URI variables 
-          declared in a <code>SecurityScheme</code> 
-          MUST be distinct from all other URI variables 
-          declared in the TD.</span></p><table class="def numbered"><caption>Vocabulary Terms in SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme"><td><code>proxy</code></td><td>URI of the proxy server this security
-                configuration provides access to. If not given, the
-                corresponding security configuration is for the
-                endpoint.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme"><td><code>scheme</code></td><td>Identification of the security mechanism being
-                configured.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>nosec</code>, <code>combo</code>, <code>basic</code>, <code>digest</code>, <code>bearer</code>, <code>psk</code>, <code>oauth2</code>, <code>apikey</code>, or <code>auto</code>)</td></tr></tbody></table><p>The class <code>SecurityScheme</code> has the following subclasses:</p><ul><li><a href="#nosecurityscheme"><code>NoSecurityScheme</code></a></li>
-<li><a href="#autosecurityscheme"><code>AutoSecurityScheme</code></a></li>
-<li><a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a></li>
-<li><a href="#basicsecurityscheme"><code>BasicSecurityScheme</code></a></li>
-<li><a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a></li>
-<li><a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a></li>
-<li><a href="#bearersecurityscheme"><code>BearerSecurityScheme</code></a></li>
-<li><a href="#psksecurityscheme"><code>PSKSecurityScheme</code></a></li>
-<li><a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a></li></ul></section>
-<section><h3><code>NoSecurityScheme</code></h3><p>A security configuration corresponding to identified
-          by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-          <code>nosec</code> (i.e., <code>"scheme":
-          "nosec"</code>), indicating there is no authentication or
-          other mechanism required to access the resource.</p></section>
-<section><h3><code>AutoSecurityScheme</code></h3><p>An automatic authentication security configuration identified by the term <code>auto</code> (i.e., <code>"scheme": "auto"</code>). This scheme indicates that the security parameters are going to be negotiated by the underlying protocols at runtime, subject to the respective specifications for the protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).</p></section>
-<section><h3><code>ComboSecurityScheme</code></h3><p>A combination of other security schemes identified by the <a>Vocabulary Term</a> <code>combo</code> (i.e., <code>"scheme": "combo"</code>).  Elements of this scheme define various ways in which other named schemes defined in <code>securityDefinitions</code>, including other <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> definitions, are to be combined to create a new scheme definition.  <span class="rfc2119-assertion" id="td-security-combo-exclusive-oneof-or-allof">Exactly one of either <code>oneOf</code> or <code>allOf</code> <i>vocabulary terms</i> MUST be included.</span> <!-- Redundant, table states "two or more" already <scan class="rfc2119-assertion">The array given as a value associated with either <code>oneOf</code> or <code>allOf</code> MUST have at least two elements.</scan> --> Only security scheme definitions which can be used together can be combined with <code>allOf</code>.  For example, it is not possible in general to combine different OAuth 2.0 flows together using <code>allOf</code> unless one applies to a proxy and one to the endpoint.  Note that when multiple named security scheme definitions are listed in a <code>security</code> field the same semantics apply as in an <code>allOf</code> combination (and the same limitations on allowable combinations).  The <code>oneOf</code> combination is equivalent to using different security schemes on forms that are otherwise identical.  In this sense a <code>oneOf</code> scheme is not an essential feature but it does avoid redundancy in such cases.</p><table class="def numbered"><caption>Vocabulary Terms in ComboSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-oneOf--ComboSecurityScheme"><td><code>oneOf</code></td><td>Array of two or more strings identifying other named security scheme definitions, any one of which, when satisfied, will allow access.  Only one may be chosen for use.</td><td>mandatory</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-allOf--ComboSecurityScheme"><td><code>allOf</code></td><td>Array of two or more strings identifying other named security scheme definitions, all of which must be satisfied for access.</td><td>mandatory</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><!-- <p class="ednote" title="Recursive Use">The 
-<a href="#combosecurityscheme">ComboSecurityScheme</a> may be applied recursively to generate Boolean expressions for combinations of security schemes. One use case for this is when multiple security schemes are needed for a proxy in combination with multiple security schemes for an endpoint.  Suppose for example a proxy accepts either schemes A or B, and then the endpoint accepts either C or D.  Then the possible combinations are AC, AD, BC, and BD.  These could be expressed directly at the <code>Form</code> level but would require four-fold redundancy.  Instead, three <code>combo</code> nodes can be used to combine the four leaf schemes in the correct way into a single scheme.  It is not clear however if other use cases exist for deeper expression trees and if not, we may consider limiting the recursion depth to two.</p>--></section>
-<section><h3><code>BasicSecurityScheme</code></h3><p>Basic Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7617" title="The 'Basic' HTTP Authentication Scheme">RFC7617</a></cite>]
-          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>basic</code> (i.e.,
-          <code>"scheme": "basic"</code>), using an unencrypted
-          username and password.</p><table class="def numbered"><caption>Vocabulary Terms in BasicSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr></tbody></table></section>
-<section><h3><code>DigestSecurityScheme</code></h3><p>Digest Access Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication">RFC7616</a></cite>]
-          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>digest</code> (i.e.,
-          <code>"scheme": "digest"</code>). This scheme is similar
-          to basic authentication but with added features to avoid
-          man-in-the-middle attacks.</p><table class="def numbered"><caption>Vocabulary Terms in DigestSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme"><td><code>qop</code></td><td>Quality of protection.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>auth</code>, or <code>auth-int</code>)</td></tr></tbody></table></section>
-<section><h3><code>APIKeySecurityScheme</code></h3><p>API key authentication security configuration
-          identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-          <code>apikey</code> (i.e., <code>"scheme":
-          "apikey"</code>). 
-          This scheme is to be used when the access token is opaque,
-          for example when a key in an unknown or proprietary format is provided by a cloud service provider.
-          In this case the key may not be using a standard token format.
-          This scheme indicates that the key provided by the service provider 
-          needs to be supplied as part 
-          of service requests using the mechanism indicated by the <code>"in"</code> field.</p><table class="def numbered"><caption>Vocabulary Terms in APIKeySecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, <code>uri</code>, or <code>auto</code>)</td></tr></tbody></table></section>
-<section><h3><code>BearerSecurityScheme</code></h3><p>Bearer Token [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6750" title="The OAuth 2.0 Authorization Framework: Bearer Token Usage">RFC6750</a></cite>]
-          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>bearer</code> (i.e.,
-          <code>"scheme": "bearer"</code>) for situations where
-          bearer tokens are used independently of OAuth2. If the
-          <code>oauth2</code> scheme is specified it is not
-          generally necessary to specify this scheme as well as it
-          is implied. For <code>format</code>, the value
-          <code>jwt</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>],
-          <code>jws</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7797" title="JSON Web Signature (JWS) Unencoded Payload Option">RFC7797</a></cite>],
-          <code>cwt</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)">RFC8392</a></cite>], and
-          <code>jwe</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>], with
-          values for <code>alg</code> interpreted consistently with
-          those standards. <span class="rfc2119-assertion" id="td-security-bearer-format-extensions">Other formats and
-          algorithms for bearer tokens MAY be specified in vocabulary
-          extensions</span>.</p><table class="def numbered"><caption>Vocabulary Terms in BearerSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme"><td><code>alg</code></td><td>Encoding, encryption, or digest algorithm.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>ES256</code>, or <code>ES512-256</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme"><td><code>format</code></td><td>Specifies format of security authentication
-                 information.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)</td></tr></tbody></table></section>
-<section><h3><code>PSKSecurityScheme</code></h3><p>Pre-shared key authentication security configuration
-          identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-          <code>psk</code> (i.e., <code>"scheme":
-          "psk"</code>).
-          This is meant to identify that a standard is used for pre-shared keys such as TLS-PSK [[RFC4279]], 
-          and that the ciphersuite used for keys will be established during protocol negotiation.</p><table class="def numbered"><caption>Vocabulary Terms in PSKSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-identity--PSKSecurityScheme"><td><code>identity</code></td><td>Identifier providing information which can be
-                   used for selection or confirmation.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>OAuth2SecurityScheme</code></h3><p>OAuth 2.0 authentication security configuration
-            for systems conformant with [[!RFC6749]] and [[!RFC8252]], <!-- and
-            (for the <code>device</code> flow) [[!RFC8628]],--> identified
-            by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e.,
-            <code>"scheme": "oauth2"</code>).</p><table class="def numbered"><caption>Vocabulary Terms in OAuth2SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.<!-- In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]. --></td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme"><td><code>token</code></td><td>URI of the token server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme"><td><code>refresh</code></td><td>URI of the refresh server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided
-                as an array. These are provided in tokens returned
-                by an authorization server and associated with
-                forms in order to identify what resources a client
-                may access and how. The values associated with a
-                form SHOULD be chosen from those defined in an
-                <code>OAuth2SecurityScheme</code> active on that
-                form.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme"><td><code>flow</code></td><td>Authorization flow.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>code</code>, or <code>client</code>)</td></tr></tbody></table><p><span class="rfc2119-assertion" id="td-security-oauth2-code-flow">For
-            the <code>code</code> flow both <code>authorization</code> and <code>token</code> <a>vocabulary terms</a>
-            MUST be included.</span> <span class="rfc2119-assertion" id="td-security-oauth2-client-flow">For
-            the <code>client</code> flow <code>token</code> <a>vocabulary term</a> MUST be included.</span>
-            <span class="rfc2119-assertion" id="td-security-oauth2-client-flow-no-auth">For the
-            <code>client</code> flow <code>authorization</code> <a>vocabulary term</a> MUST NOT be included.</span>
-            <!-- <span class="rfc2119-assertion" id="td-security-oauth2-device-flow">For the
+          <section>
+            <h3><code>SecurityScheme</code></h3>
+            <p></p>
+            <p>
+              Metadata describing the configuration of a security mechanism.
+              <span class="rfc2119-assertion" id="td-security-scheme-name"
+                >The value assigned to the name <code>scheme</code> MUST be defined within a
+                <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
+                included in the
+                <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>, either
+                in the standard
+                <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined in
+                <a href="#sec-vocabulary-definition" class="sec-ref"
+                  >§&nbsp;<bdi class="secno">5.</bdi> TD Information Model</a
+                >
+                or in a
+                <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>.</span
+              >
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-security-no-secrets"
+                >For all security schemes, any keys, passwords, or other sensitive information directly providing access
+                MUST NOT be stored in the TD and should instead be shared and stored out-of-band via other
+                mechanisms.</span
+              >
+              The purpose of a TD is to describe how to access a Thing if and only if a Consumer already has
+              authorization, and is not meant be used to grant that authorization.
+            </p>
+            <p>
+              Each security scheme object used in a TD defines a set of requirements to be met before access can be
+              granted. We say a security scheme is <em>satisfied</em> when all its requirements are met. In some cases
+              requirements from multiple security schemes will have to be met before access can be granted.
+            </p>
+            <p>
+              Security schemes generally may require additional authentication parameters, such as a password or key.
+              The location of this information is indicated by the value associated with the name <code>in</code>, often
+              in combination with the value associated with <code>name</code>. The value associated with
+              <code>in</code> can take one of the following values:
+            </p>
+            <dl>
+              <dt><code>header</code>:</dt>
+              <dd>
+                The parameter will be given in a header provided by the protocol, with the name of the header provided
+                by the value of <code>name</code>.
+              </dd>
+              <dt><code>query</code>:</dt>
+              <dd>
+                The parameter will be appended to the URI as a query parameter, with the name of the query parameter
+                provided by <code>name</code>.
+              </dd>
+              <dt><code>body</code>:</dt>
+              <dd>
+                The parameter will be provided in the body of the request payload, with the data schema element used
+                provided by <code>name</code>.
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer"
+                  >When used in the context of a <code>body</code> security information location, the value of
+                  <code>name</code> MUST be in the form of a JSON pointer [[!RFC6901]] relative to the root of the input
+                  <code>DataSchema</code> for each interaction it is used with.</span
+                >
+                Since this value is not a fragment identifier, and is not relative to the root of the TD but to
+                whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
+                it is a "pure" JSON pointer. Since this value is not a fragment identifier, it also does not need to
+                URL-encode special characters. The targeted element may or may not already exist at the specified
+                location in the referenced object or array schema (consequently the mechanism is not applicable to
+                simple types). If it does not, it will be inserted. This avoids having to duplicate definitions in the
+                data schemas of every interaction.
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-creatable"
+                  >When an element of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
+                  does not already exist in the indicated schema, it MUST be possible to insert the indicated element at
+                  the location indicated by the pointer.</span
+                >
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-array"
+                  >The JSON pointer used in the <code>body</code> locator MAY use the "<code>-</code>" character to
+                  indicate a non-existent array element when it is necessary to insert an element after the last element
+                  of an existing array.
+                </span>
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-type"
+                  >The element referenced (or created) by a <code>body</code> security information location MUST be
+                  required and of type "<code>string</code>".</span
+                >
+                If <code>name</code> is not given, it is assumed the entire body is to be used as the security
+                parameter.
+              </dd>
+              <dt><code>cookie</code>:</dt>
+              <dd>The parameter is stored in a cookie identified by the value of <code>name</code>.</dd>
+              <dt><code>uri</code>:</dt>
+              <dd>
+                The parameter is embedded in the URI itself, which is encoded in the relevant interaction using a URI
+                template variable defined by the value of <code>name</code>. This is more general than the
+                <code>query</code> mechanism but more complex.
+                <span class="rfc2119-assertion" id="td-security-in-query-over-uri"
+                  >The value <code>uri</code> SHOULD be specified for the name <code>in</code> in a security scheme only
+                  if <code>query</code> is not applicable.</span
+                >
+                <span class="rfc2119-assertion" id="td-security-in-uri-variable"
+                  >The URIs provided in interactions where a security scheme using <code>uri</code> as the value for
+                  <code>in</code>
+                  MUST be a URI template including the defined variable.
+                </span>
+              </dd>
+              <dt><code>auto</code>:</dt>
+              <dd>
+                The location is determined as part of the protocol, or negotiated.
+                <span class="rfc2119-assertion" id="td-security-security-vocab-auto-in-no-name"
+                  >If a value of <code>auto</code> is set for the <code>in</code> field of a
+                  <code>SecurityScheme</code>, then the <code>name</code> field SHOULD NOT be set.</span
+                >
+                In this case, the application of the <code>SecurityScheme</code> is subject to the respective
+                specification for the given protocol (e.g. [[!RFC8288]] when using the
+                <code>BasicSecurityScheme</code> with HTTP).
+              </dd>
+            </dl>
+            <p>
+              If multiple parameters are needed for a security scheme, repeat the security scheme definition for each
+              parameter and combine them using a <code>combo</code> security scheme and <code>allOf</code>. In some
+              cases parameters may not actually be secret but a user may wish to leave them out of the TD to help
+              protect privacy. As an example of this, some security mechanisms require both a client identifier and a
+              secret key. In theory, the client identifier is public however it may be hard to update and pose a
+              tracking risk. In such a case it can be provided as an additional security parameter so it does not appear
+              in the TD.
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-security-uri-variables-distinct"
+                >The names of URI variables declared in a <code>SecurityScheme</code> MUST be distinct from all other
+                URI variables declared in the TD.</span
+              >
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in SecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme">
+                  <td><code>proxy</code></td>
+                  <td>
+                    URI of the proxy server this security configuration provides access to. If not given, the
+                    corresponding security configuration is for the endpoint.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme">
+                  <td><code>scheme</code></td>
+                  <td>Identification of the security mechanism being configured.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>nosec</code>, <code>combo</code>, <code>basic</code>, <code>digest</code>,
+                    <code>bearer</code>, <code>psk</code>, <code>oauth2</code>, <code>apikey</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>The class <code>SecurityScheme</code> has the following subclasses:</p>
+            <ul>
+              <li>
+                <a href="#nosecurityscheme"><code>NoSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#autosecurityscheme"><code>AutoSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#basicsecurityscheme"><code>BasicSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#bearersecurityscheme"><code>BearerSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#psksecurityscheme"><code>PSKSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a>
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3><code>NoSecurityScheme</code></h3>
+            <p>
+              A security configuration corresponding to identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>nosec</code> (i.e., <code>"scheme": "nosec"</code>), indicating there is no authentication or other
+              mechanism required to access the resource.
+            </p>
+          </section>
+          <section>
+            <h3><code>AutoSecurityScheme</code></h3>
+            <p>
+              An automatic authentication security configuration identified by the term <code>auto</code> (i.e.,
+              <code>"scheme": "auto"</code>). This scheme indicates that the security parameters are going to be
+              negotiated by the underlying protocols at runtime, subject to the respective specifications for the
+              protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).
+            </p>
+          </section>
+          <section>
+            <h3><code>ComboSecurityScheme</code></h3>
+            <p>
+              A combination of other security schemes identified by the <a>Vocabulary Term</a> <code>combo</code> (i.e.,
+              <code>"scheme": "combo"</code>). Elements of this scheme define various ways in which other named schemes
+              defined in <code>securityDefinitions</code>, including other
+              <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> definitions, are to be combined to
+              create a new scheme definition.
+              <span class="rfc2119-assertion" id="td-security-combo-exclusive-oneof-or-allof"
+                >Exactly one of either <code>oneOf</code> or <code>allOf</code> <i>vocabulary terms</i> MUST be
+                included.</span
+              >
+              <!-- Redundant, table states "two or more" already <scan class="rfc2119-assertion">The array given as a value associated with either <code>oneOf</code> or <code>allOf</code> MUST have at least two elements.</scan> -->
+              Only security scheme definitions which can be used together can be combined with <code>allOf</code>. For
+              example, it is not possible in general to combine different OAuth 2.0 flows together using
+              <code>allOf</code> unless one applies to a proxy and one to the endpoint. Note that when multiple named
+              security scheme definitions are listed in a <code>security</code> field the same semantics apply as in an
+              <code>allOf</code> combination (and the same limitations on allowable combinations). The
+              <code>oneOf</code> combination is equivalent to using different security schemes on forms that are
+              otherwise identical. In this sense a <code>oneOf</code> scheme is not an essential feature but it does
+              avoid redundancy in such cases.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ComboSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--ComboSecurityScheme">
+                  <td><code>oneOf</code></td>
+                  <td>
+                    Array of two or more strings identifying other named security scheme definitions, any one of which,
+                    when satisfied, will allow access. Only one may be chosen for use.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-allOf--ComboSecurityScheme">
+                  <td><code>allOf</code></td>
+                  <td>
+                    Array of two or more strings identifying other named security scheme definitions, all of which must
+                    be satisfied for access.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <!-- <p class="ednote" title="Recursive Use">The 
+<a href="#combosecurityscheme">ComboSecurityScheme</a> may be applied recursively to generate Boolean expressions for combinations of security schemes. One use case for this is when multiple security schemes are needed for a proxy in combination with multiple security schemes for an endpoint.  Suppose for example a proxy accepts either schemes A or B, and then the endpoint accepts either C or D.  Then the possible combinations are AC, AD, BC, and BD.  These could be expressed directly at the <code>Form</code> level but would require four-fold redundancy.  Instead, three <code>combo</code> nodes can be used to combine the four leaf schemes in the correct way into a single scheme.  It is not clear however if other use cases exist for deeper expression trees and if not, we may consider limiting the recursion depth to two.</p>-->
+          </section>
+          <section>
+            <h3><code>BasicSecurityScheme</code></h3>
+            <p>
+              Basic Authentication [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-rfc7617"
+                  title="The 'Basic' HTTP Authentication Scheme"
+                  >RFC7617</a
+                ></cite
+              >] security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>basic</code> (i.e., <code>"scheme": "basic"</code>), using an unencrypted username and password.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in BasicSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>DigestSecurityScheme</code></h3>
+            <p>
+              Digest Access Authentication [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication"
+                  >RFC7616</a
+                ></cite
+              >] security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>digest</code> (i.e., <code>"scheme": "digest"</code>). This scheme is similar to basic
+              authentication but with added features to avoid man-in-the-middle attacks.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in DigestSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme">
+                  <td><code>qop</code></td>
+                  <td>Quality of protection.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>auth</code>, or <code>auth-int</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>APIKeySecurityScheme</code></h3>
+            <p>
+              API key authentication security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>apikey</code> (i.e., <code>"scheme": "apikey"</code>). This scheme is to be used when the access
+              token is opaque, for example when a key in an unknown or proprietary format is provided by a cloud service
+              provider. In this case the key may not be using a standard token format. This scheme indicates that the
+              key provided by the service provider needs to be supplied as part of service requests using the mechanism
+              indicated by the <code>"in"</code> field.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in APIKeySecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>,
+                    <code>uri</code>, or <code>auto</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>BearerSecurityScheme</code></h3>
+            <p>
+              Bearer Token [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-rfc6750"
+                  title="The OAuth 2.0 Authorization Framework: Bearer Token Usage"
+                  >RFC6750</a
+                ></cite
+              >] security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>bearer</code> (i.e., <code>"scheme": "bearer"</code>) for situations where bearer tokens are used
+              independently of OAuth2. If the <code>oauth2</code> scheme is specified it is not generally necessary to
+              specify this scheme as well as it is implied. For <code>format</code>, the value
+              <code>jwt</code> indicates conformance with [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)"
+                  >RFC7519</a
+                ></cite
+              >], <code>jws</code> indicates conformance with [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-rfc7797"
+                  title="JSON Web Signature (JWS) Unencoded Payload Option"
+                  >RFC7797</a
+                ></cite
+              >], <code>cwt</code> indicates conformance with [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)"
+                  >RFC8392</a
+                ></cite
+              >], and <code>jwe</code> indicates conformance with [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)"
+                  >RFC7516</a
+                ></cite
+              >], with values for <code>alg</code> interpreted consistently with those standards.
+              <span class="rfc2119-assertion" id="td-security-bearer-format-extensions"
+                >Other formats and algorithms for bearer tokens MAY be specified in vocabulary extensions</span
+              >.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in BearerSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme">
+                  <td><code>authorization</code></td>
+                  <td>URI of the authorization server.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme">
+                  <td><code>alg</code></td>
+                  <td>Encoding, encryption, or digest algorithm.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>ES256</code>, or <code>ES512-256</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme">
+                  <td><code>format</code></td>
+                  <td>Specifies format of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>PSKSecurityScheme</code></h3>
+            <p>
+              Pre-shared key authentication security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>psk</code> (i.e., <code>"scheme": "psk"</code>). This is meant to identify that a standard is used
+              for pre-shared keys such as TLS-PSK [[RFC4279]], and that the ciphersuite used for keys will be
+              established during protocol negotiation.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in PSKSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-identity--PSKSecurityScheme">
+                  <td><code>identity</code></td>
+                  <td>Identifier providing information which can be used for selection or confirmation.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>OAuth2SecurityScheme</code></h3>
+            <p>
+              OAuth 2.0 authentication security configuration for systems conformant with [[!RFC6749]] and [[!RFC8252]],
+              <!-- and
+            (for the <code>device</code> flow) [[!RFC8628]],-->
+              identified by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e., <code>"scheme": "oauth2"</code>).
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in OAuth2SecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme">
+                  <td><code>authorization</code></td>
+                  <td>
+                    URI of the authorization server.<!-- In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]. -->
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme">
+                  <td><code>token</code></td>
+                  <td>URI of the token server.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme">
+                  <td><code>refresh</code></td>
+                  <td>URI of the refresh server.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme">
+                  <td><code>scopes</code></td>
+                  <td>
+                    Set of authorization scope identifiers provided as an array. These are provided in tokens returned
+                    by an authorization server and associated with forms in order to identify what resources a client
+                    may access and how. The values associated with a form SHOULD be chosen from those defined in an
+                    <code>OAuth2SecurityScheme</code> active on that form.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme">
+                  <td><code>flow</code></td>
+                  <td>Authorization flow.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>code</code>, or <code>client</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              <span class="rfc2119-assertion" id="td-security-oauth2-code-flow"
+                >For the <code>code</code> flow both <code>authorization</code> and <code>token</code>
+                <a>vocabulary terms</a> MUST be included.</span
+              >
+              <span class="rfc2119-assertion" id="td-security-oauth2-client-flow"
+                >For the <code>client</code> flow <code>token</code> <a>vocabulary term</a> MUST be included.</span
+              >
+              <span class="rfc2119-assertion" id="td-security-oauth2-client-flow-no-auth"
+                >For the <code>client</code> flow <code>authorization</code> <a>vocabulary term</a> MUST NOT be
+                included.</span
+              >
+              <!-- <span class="rfc2119-assertion" id="td-security-oauth2-device-flow">For the
             <code>device</code> flow both <code>authorization</code> and <code>token</code> <a>vocabulary terms</a>
             MUST be included.</span> In the case of the <code>device</code> flow the value
             provided for <code>authorization</code> <a>vocabulary terms</a> refers to the device authorization endpoint
-            defined in [[!RFC8628]]. --> The mandatory elements for each flow are summarized in the
-            following table:
+            defined in [[!RFC8628]]. -->
+              The mandatory elements for each flow are summarized in the following table:
             </p>
-            <table class="def numbered"> <tr><th>Element</th><th><code>code</code></th><th><code>client</code></th></tr> <tr><td><code>authorization</code></td><td>mandatory</td><td>omit</td><!-- <td>mandatory; refers to device authorization endpoint</td> --></tr> <tr><td><code>token</code></td><td>mandatory</td><td>mandatory</td><!-- <td>mandatory</td> --></tr> <tr><td><code>refresh</code></td><td>optional</td><td>optional</td><!-- <td>optional</td> --></tr> </table>
+            <table class="def numbered">
+              <tr>
+                <th>Element</th>
+                <th><code>code</code></th>
+                <th><code>client</code></th>
+              </tr>
+              <tr>
+                <td><code>authorization</code></td>
+                <td>mandatory</td>
+                <td>omit</td>
+                <!-- <td>mandatory; refers to device authorization endpoint</td> -->
+              </tr>
+              <tr>
+                <td><code>token</code></td>
+                <td>mandatory</td>
+                <td>mandatory</td>
+                <!-- <td>mandatory</td> -->
+              </tr>
+              <tr>
+                <td><code>refresh</code></td>
+                <td>optional</td>
+                <td>optional</td>
+                <!-- <td>optional</td> -->
+              </tr>
+            </table>
             <!-- 
 	    <p class="ednote"> Note that the <code>OAuth2SecurityScheme</code> class definition lists these elements as "optional". 
             In fact whether they are mandatory or not depends on the flow.  The <code>token</code>
@@ -1930,7 +3371,8 @@
             however an alternative design where there is a separate element,
             <code>device_authorization</code>, which MUST be included for the <code>device</code>
             flow (and then the regular authorization endpoint then MUST NOT be used).</p>
-	    --></section>
+	    -->
+          </section>
         </section>
 
         <section id="sec-hypermedia-vocabulary-definition">
@@ -1946,587 +3388,843 @@
           </p>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>Link</code></h3><p>A link can be viewed as a statement of the form
-          "<b><em>link context</em></b> has a <b><em>relation
-          type</em></b> resource at <b><em>link target</em></b>",
-          where the optional <b><em>target attributes</em></b> may
-          further describe the resource.</p><table class="def numbered"><caption>Vocabulary Terms in Link Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Link"><td><code>href</code></td><td>Target IRI of a link or submission target of a
-                form.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-type--Link"><td><code>type</code></td><td>Target attribute providing a hint indicating
-                what the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]
-                of the result of dereferencing the link should
-                be.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-rel--Link"><td><code>rel</code></td><td>A link relation type identifies the semantics
-                of a link.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link"><td><code>anchor</code></td><td>Overrides the link context (by default the
-                Thing itself identified by its <code>id</code>)
-                with the given URI or IRI.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link"><td><code>sizes</code></td><td>Target attribute that specifies one or more sizes for the referenced icon. 
-                    Only applicable for relation type "icon". The value pattern follows 
-                    {Height}x{Width} (e.g., "16x16", "16x16 32x32").</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-hreflang--Link"><td><code>hreflang</code></td><td>The hreflang attribute specifies the language of a linked document. The value of this must be a valid language tag [[BCP47]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><p class="note" title="hreflang type">
-        The <code>hreflang</code> attribute is allowed to be a <code>string</code> or <code>array</code> in this version of the spec. Depending on the result of [[LINKSET-MEDIA-TYPES]] the values of <code>hrefLang</code> can be restricted to <code>array</code> only.
-	</p>
-     <p>Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description
-    is an instance of a specific Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended to reuse existing and established 
-    <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
-    </p>
-        <p>In the following a best practice relation type table is introduced that is recommended to use within WoT <a>Thing Description</a>
-    or <a>Thing Model</a> instances.      
-    </p>
-    <table class="def numbered">
-        <caption>Best practice relation type table</caption>
-        <thead>
-            <tr>
-                <th>Value</th>                
-                <th>Occurrence</th>
-                <th>Explanation</th>
-                <th>Source of value origin</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr >
-                <td>
+          <section>
+            <h3><code>Link</code></h3>
+            <p>
+              A link can be viewed as a statement of the form "<b><em>link context</em></b> has a
+              <b><em>relation type</em></b> resource at <b><em>link target</em></b
+              >", where the optional <b><em>target attributes</em></b> may further describe the resource.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in Link Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-href--Link">
+                  <td><code>href</code></td>
+                  <td>Target IRI of a link or submission target of a form.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-type--Link">
+                  <td><code>type</code></td>
+                  <td>
+                    Target attribute providing a hint indicating what the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >] of the result of dereferencing the link should be.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-rel--Link">
+                  <td><code>rel</code></td>
+                  <td>A link relation type identifies the semantics of a link.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link">
+                  <td><code>anchor</code></td>
+                  <td>
+                    Overrides the link context (by default the Thing itself identified by its <code>id</code>) with the
+                    given URI or IRI.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link">
+                  <td><code>sizes</code></td>
+                  <td>
+                    Target attribute that specifies one or more sizes for the referenced icon. Only applicable for
+                    relation type "icon". The value pattern follows {Height}x{Width} (e.g., "16x16", "16x16 32x32").
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-hreflang--Link">
+                  <td><code>hreflang</code></td>
+                  <td>
+                    The hreflang attribute specifies the language of a linked document. The value of this must be a
+                    valid language tag [[BCP47]].
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="note" title="hreflang type">
+              The <code>hreflang</code> attribute is allowed to be a <code>string</code> or <code>array</code> in this
+              version of the spec. Depending on the result of [[LINKSET-MEDIA-TYPES]] the values of
+              <code>hrefLang</code> can be restricted to <code>array</code> only.
+            </p>
+            <p>
+              Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a
+              Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description is an instance of a specific
+              Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended
+              to reuse existing and established
+              <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
+            </p>
+            <p>
+              In the following a best practice relation type table is introduced that is recommended to use within WoT
+              <a>Thing Description</a> or <a>Thing Model</a> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Best practice relation type table
+              </caption>
+              <thead>
+                <tr>
+                  <th>Value</th>
+                  <th>Occurrence</th>
+                  <th>Explanation</th>
+                  <th>Source of value origin</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
                     <code>icon</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Imports an icon associated to the <a>Thing</a> (e.g., for UI purposes).</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>Imports an icon associated to the <a>Thing</a> (e.g., for UI purposes).</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>service-doc</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Relation to a resource that provide (human-readable) documentation or descriptions.</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>Relation to a resource that provide (human-readable) documentation or descriptions.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>alternate</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Point to alternative representation of the <a>Thing</a> (i.e. RDF-Turtle, human-readable HTML document, ...).</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Point to alternative representation of the <a>Thing</a> (i.e. RDF-Turtle, human-readable HTML
+                    document, ...).
+                  </td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>type</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Indicate that the <a>Thing</a> is an instance of the target resource such as to a <a>Thing Model</a>.</td>
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>
+                    Indicate that the <a>Thing</a> is an instance of the target resource such as to a
+                    <a>Thing Model</a>.
+                  </td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>tm:extends</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Extends an existing definition of the target resource such as a <a>Thing Model</a>. Only applicable for Thing Model definitions.</td>
-                <td>
-                    W3C WoT Thing Model
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>
+                    Extends an existing definition of the target resource such as a <a>Thing Model</a>. Only applicable
+                    for Thing Model definitions.
+                  </td>
+                  <td>W3C WoT Thing Model</td>
+                </tr>
+                <tr>
+                  <td>
                     <code>tm:submodel</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Used to compose one or multiple <a>Thing Models</a>. Only applicable for Thing Model definitions.</td>
-                <td>
-                    W3C WoT Thing Model
-                </td>
-            </tr>                         
-            <tr >
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Used to compose one or multiple <a>Thing Models</a>. Only applicable for Thing Model definitions.
+                  </td>
+                  <td>W3C WoT Thing Model</td>
+                </tr>
+                <tr>
+                  <td>
                     <code>manifest</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Point to the web app manifest of a web application which provides, e.g., a user interface with which a user can interact with the Thing (also see [[APPMANIFEST]]).</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Point to the web app manifest of a web application which provides, e.g., a user interface with which
+                    a user can interact with the Thing (also see [[APPMANIFEST]]).
+                  </td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>proxy-to</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Target resource provide the address of a proxy. Additional security metadata can be provided using the <code>proxy</code> field in a <a href="#securityscheme">SecurityScheme</a>.</td>
-                <td>
-                    W3C WoT Security and WoT Binding Template
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Target resource provide the address of a proxy. Additional security metadata can be provided using
+                    the <code>proxy</code> field in a <a href="#securityscheme">SecurityScheme</a>.
+                  </td>
+                  <td>W3C WoT Security and WoT Binding Template</td>
+                </tr>
+                <tr>
+                  <td>
                     <code>collection</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Points to a collections of <a>Things</a>.</td>
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>Points to a collections of <a>Things</a>.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>item</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Points to a <a>Thing</a> that is member of the current <a>Thing</a> collections.</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>Points to a <a>Thing</a> that is member of the current <a>Thing</a> collections.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>predecessor-version</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Points to a previous <a>Thing Description</a> or <a>Thing Model</a> version.</td>
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>Points to a previous <a>Thing Description</a> or <a>Thing Model</a> version.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>controlledBy</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Refers to a <a>Thing</a> that controls the context <a>Thing</a>.</td>
-                <td>
-                    W3C Thing Description
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    </section>
-<section><h3><code>Form</code></h3><p>A form can be viewed as a statement of "To perform an
-          <b><em>operation type</em></b> operation on <b><em>form
-          context</em></b>, make a <b><em>request method</em></b>
-          request to <b><em>submission target</em></b>" where the
-          optional <b><em>form fields</em></b> may further describe
-          the required request. In Thing Descriptions, the
-          <b><em>form context</em></b> is the surrounding Object,
-          such as Properties, Actions, and Events or the Thing
-          itself for meta-interactions.</p><table class="def numbered"><caption>Vocabulary Terms in Form Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Form"><td><code>href</code></td><td>Target IRI of a link or submission target of a
-                form.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form"><td><code>contentType</code></td><td>Assign a content type based on a media type
-                (e.g., <code>text/plain</code>) and potential
-                parameters (e.g., <code>charset=utf-8</code>) for
-                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form"><td><code>contentCoding</code></td><td>Content coding values indicate an encoding
-                transformation that has been or can be applied to a
-                representation. Content codings are primarily used
-                to allow a representation to be compressed or
-                otherwise usefully transformed without losing the
-                identity of its underlying media type and without
-                loss of information. Examples of content coding
-                include "gzip", "deflate", etc. .</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-security--Form"><td><code>security</code></td><td>Set of security definition names, chosen from
-                those defined in <code>securityDefinitions</code>.
-                These must all be satisfied for access to resources.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided
-                as an array. These are provided in tokens returned
-                by an authorization server and associated with
-                forms in order to identify what resources a client
-                may access and how. The values associated with a
-                form SHOULD be chosen from those defined in an
-                <code>OAuth2SecurityScheme</code> active on that
-                form.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-response--Form"><td><code>response</code></td><td>This optional term can be used if, e.g., the
-                output communication metadata differ from input
-                metadata (e.g., output contentType differ from the
-                input contentType). The response name contains
-                metadata that is only valid for the primary response
-                messages.</td><td>optional</td><td><a href="#expectedresponse"><code>ExpectedResponse</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-additionalResponses--Form"><td><code>additionalResponses</code></td><td>This optional term can be used if additional expected responses
-                are possible, e.g. for error reporting.  Each additional response needs to be 
-                distinguished from others in some way (for example, by specifying
-                a protocol-specific error code), and may also have its own data schema.</td><td>optional</td><td><a>Array</a> of <a href="#additionalexpectedresponse"><code>AdditionalExpectedResponse</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form"><td><code>subprotocol</code></td><td>Indicates the exact mechanism by which an
-                interaction will be accomplished for a given
-                protocol when there are multiple options. For
-                example, for HTTP and Events, it indicates which of
-                several available mechanisms should be used for
-                asynchronous notifications such as long polling
-                (<code>longpoll</code>), WebSub [<cite><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite>]
-                (<code>websub</code>), Server-Sent Events
-                (<code>sse</code>) [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite>] (also known as
-                EventSource). Please note that there is no
-                restriction on the subprotocol selection and other
-                mechanisms can also be announced by this
-                subprotocol term.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-op--Form"><td><code>op</code></td><td>Indicates the semantic intention of performing
-                the operation(s) described by the form. For
-                example, the Property interaction allows get and
-                set operations. The protocol binding may contain a
-                form for the get operation and a different form for
-                the set operation. The op attribute indicates which
-                form is for which and allows the client to select
-                the correct form for the operation required. op can
-                be assigned one or more interaction verb(s) each
-                representing a semantic intention of an
-                operation.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>, <code>unobserveproperty</code>, <code>invokeaction</code>, <code>queryaction</code>, <code>cancelaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>, <code>readallproperties</code>, <code>writeallproperties</code>, <code>readmultipleproperties</code>, <code>writemultipleproperties</code>, <code>observeallproperties</code>, <code>unobserveallproperties</code>, <code>subscribeallevents</code>, <code>unsubscribeallevents</code>, or <code>queryallactions</code>)</td></tr></tbody></table><p>Possible values for the <code>contentCoding</code>
-          property can be found, e.g., in the <a href=
-          "https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
-          IANA HTTP content coding registry</a>.</p>
-          <p>The list of possible operation types of a form is
-          fixed. As of this version of the specification, it only
-          includes the well-known types necessary to implement the
-          WoT interaction model described in [<cite><a class=
-          "bibref" data-link-type="biblio" href=
-          "#bib-wot-architecture11" title=
-          "Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>].
-          Future versions of the standard may extend this list but
-          <span class="rfc2119-assertion" id=
-          "well-known-operation-types-only">operations types
-          MUST be restricted to the values in the
-          table below.</span></p>
-
-        <div id="table-operation-types">
-          <table class="def numbered">
-            <caption>Well-known operation types</caption>
-            <thead>
-              <tr>
-                <th>Operation Type</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>readproperty</td>
-                <td>Identifies the read operation on
-                  Property Affordances to retrieve the
-                  corresponding data.</td>
-              </tr>
-              <tr>
-                <td>writeproperty</td>
-                <td>Identifies the write operation on
-                  Property Affordances to update the
-                  corresponding data.</td>
-              </tr>
-              <tr>
-                <td>observeproperty</td>
-                <td>Identifies the observe operation on
-                  Property Affordances to be notified with
-                  the new data when the Property is
-                  updated.</td>
-              </tr>
-              <tr>
-                <td>unobserveproperty</td>
-                <td>Identifies the unobserve
-                  operation on Property Affordances to stop
-                  the corresponding notifications.</td>
-              </tr>
-              <tr>
-                <td>invokeaction</td>
-                <td>Identifies the invoke operation on
-                  Action Affordances to perform the
-                  corresponding action.</td>
-              </tr>
-              <tr>
-                <td>queryaction</td>
-                <td>Identifies the querying operation on
-                  Action Affordances to get the status of the
-                  corresponding action.</td>
-              </tr>
-              <tr>
-                <td>cancelaction</td>
-                <td>Identifies the cancel operation on
-                  Action Affordances to cancel the ongoing
-                  corresponding action.</td>
-              </tr>
-              <tr>
-                <td>subscribeevent</td>
-                <td>Identifies the subscribe operation
-                  on Event Affordances to be notified by
-                  the Thing when the event occurs.</td>
-              </tr>
-              <tr>
-                <td>unsubscribeevent</td>
-                <td>Identifies the unsubscribe
-                  operation on Event Affordances to stop
-                  the corresponding notifications.</td>
-              </tr>
-              <tr>
-                <td>readallproperties</td>
-                <td>Identifies the readallproperties
-                  operation on a Thing to retrieve the
-                  data of all Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>writeallproperties</td>
-                <td>Identifies the writeallproperties
-                  operation on a Thing to update the
-                  data of all writable Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>readmultipleproperties</td>
-                <td>Identifies the readmultipleproperties
-                  operation on a Thing to retrieve the
-                  data of selected Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>writemultipleproperties</td>
-                <td>Identifies the writemultipleproperties
-                  operation on a Thing to update the
-                  data of selected writable Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>observeallproperties</td>
-                <td>Identifies the observeallproperties operation on
-                  Properties to be notified with new data when any Property is
-                  updated.</td>
-              </tr>
-              <tr>
-                <td>unobserveallproperties</td>
-                <td>Identifies the unobserveallproperties operation on
-                  Properties to stop notifications from all Properties in a 
-                  single interaction.</td>
-              </tr>
-              <tr>
-                <td>queryallactions</td>
-                <td>Identifies the queryallactions operation on a Thing to get the status of
-                 all Actions in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>subscribeallevents</td>
-                <td>Identifies the subscribeallevents operation on Events to subscribe
-                  to notifications from all Events in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>unsubscribeallevents</td>
-                <td>Identifies the unsubscribeallevents operation on Events to unsubscribe
-                  from notifications from all Events in a single interaction.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <p>
-          A <a>Thing Description</a> of a WoT <a>producer</a> may have multiple forms entries with, e.g., different 
-          protocol and/or content types declarations that a <a>Consumer</a> could possibly support. In that case 
-          the Consumer may choose any form entry that works (e.g., the protocol and content type is supported) for them. 
-          When one form is chosen, it is expected that the <a>Consumer</a> will continue to use it as long as possible 
-          for every new interaction with the WoT <a>producer</a>.
-        </p>
-
-        <section id="sec-op-data-schema-mapping" class="informative">
-        <h4>Mapping op Values to Data Schemas</h4>
-
-        <p>
-            Protocols that can be used with TDs follow request-response or eventing mechanisms. 
-            The Data Schema of an affordance generally correlates with the <code>op</code> keywords used in <code>forms</code>.
-            The table below informatively summarizes the available data schema related terms with the <code>op</code> keywords.
-        </p>
-        <ul>
-            <li>Consumer to Thing applies for messages sent by the Consumer to the Thing, such as the value for writing a property.</li>
-            <li>Thing to Consumer applies for messages sent by the Thing to the Consumer, such as the value of a property value as the result of reading a property.</li>
-            <li>In case that there is no correlation with the data schema and the operation, it implies that no payload is required for executing the operation or no 
-            payload is expected as a result of the operation.</li>
-        </ul>
-
-        <table class="def numbered">
-        <caption>Mapping op Values to Data Schemas</caption>
-        <thead>
-            <tr>
-            <th>Operation Type</th>
-            <th>Consumer to Thing DataSchema Correlation</th>
-            <th>Thing to Consumer DataSchema Correlation</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-            <td>readproperty</td>
-            <td>No correlation.</td>
-            <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
-            </tr>
-            <tr>
-            <td>writeproperty</td>
-            <td>All fields in the Property Affordance without <code>"readOnly":true</code>.</td>
-            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-            </tr>
-            <tr>
-            <td>observeproperty</td>
-            <td>No correlation.</td>
-            <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
-            </tr>
-            <tr>
-            <td>unobserveproperty</td>
-            <td>No correlation.</td>
-            <td>No correlation.</td>
-            </tr>
-            <tr>
-            <td>invokeaction</td>
-            <td>Value of the <code>input</code> key.</td>
-            <td>Value of the <code>output</code> key.</td>
-            </tr>
-            <tr>
-            <td>queryaction</td>
-            <td>No correlation.</td>
-            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-            </tr>
-            <tr>
-            <td>cancelaction</td>
-            <td>No correlation.</td>
-            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-            </tr>
-            <tr>
-            <td>subscribeevent</td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code></td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code></td>
-            </tr>
-            <tr>
-            <td>unsubscribeevent</td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code></td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code></td>
-            </tr>
-        </tbody>
-        </table>
-        <p class="note" title="writeproperty and observeproperty relationship">
-            Writing to a property does not necessarily mean that a new value will be sent to the Consumer observing the property. 
-            It depends on the protocol and implementation.
-        </p>
-        <p class="note" title="Further Data Schemas mappings">
-            Further specification of how to map operations to data schemas, as well as mapping meta operations such as <code>readallproperties</code> 
-            can be found in the respective protocol specification of the [[WOT-BINDING-TEMPLATES]].
-        </p>
-        </section>
-
-        <section id="sec-response-usage">
-        <h4>Response-related Terms Usage</h4>
-
-          <p>The optional <code>response</code> name-value pair can
-          be used to provide metadata for the expected response
-          message. 
-          With the core vocabulary, it only includes
-          content type information, but TD Context Extensions could
-          be applied. <span class="rfc2119-assertion" id=
-          "td-expectedResponse-default-contentType">If no
-          <code>response</code> name-value pair is provided, it
-          MUST be assumed
-          that the content type of the response is equal to the
-          content type assigned to the Form instance.</span> Note
-          that <code>contentType</code> within an
-          <code>ExpectedResponse</code> 
-          <a href="#dfn-class" class=
-          "internalDFN" data-link-type="dfn">Class</a> does not
-          have a <a href="#dfn-default-value" class="internalDFN"
-          data-link-type="dfn">Default Value</a>. For instance, if
-          the value of the content type of the form is
-          <code>application/xml</code> the assumed value of the
-          content type of the response will be also
-          <code>application/xml</code>.</p>
-          <p>
-          In some cases additional responses might be possible.
-          One example of this is error responses but in some cases
-          there might also be additional successful responses.
-          In this case, the <code>response</code> name-value pair
-          is still used for the primary response but 
-          <code>additionalResponses</code> may also be provided,
-          whose value is an array of <code>AdditionalExpectedResponse</code>
-          objects.
-          Each additional response must be distinguished in some way from the primary
-          response, either by <code>contentType</code> or by
-          protocol-specific settings such as error code header values.
-          Each additional response may also have a data schema
-          which can differ from the normal output data schema for the
-          interaction.  
-          </p>
-          <p>In some use cases, input and output data might be
-          represented in a different form, for instance an Action
-          that accepts JSON, but returns an image. In such a case,
-          the optional <code>response</code> name-value pair can
-          describe the content type of the expected response.
-          <span class="rfc2119-assertion" id=
-          "td-expectedResponse-contentType">If the content type of
-          the expected response differs from the content type of
-          the form, the <code>Form</code> instance <em class=
-          "rfc2119" title="MUST">MUST</em> include a name-value
-          pair with the name <code>response</code>.</span> 
-          For instance, an <code>ActionAffordance</code> could only
-          accept <code>application/json</code> for its input data,
-          while it will respond with an <code>image/jpeg</code>
-          content type for its output data. In that case the
-          content types differ and the <code>response</code>
-          name-value pair has to be used to provide response
-          content type (<code>image/jpeg</code>) information to the
-          <a href="#dfn-consumer" class="internalDFN"
-          data-link-type="dfn">Consumer</a>.</p>
-          <p>
-          Similar considerations apply to additional responses,
-          although in this case the <code>contentType</code> is optional
-          if it is the same as the input content Type (e.g. JSON).
-          <span class="rfc2119-assertion" id=
-          "td-additionalExpectedResponse-contentType">If the content type of
-          an additional expected response differs from the content type of
-          the form, the <code>Form</code> instance <em class=
-          "rfc2119" title="MUST">MUST</em> include an entry in the array
-          associated with the name <code>additionalResponses</code>
-          that includes a value for the name <code>contentType</code>.</span> 
-          <span class="rfc2119-assertion" id=
-          "td-additionalExpectedResponse-schema">If the data schema of
-          an additional expected response differs from the output data schema of
-          the interaction, the <code>Form</code> instance <em class=
-          "rfc2119" title="MUST">MUST</em> include an entry in the array
-          associated with the name <code>additionalResponses</code> that
-          includes a value for the name <code>schema</code>.</span> 
-          </p>
-          <p>
-            The different cases on the variation of request and response are explained above.
-            The tables at <a href="#contentType-usage"></a> summarize these cases in a concise manner.
-          </p>
+                  </td>
+                  <td>0..*</td>
+                  <td>Refers to a <a>Thing</a> that controls the context <a>Thing</a>.</td>
+                  <td>W3C Thing Description</td>
+                </tr>
+              </tbody>
+            </table>
           </section>
+          <section>
+            <h3><code>Form</code></h3>
+            <p>
+              A form can be viewed as a statement of "To perform an <b><em>operation type</em></b> operation on
+              <b><em>form context</em></b
+              >, make a <b><em>request method</em></b> request to <b><em>submission target</em></b
+              >" where the optional <b><em>form fields</em></b> may further describe the required request. In Thing
+              Descriptions, the <b><em>form context</em></b> is the surrounding Object, such as Properties, Actions, and
+              Events or the Thing itself for meta-interactions.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in Form Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-href--Form">
+                  <td><code>href</code></td>
+                  <td>Target IRI of a link or submission target of a form.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form">
+                  <td><code>contentType</code></td>
+                  <td>
+                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
+                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >].
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form">
+                  <td><code>contentCoding</code></td>
+                  <td>
+                    Content coding values indicate an encoding transformation that has been or can be applied to a
+                    representation. Content codings are primarily used to allow a representation to be compressed or
+                    otherwise usefully transformed without losing the identity of its underlying media type and without
+                    loss of information. Examples of content coding include "gzip", "deflate", etc. .
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-security--Form">
+                  <td><code>security</code></td>
+                  <td>
+                    Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.
+                    These must all be satisfied for access to resources.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form">
+                  <td><code>scopes</code></td>
+                  <td>
+                    Set of authorization scope identifiers provided as an array. These are provided in tokens returned
+                    by an authorization server and associated with forms in order to identify what resources a client
+                    may access and how. The values associated with a form SHOULD be chosen from those defined in an
+                    <code>OAuth2SecurityScheme</code> active on that form.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-response--Form">
+                  <td><code>response</code></td>
+                  <td>
+                    This optional term can be used if, e.g., the output communication metadata differ from input
+                    metadata (e.g., output contentType differ from the input contentType). The response name contains
+                    metadata that is only valid for the primary response messages.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#expectedresponse"><code>ExpectedResponse</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-additionalResponses--Form">
+                  <td><code>additionalResponses</code></td>
+                  <td>
+                    This optional term can be used if additional expected responses are possible, e.g. for error
+                    reporting. Each additional response needs to be distinguished from others in some way (for example,
+                    by specifying a protocol-specific error code), and may also have its own data schema.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#additionalexpectedresponse"><code>AdditionalExpectedResponse</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form">
+                  <td><code>subprotocol</code></td>
+                  <td>
+                    Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when
+                    there are multiple options. For example, for HTTP and Events, it indicates which of several
+                    available mechanisms should be used for asynchronous notifications such as long polling
+                    (<code>longpoll</code>), WebSub [<cite
+                      ><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite
+                    >] (<code>websub</code>), Server-Sent Events (<code>sse</code>) [<cite
+                      ><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite
+                    >] (also known as EventSource). Please note that there is no restriction on the subprotocol
+                    selection and other mechanisms can also be announced by this subprotocol term.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-op--Form">
+                  <td><code>op</code></td>
+                  <td>
+                    Indicates the semantic intention of performing the operation(s) described by the form. For example,
+                    the Property interaction allows get and set operations. The protocol binding may contain a form for
+                    the get operation and a different form for the set operation. The op attribute indicates which form
+                    is for which and allows the client to select the correct form for the operation required. op can be
+                    assigned one or more interaction verb(s) each representing a semantic intention of an operation.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>,
+                    <code>unobserveproperty</code>, <code>invokeaction</code>, <code>queryaction</code>,
+                    <code>cancelaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>,
+                    <code>readallproperties</code>, <code>writeallproperties</code>,
+                    <code>readmultipleproperties</code>, <code>writemultipleproperties</code>,
+                    <code>observeallproperties</code>, <code>unobserveallproperties</code>,
+                    <code>subscribeallevents</code>, <code>unsubscribeallevents</code>, or <code>queryallactions</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              Possible values for the <code>contentCoding</code> property can be found, e.g., in the
+              <a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
+                IANA HTTP content coding registry</a
+              >.
+            </p>
+            <p>
+              The list of possible operation types of a form is fixed. As of this version of the specification, it only
+              includes the well-known types necessary to implement the WoT interaction model described in [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-wot-architecture11"
+                  title="Web of Things (WoT) Architecture 1.1"
+                  >wot-architecture11</a
+                ></cite
+              >]. Future versions of the standard may extend this list but
+              <span class="rfc2119-assertion" id="well-known-operation-types-only"
+                >operations types MUST be restricted to the values in the table below.</span
+              >
+            </p>
+
+            <div id="table-operation-types">
+              <table class="def numbered">
+                <caption>
+                  Well-known operation types
+                </caption>
+                <thead>
+                  <tr>
+                    <th>Operation Type</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>readproperty</td>
+                    <td>Identifies the read operation on Property Affordances to retrieve the corresponding data.</td>
+                  </tr>
+                  <tr>
+                    <td>writeproperty</td>
+                    <td>Identifies the write operation on Property Affordances to update the corresponding data.</td>
+                  </tr>
+                  <tr>
+                    <td>observeproperty</td>
+                    <td>
+                      Identifies the observe operation on Property Affordances to be notified with the new data when the
+                      Property is updated.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unobserveproperty</td>
+                    <td>
+                      Identifies the unobserve operation on Property Affordances to stop the corresponding
+                      notifications.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>invokeaction</td>
+                    <td>Identifies the invoke operation on Action Affordances to perform the corresponding action.</td>
+                  </tr>
+                  <tr>
+                    <td>queryaction</td>
+                    <td>
+                      Identifies the querying operation on Action Affordances to get the status of the corresponding
+                      action.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>cancelaction</td>
+                    <td>
+                      Identifies the cancel operation on Action Affordances to cancel the ongoing corresponding action.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>subscribeevent</td>
+                    <td>
+                      Identifies the subscribe operation on Event Affordances to be notified by the Thing when the event
+                      occurs.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unsubscribeevent</td>
+                    <td>
+                      Identifies the unsubscribe operation on Event Affordances to stop the corresponding notifications.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>readallproperties</td>
+                    <td>
+                      Identifies the readallproperties operation on a Thing to retrieve the data of all Properties in a
+                      single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>writeallproperties</td>
+                    <td>
+                      Identifies the writeallproperties operation on a Thing to update the data of all writable
+                      Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>readmultipleproperties</td>
+                    <td>
+                      Identifies the readmultipleproperties operation on a Thing to retrieve the data of selected
+                      Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>writemultipleproperties</td>
+                    <td>
+                      Identifies the writemultipleproperties operation on a Thing to update the data of selected
+                      writable Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>observeallproperties</td>
+                    <td>
+                      Identifies the observeallproperties operation on Properties to be notified with new data when any
+                      Property is updated.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unobserveallproperties</td>
+                    <td>
+                      Identifies the unobserveallproperties operation on Properties to stop notifications from all
+                      Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>queryallactions</td>
+                    <td>
+                      Identifies the queryallactions operation on a Thing to get the status of all Actions in a single
+                      interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>subscribeallevents</td>
+                    <td>
+                      Identifies the subscribeallevents operation on Events to subscribe to notifications from all
+                      Events in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unsubscribeallevents</td>
+                    <td>
+                      Identifies the unsubscribeallevents operation on Events to unsubscribe from notifications from all
+                      Events in a single interaction.
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <p>
+              A <a>Thing Description</a> of a WoT <a>producer</a> may have multiple forms entries with, e.g., different
+              protocol and/or content types declarations that a <a>Consumer</a> could possibly support. In that case the
+              Consumer may choose any form entry that works (e.g., the protocol and content type is supported) for them.
+              When one form is chosen, it is expected that the <a>Consumer</a> will continue to use it as long as
+              possible for every new interaction with the WoT <a>producer</a>.
+            </p>
+
+            <section id="sec-op-data-schema-mapping" class="informative">
+              <h4>Mapping op Values to Data Schemas</h4>
+
+              <p>
+                Protocols that can be used with TDs follow request-response or eventing mechanisms. The Data Schema of
+                an affordance generally correlates with the <code>op</code> keywords used in <code>forms</code>. The
+                table below informatively summarizes the available data schema related terms with the
+                <code>op</code> keywords.
+              </p>
+              <ul>
+                <li>
+                  Consumer to Thing applies for messages sent by the Consumer to the Thing, such as the value for
+                  writing a property.
+                </li>
+                <li>
+                  Thing to Consumer applies for messages sent by the Thing to the Consumer, such as the value of a
+                  property value as the result of reading a property.
+                </li>
+                <li>
+                  In case that there is no correlation with the data schema and the operation, it implies that no
+                  payload is required for executing the operation or no payload is expected as a result of the
+                  operation.
+                </li>
+              </ul>
+
+              <table class="def numbered">
+                <caption>
+                  Mapping op Values to Data Schemas
+                </caption>
+                <thead>
+                  <tr>
+                    <th>Operation Type</th>
+                    <th>Consumer to Thing DataSchema Correlation</th>
+                    <th>Thing to Consumer DataSchema Correlation</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>readproperty</td>
+                    <td>No correlation.</td>
+                    <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
+                  </tr>
+                  <tr>
+                    <td>writeproperty</td>
+                    <td>All fields in the Property Affordance without <code>"readOnly":true</code>.</td>
+                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+                  </tr>
+                  <tr>
+                    <td>observeproperty</td>
+                    <td>No correlation.</td>
+                    <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
+                  </tr>
+                  <tr>
+                    <td>unobserveproperty</td>
+                    <td>No correlation.</td>
+                    <td>No correlation.</td>
+                  </tr>
+                  <tr>
+                    <td>invokeaction</td>
+                    <td>Value of the <code>input</code> key.</td>
+                    <td>Value of the <code>output</code> key.</td>
+                  </tr>
+                  <tr>
+                    <td>queryaction</td>
+                    <td>No correlation.</td>
+                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+                  </tr>
+                  <tr>
+                    <td>cancelaction</td>
+                    <td>No correlation.</td>
+                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+                  </tr>
+                  <tr>
+                    <td>subscribeevent</td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code>
+                    </td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unsubscribeevent</td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code>
+                    </td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <p class="note" title="writeproperty and observeproperty relationship">
+                Writing to a property does not necessarily mean that a new value will be sent to the Consumer observing
+                the property. It depends on the protocol and implementation.
+              </p>
+              <p class="note" title="Further Data Schemas mappings">
+                Further specification of how to map operations to data schemas, as well as mapping meta operations such
+                as <code>readallproperties</code>
+                can be found in the respective protocol specification of the [[WOT-BINDING-TEMPLATES]].
+              </p>
+            </section>
+
+            <section id="sec-response-usage">
+              <h4>Response-related Terms Usage</h4>
+
+              <p>
+                The optional <code>response</code> name-value pair can be used to provide metadata for the expected
+                response message. With the core vocabulary, it only includes content type information, but TD Context
+                Extensions could be applied.
+                <span class="rfc2119-assertion" id="td-expectedResponse-default-contentType"
+                  >If no <code>response</code> name-value pair is provided, it MUST be assumed that the content type of
+                  the response is equal to the content type assigned to the Form instance.</span
+                >
+                Note that <code>contentType</code> within an
+                <code>ExpectedResponse</code>
+                <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> does not have a
+                <a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">Default Value</a>. For instance,
+                if the value of the content type of the form is <code>application/xml</code> the assumed value of the
+                content type of the response will be also <code>application/xml</code>.
+              </p>
+              <p>
+                In some cases additional responses might be possible. One example of this is error responses but in some
+                cases there might also be additional successful responses. In this case, the
+                <code>response</code> name-value pair is still used for the primary response but
+                <code>additionalResponses</code> may also be provided, whose value is an array of
+                <code>AdditionalExpectedResponse</code> objects. Each additional response must be distinguished in some
+                way from the primary response, either by <code>contentType</code> or by protocol-specific settings such
+                as error code header values. Each additional response may also have a data schema which can differ from
+                the normal output data schema for the interaction.
+              </p>
+              <p>
+                In some use cases, input and output data might be represented in a different form, for instance an
+                Action that accepts JSON, but returns an image. In such a case, the optional
+                <code>response</code> name-value pair can describe the content type of the expected response.
+                <span class="rfc2119-assertion" id="td-expectedResponse-contentType"
+                  >If the content type of the expected response differs from the content type of the form, the
+                  <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include a name-value pair with
+                  the name <code>response</code>.</span
+                >
+                For instance, an <code>ActionAffordance</code> could only accept <code>application/json</code> for its
+                input data, while it will respond with an <code>image/jpeg</code> content type for its output data. In
+                that case the content types differ and the <code>response</code>
+                name-value pair has to be used to provide response content type (<code>image/jpeg</code>) information to
+                the
+                <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumer</a>.
+              </p>
+              <p>
+                Similar considerations apply to additional responses, although in this case the
+                <code>contentType</code> is optional if it is the same as the input content Type (e.g. JSON).
+                <span class="rfc2119-assertion" id="td-additionalExpectedResponse-contentType"
+                  >If the content type of an additional expected response differs from the content type of the form, the
+                  <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include an entry in the array
+                  associated with the name <code>additionalResponses</code> that includes a value for the name
+                  <code>contentType</code>.</span
+                >
+                <span class="rfc2119-assertion" id="td-additionalExpectedResponse-schema"
+                  >If the data schema of an additional expected response differs from the output data schema of the
+                  interaction, the <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include an
+                  entry in the array associated with the name <code>additionalResponses</code> that includes a value for
+                  the name <code>schema</code>.</span
+                >
+              </p>
+              <p>
+                The different cases on the variation of request and response are explained above. The tables at
+                <a href="#contentType-usage"></a> summarize these cases in a concise manner.
+              </p>
+            </section>
           </section>
-<section><h3><code>ExpectedResponse</code></h3><p>Communication metadata describing the expected
-          response message for the primary response.</p><table class="def numbered"><caption>Vocabulary Terms in ExpectedResponse Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type
-                (e.g., <code>text/plain</code>) and potential
-                parameters (e.g., <code>charset=utf-8</code>) for
-                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>AdditionalExpectedResponse</code></h3><p>Communication metadata describing the expected
-          response message for additional responses.</p><table class="def numbered"><caption>Vocabulary Terms in AdditionalExpectedResponse Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-success--AdditionalExpectedResponse"><td><code>success</code></td><td>Signals if an additional response should not be considered an error.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentType--AdditionalExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type
-                (e.g., <code>text/plain</code>) and potential
-                parameters (e.g., <code>charset=utf-8</code>) for
-                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-schema--AdditionalExpectedResponse"><td><code>schema</code></td><td>Used to define the output data schema 
-                for an additional response if it differs from the default
-                output data schema. 
-                Rather than a <code>DataSchema</code> object, the
-                name of a previous definition given in a 
-                <code>schemaDefinitions</code> map must be used.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+          <section>
+            <h3><code>ExpectedResponse</code></h3>
+            <p>Communication metadata describing the expected response message for the primary response.</p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ExpectedResponse Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse">
+                  <td><code>contentType</code></td>
+                  <td>
+                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
+                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >].
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>AdditionalExpectedResponse</code></h3>
+            <p>Communication metadata describing the expected response message for additional responses.</p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in AdditionalExpectedResponse Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-success--AdditionalExpectedResponse">
+                  <td><code>success</code></td>
+                  <td>Signals if an additional response should not be considered an error.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--AdditionalExpectedResponse">
+                  <td><code>contentType</code></td>
+                  <td>
+                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
+                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >].
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-schema--AdditionalExpectedResponse">
+                  <td><code>schema</code></td>
+                  <td>
+                    Used to define the output data schema for an additional response if it differs from the default
+                    output data schema. Rather than a <code>DataSchema</code> object, the name of a previous definition
+                    given in a <code>schemaDefinitions</code> map must be used.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
         </section>
       </section>
       <section id="sec-default-values">

--- a/index.template.html
+++ b/index.template.html
@@ -386,9 +386,10 @@
   <body>
     <section id="abstract">
       <p>
-        This document describes a formal information model and a common representation for a Web of Things (WoT) Thing Description (TD), Version 2.0. A Thing Description describes the metadata and interfaces of <a>Things</a>, where a
-        <a>Thing</a> is an abstraction of a physical or virtual entity that provides interactions to and participates in
-        the Web of Things. Thing Descriptions provide a set of interactions based on a small vocabulary that makes it
+        This document describes a formal information model and a common representation for a Web of Things (WoT) Thing
+        Description (TD), Version 2.0. A Thing Description describes the metadata and interfaces of <a>Things</a>, where
+        a <a>Thing</a> is an abstraction of a physical or virtual entity that provides interactions to and participates
+        in the Web of Things. Thing Descriptions provide a set of interactions based on a small vocabulary that makes it
         possible both to integrate diverse devices and to allow diverse applications to interoperate. Thing
         Descriptions, by default, are encoded in a JSON format that also allows JSON-LD processing. The latter provides
         a powerful foundation to represent knowledge about <a>Things</a> in a machine-understandable way. A Thing


### PR DESCRIPTION
<!-- Changes to WoT documents follow the [asynchronous decision policy](https://github.com/w3c/wot/blob/main/policies/async-decision.md). Please fill below to speed up the process -->

## Description of Changes

I am changing the respec configs to follow https://www.w3.org/2025/06/18-wot-td-minutes.html#3e02 . I have quickly fixed the respec errors too.

## Related Issue

<!-- Put the issue number after # -->

Closes #2110 #2111 

## Type of Change

Keep the correct line, remove the other and add the corresponding label if you are an editor.

<!-- In this case, once the label is added and approved by an Editor, after 1 week the PR can be merged. -->

- [Normative](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Normative Label](https://img.shields.io/github/labels/w3c/wot-thing-description/normative%20change)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/2113.html" title="Last updated on Jul 10, 2025, 8:24 PM UTC (6567b8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/2113/abf579a...6567b8b.html" title="Last updated on Jul 10, 2025, 8:24 PM UTC (6567b8b)">Diff</a>