### PR TITLE
Binding Intro Reorganization

### DIFF
--- a/index.html
+++ b/index.html
@@ -789,7 +789,8 @@
         <dt><dfn id="dfn-binding-specification">Binding Specification</dfn></dt>
         <dd>
           A binding specification is a document that specifies a binding
-          for a protocol or payload format or both. All bindings follow the rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
+          for a protocol, a payload format, or both. All bindings follow the
+          rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
         </dd>
       </dl>
 
@@ -5356,12 +5357,14 @@
     <section id="bindings">
       <h2>Bindings</h2>
         <p>
-          Every message sent from a Consumer to the Thing and back needs to follow a network protocol, despite the Property, Action, Event abstraction provided by WoT.
-          The operations in the form level need to be bound to how the message needs to look like over the network.
+          Every message sent from a Consumer to the Thing and back needs to
+          travel over a network protocol, despite the
+          Property&ndash;Action&ndash;Event abstraction provided by WoT.
+          The operations in the Forms level need to be bound to how the message is meant to look, over the network.
           Thus, every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>.
-          For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can then
-          infer the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP and it should expect HTTP-specific
-          terms in the form instance.
+          For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can
+          infer that the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific
+          terms in an instance of this form.
           Furthermore, the payloads described by the <a>Data Schema</a> in the affordance level need to be serialized to the correct payload format.
           Similar to how operations are bound to protocol messages, the
        </p>

--- a/index.html
+++ b/index.html
@@ -788,9 +788,8 @@
         </dd>
         <dt><dfn id="dfn-binding-specification">Binding Specification</dfn></dt>
         <dd>
-          A binding specification is a document that specifies a binding
-          for a protocol, a payload format, or both. All bindings follow the
-          rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
+          A binding specification is a document that specifies a binding for a protocol, a payload format, or both. All
+          bindings follow the rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
         </dd>
       </dl>
 
@@ -1131,363 +1130,862 @@
           <h2>Core Vocabulary Definitions</h2>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>Thing</code></h3><p>An abstraction of a physical or a virtual entity whose
-          metadata and interfaces are described by a WoT Thing
-          Description, whereas a virtual entity is the composition
-          of one or more Things.</p><table class="def numbered"><caption>Vocabulary Terms in Thing Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing"><td><code>@context</code></td><td>JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-id--Thing"><td><code>id</code></td><td>Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI, URI with local IP address, URN, etc.).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--Thing"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
-                a text for UI representation) based on a default
-                language.</td><td>mandatory</td><td>any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing"><td><code>titles</code></td><td>Provides multi-language human-readable titles
-                (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-description--Thing"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-version--Thing"><td><code>version</code></td><td>Provides version information.</td><td>optional</td><td><a href="#versioninfo"><code>VersionInfo</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-created--Thing"><td><code>created</code></td><td>Provides information when the TD instance was
-                created.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing"><td><code>modified</code></td><td>Provides information when the TD instance was
-                last modified.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-support--Thing"><td><code>support</code></td><td>Provides information about the TD maintainer as
-                URI scheme (e.g., <code>mailto</code> [[RFC6068]],
-                <code>tel</code> [[RFC3966]],
-                <code>https</code> [[RFC9112]]).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-base--Thing"><td><code>base</code></td><td>Define the base URI that is used for all
-                relative URI references throughout a TD document.
-                In TD instances, all relative URIs are resolved
-                relative to the base URI using the algorithm
-                defined in [<cite><a class="bibref" data-link-type=
-                "biblio" href='#bib-rfc3986' title=
-                "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>].<br>
-                <br>
-                <code>base</code> does not affect the URIs used in
-                <code>@context</code> and the IRIs used within
-                Linked Data [<cite><a class="bibref"
-                data-link-type="biblio" href='#bib-linked-data'
-                title=
-                "Linked Data Design Issues">LINKED-DATA</a></cite>]
-                graphs that are relevant when semantic processing
-                is applied to TD instances.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing"><td><code>properties</code></td><td>All Property-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#propertyaffordance"><code>PropertyAffordance</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing"><td><code>actions</code></td><td>All Action-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#actionaffordance"><code>ActionAffordance</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-events--Thing"><td><code>events</code></td><td>All Event-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#eventaffordance"><code>EventAffordance</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-links--Thing"><td><code>links</code></td><td>Provides Web links to arbitrary resources that
-                relate to the specified Thing Description.</td><td>optional</td><td><a>Array</a> of <a href="#link"><code>Link</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing"><td><code>forms</code></td><td>Set of form hypermedia controls that describe how 
-                  an operation can be performed. Forms are
-                  serializations of Protocol Bindings. <a>Thing level</a> forms are used to describe endpoints for a group of interaction affordances.</td><td>optional</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-security--Thing"><td><code>security</code></td><td>Set of security definition names, chosen from
-                those defined in <code>securityDefinitions</code>.
-                These must all be satisfied for access to resources.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing"><td><code>securityDefinitions</code></td><td>Set of named security configurations
-                (definitions only). Not actually applied unless
-                names are used in a <code>security</code>
-                name-value pair.</td><td>mandatory</td><td><a>Map</a> of <a href="#securityscheme"><code>SecurityScheme</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-profile--Thing"><td><code>profile</code></td><td>Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing implementation.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-schemaDefinitions--Thing"><td><code>schemaDefinitions</code></td><td>Set of named data schemas.
-                To be used in a <code>schema</code>
-                name-value pair inside an 
-                <code>AdditionalExpectedResponse</code> object.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
-                based on DataSchema declarations. The <a>Thing level</a> <code>uriVariables</code> can be used in <a>Thing level</a> 
-                <code>forms</code> or in Interaction Affordances.
-                The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
-                to be serialized to a string inside the <code>href</code> upon the execution of the operation.
-                If the same variable is both declared in <a>Thing level</a> <code>uriVariables</code> and in Interaction Affordance level,
-                 the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>
-              For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:
-              </p>
-        <ul>
-            <li>
-    <span class="rfc2119-assertion" id=
-          "td-context-ns-thing-mandatory">
+          <section>
+            <h3><code>Thing</code></h3>
+            <p>
+              An abstraction of a physical or a virtual entity whose metadata and interfaces are described by a WoT
+              Thing Description, whereas a virtual entity is the composition of one or more Things.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in Thing Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing">
+                  <td><code>@context</code></td>
+                  <td>
+                    JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or
+                    <a>Array</a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-id--Thing">
+                  <td><code>id</code></td>
+                  <td>
+                    Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI,
+                    URI with local IP address, URN, etc.).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-title--Thing">
+                  <td><code>title</code></td>
+                  <td>
+                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
+                    language.
+                  </td>
+                  <td>mandatory</td>
+                  <td>any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing">
+                  <td><code>titles</code></td>
+                  <td>
+                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
+                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--Thing">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-version--Thing">
+                  <td><code>version</code></td>
+                  <td>Provides version information.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#versioninfo"><code>VersionInfo</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-created--Thing">
+                  <td><code>created</code></td>
+                  <td>Provides information when the TD instance was created.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing">
+                  <td><code>modified</code></td>
+                  <td>Provides information when the TD instance was last modified.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-support--Thing">
+                  <td><code>support</code></td>
+                  <td>
+                    Provides information about the TD maintainer as URI scheme (e.g., <code>mailto</code> [[RFC6068]],
+                    <code>tel</code> [[RFC3966]], <code>https</code> [[RFC9112]]).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-base--Thing">
+                  <td><code>base</code></td>
+                  <td>
+                    Define the base URI that is used for all relative URI references throughout a TD document. In TD
+                    instances, all relative URIs are resolved relative to the base URI using the algorithm defined in
+                    [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc3986"
+                        title="Uniform Resource Identifier (URI): Generic Syntax"
+                        >RFC3986</a
+                      ></cite
+                    >].<br />
+                    <br />
+                    <code>base</code> does not affect the URIs used in <code>@context</code> and the IRIs used within
+                    Linked Data [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-linked-data"
+                        title="Linked Data Design Issues"
+                        >LINKED-DATA</a
+                      ></cite
+                    >] graphs that are relevant when semantic processing is applied to TD instances.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing">
+                  <td><code>properties</code></td>
+                  <td>
+                    All Property-based
+                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
+                      >Interaction Affordances</a
+                    >
+                    of the Thing.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#propertyaffordance"><code>PropertyAffordance</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing">
+                  <td><code>actions</code></td>
+                  <td>
+                    All Action-based
+                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
+                      >Interaction Affordances</a
+                    >
+                    of the Thing.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#actionaffordance"><code>ActionAffordance</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-events--Thing">
+                  <td><code>events</code></td>
+                  <td>
+                    All Event-based
+                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
+                      >Interaction Affordances</a
+                    >
+                    of the Thing.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#eventaffordance"><code>EventAffordance</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-links--Thing">
+                  <td><code>links</code></td>
+                  <td>Provides Web links to arbitrary resources that relate to the specified Thing Description.</td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#link"><code>Link</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing">
+                  <td><code>forms</code></td>
+                  <td>
+                    Set of form hypermedia controls that describe how an operation can be performed. Forms are
+                    serializations of Protocol Bindings. <a>Thing level</a> forms are used to describe endpoints for a
+                    group of interaction affordances.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#form"><code>Form</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-security--Thing">
+                  <td><code>security</code></td>
+                  <td>
+                    Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.
+                    These must all be satisfied for access to resources.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing">
+                  <td><code>securityDefinitions</code></td>
+                  <td>
+                    Set of named security configurations (definitions only). Not actually applied unless names are used
+                    in a <code>security</code> name-value pair.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Map</a> of <a href="#securityscheme"><code>SecurityScheme</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-profile--Thing">
+                  <td><code>profile</code></td>
+                  <td>
+                    Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing
+                    implementation.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-schemaDefinitions--Thing">
+                  <td><code>schemaDefinitions</code></td>
+                  <td>
+                    Set of named data schemas. To be used in a <code>schema</code>
+                    name-value pair inside an
+                    <code>AdditionalExpectedResponse</code> object.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing">
+                  <td><code>uriVariables</code></td>
+                  <td>
+                    Define URI template variables according to [[RFC6570]] as collection based on DataSchema
+                    declarations. The <a>Thing level</a> <code>uriVariables</code> can be used in <a>Thing level</a>
+                    <code>forms</code> or in Interaction Affordances. The individual variables DataSchema cannot be an
+                    ObjectSchema or an ArraySchema since each variable needs to be serialized to a string inside the
+                    <code>href</code> upon the execution of the operation. If the same variable is both declared in
+                    <a>Thing level</a> <code>uriVariables</code> and in Interaction Affordance level, the Interaction
+                    Affordance level variable takes precedence.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:</p>
+            <ul>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-thing-mandatory">
+                  The <code>@context</code>
+                  name-value pair MUST contain the anyURI
+                  <code>https://www.w3.org/2022/wot/td/v1.1</code>
+                  in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly
+                  introduced terms.
+                </span>
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-td10-namespace">
+                  When there are possibly TD 1.0 consumers the anyURI
+                  <code>https://www.w3.org/2019/wot/td/v1</code>
+                  MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second
+                  entry.</span
+                >
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-td10-namespacev10">
+                  TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0
+                  [[wot-thing-description10]] specification.
+                </span>
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-thing-optional"
+                  >When <code>@context</code> is an
+                  <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>, the anyURI
+                  <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class="rfc2119" title="MAY">MAY</em> be followed
+                  by elements of type <code>anyURI</code> or type
+                  <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> in any order, while it is
+                  RECOMMENDED to include only one
+                  <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> with all the name-value pairs in
+                  the <code>@context</code>
+                  <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span
+                >
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-thing-map-of-namespaces"
+                  ><a href="#dfn-map" class="internalDFN" data-link-type="dfn">Maps</a> contained in an
+                  <code>@context</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> MAY
+                  contain name-value pairs, where the value is a namespace identifier of type <code>anyURI</code> and
+                  the name a <a href="#dfn-term" class="internalDFN" data-link-type="dfn">Term</a> or prefix denoting
+                  that namespace.</span
+                >
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-default-language"
+                  >One <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> contained in an
+                  <code>@context</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> SHOULD
+                  contain a name-value pair that defines the default language for the Thing Description, where the name
+                  is the <a href="#dfn-term" class="internalDFN" data-link-type="dfn">Term</a>
+                  <code>@language</code> and the value is a well-formed language tag as defined by [<cite
+                    ><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages"
+                      >BCP47</a
+                    ></cite
+                  >] (e.g., <code>en</code>, <code>de-AT</code>, <code>gsw-CH</code>, <code>zh-Hans</code>,
+                  <code>zh-Hant-HK</code>, <code>sl-nedis</code>).</span
+                >
+              </li>
+            </ul>
 
-          The <code>@context</code>
-          name-value pair MUST contain the anyURI
-          <code>https://www.w3.org/2022/wot/td/v1.1</code>
-          in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly introduced terms.
-          </span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-td10-namespace"> 
-          When there are possibly TD 1.0 consumers the anyURI
-          <code>https://www.w3.org/2019/wot/td/v1</code>
-          MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second entry.</span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-td10-namespacev10"> 
-            TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0 [[wot-thing-description10]] specification. 
-            </span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-thing-optional">When <code>@context</code>
-          is an <a href="#dfn-array" class="internalDFN"
-          data-link-type="dfn">Array</a>, the anyURI
-          <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class=
-          "rfc2119" title="MAY">MAY</em> be followed by elements of
-          type <code>anyURI</code> or type <a href="#dfn-map"
-          class="internalDFN" data-link-type="dfn">Map</a> in any
-          order, while it is RECOMMENDED to include only one
-          <a href="#dfn-map" class="internalDFN" data-link-type=
-          "dfn">Map</a> with all the name-value pairs in the
-          <code>@context</code> <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a>.</span>
-          </li>
-        <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-thing-map-of-namespaces"><a href=
-          "#dfn-map" class="internalDFN" data-link-type=
-          "dfn">Maps</a> contained in an <code>@context</code>
-          <a href="#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> MAY
-          contain name-value pairs, where the value is a namespace
-          identifier of type <code>anyURI</code> and the name a
-          <a href="#dfn-term" class="internalDFN" data-link-type=
-          "dfn">Term</a> or prefix denoting that namespace.</span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-default-language">One <a href="#dfn-map"
-          class="internalDFN" data-link-type="dfn">Map</a>
-          contained in an <code>@context</code> <a href=
-          "#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> SHOULD contain a name-value pair that
-          defines the default language for the Thing Description,
-          where the name is the <a href="#dfn-term" class=
-          "internalDFN" data-link-type="dfn">Term</a>
-          <code>@language</code> and the value is a well-formed
-          language tag as defined by [<cite><a class="bibref"
-          data-link-type="biblio" href="#bib-bcp47" title=
-          "Tags for Identifying Languages">BCP47</a></cite>] (e.g.,
-          <code>en</code>, <code>de-AT</code>, <code>gsw-CH</code>,
-          <code>zh-Hans</code>, <code>zh-Hant-HK</code>,
-          <code>sl-nedis</code>).</span>
-          </li>
-          </ul>
+            <p>
+              To determine the base direction of all human-readable text in <a>Thing Description</a> and
+              <a>Thing Model</a> instances this specification recommends to follow the [[STRING-META]] guideline about
+              <a href="https://www.w3.org/TR/string-meta/#string_specific_direction"
+                >string-specific directional information</a
+              >
+              when no built-in mechanism for associating base direction metadata is available.
+            </p>
 
-          
-          <p>To determine the base direction of all
-          human-readable text in <a>Thing Description</a> 
-          and <a>Thing Model</a> instances this specification 
-           recommends to follow the [[STRING-META]] guideline about 
-           <a href="https://www.w3.org/TR/string-meta/#string_specific_direction">string-specific directional information</a>
-           when no built-in mechanism for associating base direction metadata
-           is available.
-           </p>
-
-          <p><a href="#dfn-td-processor" class="internalDFN"
-          data-link-type="dfn">TD Processors</a> should be aware of
-          certain special cases when processing bidirectional text.
-          <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
-          <a href="#dfn-td-processor" class="internalDFN"
-          data-link-type="dfn">TD Processors</a> SHOULD take care to use bidi isolation when
-          presenting strings to users, particularly when embedding
-          in surrounding text (e.g., for Web user interface)</span>. 
-          Mixed direction text can occur in any language, even when the
-          language is properly identified.</p>
-          <p><span class="rfc2119-assertion" id="td-producer-mixed-direction">
-          TD <a>producers</a> SHOULD attempt to provide mixed direction
-          strings in a way that can be displayed successfully by a
-          naive user agent. </span>
-          For example, if an RTL string begins
-          with an LTR run (such as a number or a brand or trade
-          name in Latin script), including an RLM character at the
-          start of the string or wrapping opposite direction runs
-          in bidi controls can assist in proper display.</p>
-          <p><em>Strings on the Web: Language and Direction
-          Metadata</em> [<cite><a class="bibref" data-link-type=
-          "biblio" href="#bib-string-meta" title=
-          "Strings on the Web: Language and Direction Metadata">string-meta</a></cite>]
-          provides some guidance and illustrates a number of
-          pitfalls when using bidirectional text.</p>
-          <p id="meta-interactions-of-thing">In addition to the
-          explicitly provided <a href="#dfn-interaction-affordance"
-          class="internalDFN" data-link-type="dfn">Interaction
-          Affordances</a> in the <code>properties</code>,
-          <code>actions</code>, and <code>events</code> <a href=
-          "#dfn-map" class="internalDFN" data-link-type=
-          "dfn">Maps</a>, a <a href="#dfn-thing" class=
-          "internalDFN" data-link-type="dfn">Thing</a> can also
-          provide meta-interactions, which are indicated by
-          <code>Form</code> instances in its optional
-          <code>forms</code> <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a>.
-          <span class="rfc2119-assertion" id="td-op-for-thing">When
-          the <code>forms</code> <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a> of a
-          <a href="#dfn-thing" class="internalDFN" data-link-type=
-          "dfn">Thing</a> instance contains <code>Form</code>
-          instances, it MUST contain <code>op</code> member with the string values assigned 
-          to the name <code>op</code>, either directly or within an <a href=
-          "#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a>, MUST be one of the following <em>operation
-          types</em>: <code>readallproperties</code>,
-          <code>writeallproperties</code>,
-          <code>readmultipleproperties</code>,
-          <code>writemultipleproperties</code>, <code>observeallproperties</code>,
-          <code>unobserveallproperties</code>, <code>queryallactions</code>, 
-          <code>subscribeallevents</code>, or
-          <code>unsubscribeallevents</code>.</span> (See
-          <a href="#td-forms-readall-example">an example</a> for an
-          usage of <code>form</code> in a Thing instance.)</p>
-          <p>The data schema for each of the property meta-interactions is
-          constructed by combining the data schemas of each
-          <code>PropertyAffordance</code> instance in a single
-          <code>ObjectSchema</code> instance, where the
-          <code>properties</code> <a href="#dfn-map" class=
-          "internalDFN" data-link-type="dfn">Map</a> of the
-          <code>ObjectSchema</code> instance contains each data
-          schema of the <code>PropertyAffordances</code> identified
-          by the name of the corresponding
-          <code>PropertyAffordances</code> instance.</p>
-          <p>If not specified otherwise (e.g., through a <a href=
-          "#dfn-context-ext" class="internalDFN" data-link-type=
-          "dfn">TD Context Extension</a>), the request data of the
-          <code>readmultipleproperties</code> operation is an
-          <a href="#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> that contains the intended
-          <code>PropertyAffordances</code> instance names, which is
-          serialized to the content type specified by the
-          <code>Form</code> instance.</p></section>
-<section><h3><code>InteractionAffordance</code></h3><p>Metadata of a Thing that shows the possible choices to
-          <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a>, thereby suggesting
-          how <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> may interact with the
-          Thing. There are many types of potential affordances, but
-          <abbr title="World Wide Web Consortium">W3C</abbr> WoT
-          defines three types of Interaction Affordances:
-          Properties, Actions, and Events.</p><table class="def numbered"><caption>Vocabulary Terms in InteractionAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
-                a text for UI representation) based on a default
-                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance"><td><code>titles</code></td><td>Provides multi-language human-readable titles
-                (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance"><td><code>forms</code></td><td>Set of form hypermedia controls that describe
-                how an operation can be performed. Forms are
-                serializations of Protocol Bindings. The array cannot be empty.</td><td>mandatory</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
-                based on DataSchema declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
-                to be serialized to a string inside the <code>href</code> upon the execution of the operation. 
-                If the same variable is both declared in <a>Thing level</a> <code>uriVariables</code>and in Interaction Affordance level, 
-                the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>The class <code>InteractionAffordance</code> has the following subclasses:</p><ul><li><a href="#propertyaffordance"><code>PropertyAffordance</code></a></li>
-<li><a href="#actionaffordance"><code>ActionAffordance</code></a></li>
-<li><a href="#eventaffordance"><code>EventAffordance</code></a></li></ul></section>
-<section><h3><code>PropertyAffordance</code></h3><p>An Interaction Affordance that exposes state of the
-          Thing. This state can then be retrieved (read) and/or updated (write).
-           Things can also choose to
-          make Properties observable by pushing the new state after
-          a change.</p><table class="def numbered"><caption>Vocabulary Terms in PropertyAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance"><td><code>observable</code></td><td>A hint that indicates whether Servients hosting
-                the Thing and Intermediaries should provide a
-                Protocol Binding that supports the <code>observeproperty</code> and <code>unobserveproperty</code> operations 
-                for this Property.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table><p class="note">Property instances are also instances of
-            the class <a href="#dataschema" class="sec-ref">DataSchema</a>. Therefore, it can contain the
-            <code>type</code>, <code>unit</code>,
-            <code>readOnly</code> and <code>writeOnly</code>
-            members, among others.</p><p><code>PropertyAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> and
-          the <code>DataSchema</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-          <span class="rfc2119-assertion" id="td-op-for-property">When a Form instance is within a
-          <code>PropertyAffordance</code> instance, the value
-          assigned to <code>op</code> MUST be one of <code>readproperty</code>,
-          <code>writeproperty</code>, <code>observeproperty</code>,
-          <code>unobserveproperty</code> or an <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
-          containing a combination of these terms.</span></p><p class="note">
-		  It is considered to be good practice that each <code>observeproperty</code> has a corresponding
-		  <code>unobserveproperty</code> unless the protocol supports implicit unsubscription mechanisms
-		  (e.g., heartbeat to detect connection loss).</p><p class="note">
-		  The observation mechanism depends on the underlying protocol or sub-protocol. Having said that, it is not 
-          guaranteed that the current <a>Property</a> value will be provided once the subscription is initiated. Hence, it may be 
-          necessary to read the current <a>Property</a> value before/after the subscription to get a first value. 
-          </p></section>
-<section><h3><code>ActionAffordance</code></h3><p>An Interaction Affordance that allows to invoke a
-          function of the Thing, which manipulates state (e.g.,
-          toggling a lamp on or off) or triggers a process on the
-          Thing (e.g., dim a lamp over time).</p><table class="def numbered"><caption>Vocabulary Terms in ActionAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance"><td><code>input</code></td><td>Used to define the input data schema of the
-                Action.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance"><td><code>output</code></td><td>Used to define the output data schema of the
-                Action.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance"><td><code>safe</code></td><td>Signals if the Action is safe (=true) or not.
-                Used to signal if there is no internal state (cf.
-                resource state) is changed when invoking an Action.
-                In that case responses can be cached as
-                example.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance"><td><code>idempotent</code></td><td>Indicates whether the Action is idempotent
-                (=true) or not. Informs whether the Action can be
-                called repeatedly with the same result, if present,
-                based on the same input.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-synchronous--ActionAffordance"><td><code>synchronous</code></td><td>Indicates whether the action is synchronous (=true) or not. 
-                A synchronous action means that the response of action contains all the information 
-                about the result of the action and no further querying about the status of the action 
-                is needed. Lack of this keyword means that no claim on the synchronicity of the 
-                action can be made.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table><p><code>ActionAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-          <span class="rfc2119-assertion" id="td-op-for-action">When a Form instance is within an
-          <code>ActionAffordance</code> instance, the value
-          assigned to op MUST
-          either be <code>invokeaction</code>, <code>queryaction</code>, 
-          <code>cancelaction</code> or an 
-          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
-          containing a combination of these terms.
-          </span></p></section>
-<section><h3><code>EventAffordance</code></h3><p>An Interaction Affordance that describes an event
-          source, which asynchronously pushes event data to
-          <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating
-          alerts).</p><table class="def numbered"><caption>Vocabulary Terms in EventAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance"><td><code>subscription</code></td><td>Defines data that needs to be passed upon
-                subscription, e.g., filters or message format for
-                setting up Webhooks.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance"><td><code>data</code></td><td>Defines the data schema of the Event instance
-                messages pushed by the Thing.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-dataResponse--EventAffordance"><td><code>dataResponse</code></td><td>Defines the data schema of the Event response messages sent by the consumer in a response to a data message.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance"><td><code>cancellation</code></td><td>Defines any data that needs to be passed to
-                cancel a subscription, e.g., a specific message to
-                remove a Webhook.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p><code>EventAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-          <span class="rfc2119-assertion" id="td-op-for-event">When
-          a Form instance is within an <code>EventAffordance</code>
-          instance, the value assigned to <code>op</code>
-          MUST be either
-          <code>subscribeevent</code>,
-          <code>unsubscribeevent</code>, or both terms within an
-          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span></p><p class="note">
-		  It is considered to be good practice that each <code>subscribeevent</code> has a corresponding <code>unsubscribeevent</code> unless the protocol
-		  supports implicit unsubscription mechanisms (e.g., heartbeat to detect connection loss).</p>
-          <p>
-            EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs interested Consumers about state changes.
-            However, a main difference of EventAffordances is that not every change of the associated resource needs to trigger an event message to be emitted, e.g. a critical threshold for a numeric value.
-        Furthermore, EventAffordances allow for more complex subscribing and unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and <code>cancellation</code> DataSchema definitions.
-            Not all protocols might support these more advanced mechanisms, however, which is why in some scenarios, events may be very similar to observable PropertyAffordances.
-            In these cases, the choice between a Property and a Event for modelling the Affordance should be made based on the semantics of the underlying resource; for example, if the state of the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the appropriate choice.
-          </p>
+            <p>
+              <a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TD Processors</a> should be aware of
+              certain special cases when processing bidirectional text.
+              <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
+                <a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TD Processors</a> SHOULD take care
+                to use bidi isolation when presenting strings to users, particularly when embedding in surrounding text
+                (e.g., for Web user interface)</span
+              >. Mixed direction text can occur in any language, even when the language is properly identified.
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-producer-mixed-direction">
+                TD <a>producers</a> SHOULD attempt to provide mixed direction strings in a way that can be displayed
+                successfully by a naive user agent.
+              </span>
+              For example, if an RTL string begins with an LTR run (such as a number or a brand or trade name in Latin
+              script), including an RLM character at the start of the string or wrapping opposite direction runs in bidi
+              controls can assist in proper display.
+            </p>
+            <p>
+              <em>Strings on the Web: Language and Direction Metadata</em> [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-string-meta"
+                  title="Strings on the Web: Language and Direction Metadata"
+                  >string-meta</a
+                ></cite
+              >] provides some guidance and illustrates a number of pitfalls when using bidirectional text.
+            </p>
+            <p id="meta-interactions-of-thing">
+              In addition to the explicitly provided
+              <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
+              in the <code>properties</code>, <code>actions</code>, and <code>events</code>
+              <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Maps</a>, a
+              <a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a> can also provide
+              meta-interactions, which are indicated by <code>Form</code> instances in its optional <code>forms</code>
+              <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.
+              <span class="rfc2119-assertion" id="td-op-for-thing"
+                >When the <code>forms</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> of
+                a <a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a> instance contains
+                <code>Form</code> instances, it MUST contain <code>op</code> member with the string values assigned to
+                the name <code>op</code>, either directly or within an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>, MUST be one of the following
+                <em>operation types</em>: <code>readallproperties</code>, <code>writeallproperties</code>,
+                <code>readmultipleproperties</code>, <code>writemultipleproperties</code>,
+                <code>observeallproperties</code>, <code>unobserveallproperties</code>, <code>queryallactions</code>,
+                <code>subscribeallevents</code>, or <code>unsubscribeallevents</code>.</span
+              >
+              (See <a href="#td-forms-readall-example">an example</a> for an usage of <code>form</code> in a Thing
+              instance.)
+            </p>
+            <p>
+              The data schema for each of the property meta-interactions is constructed by combining the data schemas of
+              each <code>PropertyAffordance</code> instance in a single <code>ObjectSchema</code> instance, where the
+              <code>properties</code> <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> of the
+              <code>ObjectSchema</code> instance contains each data schema of the
+              <code>PropertyAffordances</code> identified by the name of the corresponding
+              <code>PropertyAffordances</code> instance.
+            </p>
+            <p>
+              If not specified otherwise (e.g., through a
+              <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>), the request
+              data of the <code>readmultipleproperties</code> operation is an
+              <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> that contains the intended
+              <code>PropertyAffordances</code> instance names, which is serialized to the content type specified by the
+              <code>Form</code> instance.
+            </p>
           </section>
-<section><h3><code>VersionInfo</code></h3><p>Metadata of a Thing that provides version information
-          about the TD document. If required, additional version
-          information such as firmware and hardware version (term
-          definitions outside of the TD namespace) can be extended
-          via the <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>
-          mechanism.</p><table class="def numbered"><caption>Vocabulary Terms in VersionInfo Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo"><td><code>instance</code></td><td>Provides a version indicator of this TD.
-                </td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-model--VersionInfo"><td><code>model</code></td><td>Provides a version indicator of the underlying TM.
-                </td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><p>It is recommended that the values within <code>instances</code> and <code>model</code> of
-          the <code>VersionInfo</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> follow the
-          semantic versioning pattern, where a sequence of three
-          numbers separated by a dot indicates the major version,
-          minor version, and patch version, respectively. See
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0">SEMVER</a></cite>] for
-          details.</p></section>
-<section><h3><code>MultiLanguage</code></h3><p><p>A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
-            <p><span class="rfc2119-assertion" id="td-multilanguage-language-tag">Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in [[!BCP47]].</span>
-            <span class="rfc2119-assertion" id="td-multilanguage-value"> Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>. </span> 
-            </p></section>
+          <section>
+            <h3><code>InteractionAffordance</code></h3>
+            <p>
+              Metadata of a Thing that shows the possible choices to
+              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a>, thereby suggesting how
+              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> may interact with the
+              Thing. There are many types of potential affordances, but
+              <abbr title="World Wide Web Consortium">W3C</abbr> WoT defines three types of Interaction Affordances:
+              Properties, Actions, and Events.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in InteractionAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance">
+                  <td><code>title</code></td>
+                  <td>
+                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
+                    language.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance">
+                  <td><code>titles</code></td>
+                  <td>
+                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
+                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance">
+                  <td><code>forms</code></td>
+                  <td>
+                    Set of form hypermedia controls that describe how an operation can be performed. Forms are
+                    serializations of Protocol Bindings. The array cannot be empty.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Array</a> of <a href="#form"><code>Form</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance">
+                  <td><code>uriVariables</code></td>
+                  <td>
+                    Define URI template variables according to [[RFC6570]] as collection based on DataSchema
+                    declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since
+                    each variable needs to be serialized to a string inside the <code>href</code> upon the execution of
+                    the operation. If the same variable is both declared in <a>Thing level</a>
+                    <code>uriVariables</code>and in Interaction Affordance level, the Interaction Affordance level
+                    variable takes precedence.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>The class <code>InteractionAffordance</code> has the following subclasses:</p>
+            <ul>
+              <li>
+                <a href="#propertyaffordance"><code>PropertyAffordance</code></a>
+              </li>
+              <li>
+                <a href="#actionaffordance"><code>ActionAffordance</code></a>
+              </li>
+              <li>
+                <a href="#eventaffordance"><code>EventAffordance</code></a>
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3><code>PropertyAffordance</code></h3>
+            <p>
+              An Interaction Affordance that exposes state of the Thing. This state can then be retrieved (read) and/or
+              updated (write). Things can also choose to make Properties observable by pushing the new state after a
+              change.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in PropertyAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance">
+                  <td><code>observable</code></td>
+                  <td>
+                    A hint that indicates whether Servients hosting the Thing and Intermediaries should provide a
+                    Protocol Binding that supports the <code>observeproperty</code> and
+                    <code>unobserveproperty</code> operations for this Property.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="note">
+              Property instances are also instances of the class <a href="#dataschema" class="sec-ref">DataSchema</a>.
+              Therefore, it can contain the <code>type</code>, <code>unit</code>, <code>readOnly</code> and
+              <code>writeOnly</code> members, among others.
+            </p>
+            <p>
+              <code>PropertyAffordance</code> is a
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+              <code>InteractionAffordance</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> and the <code>DataSchema</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+              <span class="rfc2119-assertion" id="td-op-for-property"
+                >When a Form instance is within a <code>PropertyAffordance</code> instance, the value assigned to
+                <code>op</code> MUST be one of <code>readproperty</code>, <code>writeproperty</code>,
+                <code>observeproperty</code>, <code>unobserveproperty</code> or an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> containing a combination of
+                these terms.</span
+              >
+            </p>
+            <p class="note">
+              It is considered to be good practice that each <code>observeproperty</code> has a corresponding
+              <code>unobserveproperty</code> unless the protocol supports implicit unsubscription mechanisms (e.g.,
+              heartbeat to detect connection loss).
+            </p>
+            <p class="note">
+              The observation mechanism depends on the underlying protocol or sub-protocol. Having said that, it is not
+              guaranteed that the current <a>Property</a> value will be provided once the subscription is initiated.
+              Hence, it may be necessary to read the current <a>Property</a> value before/after the subscription to get
+              a first value.
+            </p>
+          </section>
+          <section>
+            <h3><code>ActionAffordance</code></h3>
+            <p>
+              An Interaction Affordance that allows to invoke a function of the Thing, which manipulates state (e.g.,
+              toggling a lamp on or off) or triggers a process on the Thing (e.g., dim a lamp over time).
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ActionAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance">
+                  <td><code>input</code></td>
+                  <td>Used to define the input data schema of the Action.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance">
+                  <td><code>output</code></td>
+                  <td>Used to define the output data schema of the Action.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance">
+                  <td><code>safe</code></td>
+                  <td>
+                    Signals if the Action is safe (=true) or not. Used to signal if there is no internal state (cf.
+                    resource state) is changed when invoking an Action. In that case responses can be cached as example.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance">
+                  <td><code>idempotent</code></td>
+                  <td>
+                    Indicates whether the Action is idempotent (=true) or not. Informs whether the Action can be called
+                    repeatedly with the same result, if present, based on the same input.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-synchronous--ActionAffordance">
+                  <td><code>synchronous</code></td>
+                  <td>
+                    Indicates whether the action is synchronous (=true) or not. A synchronous action means that the
+                    response of action contains all the information about the result of the action and no further
+                    querying about the status of the action is needed. Lack of this keyword means that no claim on the
+                    synchronicity of the action can be made.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              <code>ActionAffordance</code> is a
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+              <code>InteractionAffordance</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+              <span class="rfc2119-assertion" id="td-op-for-action"
+                >When a Form instance is within an <code>ActionAffordance</code> instance, the value assigned to op MUST
+                either be <code>invokeaction</code>, <code>queryaction</code>, <code>cancelaction</code> or an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
+                containing a combination of these terms.
+              </span>
+            </p>
+          </section>
+          <section>
+            <h3><code>EventAffordance</code></h3>
+            <p>
+              An Interaction Affordance that describes an event source, which asynchronously pushes event data to
+              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating alerts).
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in EventAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance">
+                  <td><code>subscription</code></td>
+                  <td>
+                    Defines data that needs to be passed upon subscription, e.g., filters or message format for setting
+                    up Webhooks.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance">
+                  <td><code>data</code></td>
+                  <td>Defines the data schema of the Event instance messages pushed by the Thing.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-dataResponse--EventAffordance">
+                  <td><code>dataResponse</code></td>
+                  <td>
+                    Defines the data schema of the Event response messages sent by the consumer in a response to a data
+                    message.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance">
+                  <td><code>cancellation</code></td>
+                  <td>
+                    Defines any data that needs to be passed to cancel a subscription, e.g., a specific message to
+                    remove a Webhook.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              <code>EventAffordance</code> is a
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+              <code>InteractionAffordance</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+              <span class="rfc2119-assertion" id="td-op-for-event"
+                >When a Form instance is within an <code>EventAffordance</code> instance, the value assigned to
+                <code>op</code>
+                MUST be either
+                <code>subscribeevent</code>, <code>unsubscribeevent</code>, or both terms within an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span
+              >
+            </p>
+            <p class="note">
+              It is considered to be good practice that each <code>subscribeevent</code> has a corresponding
+              <code>unsubscribeevent</code> unless the protocol supports implicit unsubscription mechanisms (e.g.,
+              heartbeat to detect connection loss).
+            </p>
+            <p>
+              EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs
+              interested Consumers about state changes. However, a main difference of EventAffordances is that not every
+              change of the associated resource needs to trigger an event message to be emitted, e.g. a critical
+              threshold for a numeric value. Furthermore, EventAffordances allow for more complex subscribing and
+              unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and
+              <code>cancellation</code> DataSchema definitions. Not all protocols might support these more advanced
+              mechanisms, however, which is why in some scenarios, events may be very similar to observable
+              PropertyAffordances. In these cases, the choice between a Property and a Event for modelling the
+              Affordance should be made based on the semantics of the underlying resource; for example, if the state of
+              the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the
+              appropriate choice.
+            </p>
+          </section>
+          <section>
+            <h3><code>VersionInfo</code></h3>
+            <p>
+              Metadata of a Thing that provides version information about the TD document. If required, additional
+              version information such as firmware and hardware version (term definitions outside of the TD namespace)
+              can be extended via the
+              <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a> mechanism.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in VersionInfo Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo">
+                  <td><code>instance</code></td>
+                  <td>Provides a version indicator of this TD.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-model--VersionInfo">
+                  <td><code>model</code></td>
+                  <td>Provides a version indicator of the underlying TM.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              It is recommended that the values within <code>instances</code> and <code>model</code> of the
+              <code>VersionInfo</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> follow
+              the semantic versioning pattern, where a sequence of three numbers separated by a dot indicates the major
+              version, minor version, and patch version, respectively. See [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0"
+                  >SEMVER</a
+                ></cite
+              >] for details.
+            </p>
+          </section>
+          <section>
+            <h3><code>MultiLanguage</code></h3>
+            <p></p>
+            <p>
+              A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags
+              described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of
+              this container in a Thing Description instance.
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-multilanguage-language-tag"
+                >Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in
+                [[!BCP47]].</span
+              >
+              <span class="rfc2119-assertion" id="td-multilanguage-value">
+                Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>.
+              </span>
+            </p>
+          </section>
         </section>
 
         <section id="sec-data-schema-vocabulary-definition">
@@ -1553,122 +2051,579 @@
           </table>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>DataSchema</code></h3><p>Metadata that describes the data format used. It can
-          be used for validation.</p><table class="def numbered"><caption>Vocabulary Terms in DataSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
-                a text for UI representation) based on a default
-                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema"><td><code>titles</code></td><td>Provides multi-language human-readable titles
-                (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema"><td><code>const</code></td><td>Provides a constant value.</td><td>optional</td><td>any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema"><td><code>default</code></td><td>Supply a default value. The value SHOULD validate against the data schema in which it resides.</td><td>optional</td><td>any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema"><td><code>unit</code></td><td>Provides unit information that is used, e.g.,
-                in international science, engineering, and
-                business. To preserve uniqueness, it is recommended that 
-                the value of the unit points to a semantic definition (also see Section <a href="#semantic-annotations-example-version-units"
-          class="internalDFN" data-link-type="dfn">Semantic Annotations</a>).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema"><td><code>oneOf</code></td><td>Used to ensure that the data is valid against
-                one of the specified schemas in the array.  This can be used to describe multiple input or output schemas.</td><td>optional</td><td><a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema"><td><code>enum</code></td><td>Restricted set of values provided as an
-                array.</td><td>optional</td><td><a>Array</a> of any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema"><td><code>readOnly</code></td><td>Boolean value that is a hint to indicate
-                whether a property interaction / value is read only
-                (=true) or not (=false).</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema"><td><code>writeOnly</code></td><td>Boolean value that is a hint to indicate
-                whether a property interaction / value is write
-                only (=true) or not (=false).</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema"><td><code>format</code></td><td>Allows validation based on a format pattern
-                such as "date-time", "email", "uri", etc. (Also see
-                below.)</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-type--DataSchema"><td><code>type</code></td><td>Assignment of JSON-based data types compatible
-                with JSON Schema (one of boolean, integer, number,
-                string, object, array, or null).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> (one of <code>object</code>, <code>array</code>, <code>string</code>, <code>number</code>, <code>integer</code>, <code>boolean</code>, or <code>null</code>)</td></tr></tbody></table><p>The class <code>DataSchema</code> has the following subclasses:</p><ul><li><a href="#arrayschema"><code>ArraySchema</code></a></li>
-<li><a href="#booleanschema"><code>BooleanSchema</code></a></li>
-<li><a href="#numberschema"><code>NumberSchema</code></a></li>
-<li><a href="#integerschema"><code>IntegerSchema</code></a></li>
-<li><a href="#objectschema"><code>ObjectSchema</code></a></li>
-<li><a href="#stringschema"><code>StringSchema</code></a></li>
-<li><a href="#nullschema"><code>NullSchema</code></a></li></ul><p>The <code>format</code> string values are known from a
-          fixed set of values and their corresponding format rules
-          defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]
-          (Section 7.3 Defined Formats in particular). <span class="rfc2119-assertion" id="td-format-validation-known-values">Servients MAY use the
-          <code>format</code> value to perform additional
-          validation accordingly.</span> <span class="rfc2119-assertion" id="td-format-validation-other-values">When a value that is
-          not found in the known set of values is assigned to
-          <code>format</code>, such a validation SHOULD succeed.</span></p>
-          Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>, <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string, object, array, or null).
-          <p class="note">The <code>format</code> term is not widely implemented by JSON Schema tools. 
-          In addition, the term <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by another mechanism or removed in a future JSON Schema version.</p></section>
-<section><h3><code>ArraySchema</code></h3><p>Metadata describing data of type <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>. This
-          <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>array</code> assigned to <code>type</code> in
-          <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in ArraySchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema"><td><code>items</code></td><td>Used to define the characteristics of an
-                array.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a> or <a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema"><td><code>minItems</code></td><td>Defines the minimum number of items that have
-                to be in the array.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema"><td><code>maxItems</code></td><td>Defines the maximum number of items that have
-                to be in the array.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr></tbody></table></section>
-<section><h3><code>BooleanSchema</code></h3><p>Metadata describing data of type <code>boolean</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>boolean</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p></section>
-<section><h3><code>NumberSchema</code></h3><p>Metadata describing data of type <code>number</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>number</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in NumberSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema"><td><code>minimum</code></td><td>Specifies a minimum numeric value, representing an inclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--NumberSchema"><td><code>exclusiveMinimum</code></td><td>Specifies a minimum numeric value, representing an exclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema"><td><code>maximum</code></td><td>Specifies a maximum numeric value, representing an inclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--NumberSchema"><td><code>exclusiveMaximum</code></td><td>Specifies a maximum numeric value, representing an exclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--NumberSchema"><td><code>multipleOf</code></td><td>Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr></tbody></table></section>
-<section><h3><code>IntegerSchema</code></h3><p>Metadata describing data of type <code>integer</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>integer</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in IntegerSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema"><td><code>minimum</code></td><td>Specifies a minimum numeric value, representing an inclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--IntegerSchema"><td><code>exclusiveMinimum</code></td><td>Specifies a minimum numeric value, representing an exclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema"><td><code>maximum</code></td><td>Specifies a maximum numeric value, representing an inclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--IntegerSchema"><td><code>exclusiveMaximum</code></td><td>Specifies a maximum numeric value, representing an exclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--IntegerSchema"><td><code>multipleOf</code></td><td>Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr></tbody></table></section>
-<section><h3><code>ObjectSchema</code></h3><p>Metadata describing data of type <a href="#dfn-object" class="internalDFN" data-link-type="dfn">Object</a>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>object</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in ObjectSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema"><td><code>properties</code></td><td>Data schema nested definitions.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema"><td><code>required</code></td><td>Defines which members of the object type are mandatory, i.e. which members are mandatory in the payload that is to be sent (e.g. input of <code>invokeaction</code>, <code>writeproperty</code>) and what members will be definitely delivered in the payload that is being received (e.g. output of <code>invokeaction</code>, <code>readproperty</code>)</td><td>optional</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>StringSchema</code></h3><p>Metadata describing data of type <code>string</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>string</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in StringSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minLength--StringSchema"><td><code>minLength</code></td><td>Specifies the minimum length of a string. Only applicable for associated string types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maxLength--StringSchema"><td><code>maxLength</code></td><td>Specifies the maximum length of a string. Only applicable for associated string types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-pattern--StringSchema"><td><code>pattern</code></td><td>Provides a regular expression to express constraints of the string value. The regular expression must follow the [[ECMA-262]] dialect.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentEncoding--StringSchema"><td><code>contentEncoding</code></td><td>Specifies the encoding used to store the contents, as specified in [[RFC2045]] (Section 6.1) and [[RFC4648]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>7bit</code>, <code>8bit</code>, <code>binary</code>, <code>quoted-printable</code>, <code>base16</code>, <code>base32</code>, or <code>base64</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentMediaType--StringSchema"><td><code>contentMediaType</code></td><td>Specifies the MIME type of the contents of a string value, as described in [[RFC2046]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>image/png</code>, or <code>audio/mpeg</code>)</td></tr></tbody></table><p class="note">The length of a string (i.e., <code>minLength</code> and
-        <code>maxLength</code>) is defined as the number
-        of Unicode code points, as defined by [[RFC8259]].
-		Note that some <a href="https://www.w3.org/TR/i18n-glossary/#dfn-grapheme" target="_blank">user-perceived characters</a> are composed of more than one Unicode code point. Arbitrary index values might not fall on these grapheme boundaries, so truncation according to <code>maxLength</code> might alter the appearance or meaning of the string.
-		</p></section>
-<section><h3><code>NullSchema</code></h3><p>Metadata describing data of type <code>null</code>. This subclass is indicated by the value <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. 
-    This Subclass describes only one acceptable value, namely <code>null</code>. 
-    It is important to note that <code>null</code> does not mean the absence of a value. It is analogous to <code>null</code> in JavaScript, <code>None</code> in Python, <code>null</code> in Java and <code>nil</code> in Ruby programming languages. 
-    It can be used as part of a <code>oneOf</code> declaration, where it is used to indicate, that the data can also be <code>null</code>.</p></section>
+          <section>
+            <h3><code>DataSchema</code></h3>
+            <p>Metadata that describes the data format used. It can be used for validation.</p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in DataSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema">
+                  <td><code>title</code></td>
+                  <td>
+                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
+                    language.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema">
+                  <td><code>titles</code></td>
+                  <td>
+                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
+                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema">
+                  <td><code>const</code></td>
+                  <td>Provides a constant value.</td>
+                  <td>optional</td>
+                  <td>any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema">
+                  <td><code>default</code></td>
+                  <td>
+                    Supply a default value. The value SHOULD validate against the data schema in which it resides.
+                  </td>
+                  <td>optional</td>
+                  <td>any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema">
+                  <td><code>unit</code></td>
+                  <td>
+                    Provides unit information that is used, e.g., in international science, engineering, and business.
+                    To preserve uniqueness, it is recommended that the value of the unit points to a semantic definition
+                    (also see Section
+                    <a href="#semantic-annotations-example-version-units" class="internalDFN" data-link-type="dfn"
+                      >Semantic Annotations</a
+                    >).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema">
+                  <td><code>oneOf</code></td>
+                  <td>
+                    Used to ensure that the data is valid against one of the specified schemas in the array. This can be
+                    used to describe multiple input or output schemas.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema">
+                  <td><code>enum</code></td>
+                  <td>Restricted set of values provided as an array.</td>
+                  <td>optional</td>
+                  <td><a>Array</a> of any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema">
+                  <td><code>readOnly</code></td>
+                  <td>
+                    Boolean value that is a hint to indicate whether a property interaction / value is read only (=true)
+                    or not (=false).
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema">
+                  <td><code>writeOnly</code></td>
+                  <td>
+                    Boolean value that is a hint to indicate whether a property interaction / value is write only
+                    (=true) or not (=false).
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema">
+                  <td><code>format</code></td>
+                  <td>
+                    Allows validation based on a format pattern such as "date-time", "email", "uri", etc. (Also see
+                    below.)
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-type--DataSchema">
+                  <td><code>type</code></td>
+                  <td>
+                    Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number,
+                    string, object, array, or null).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> (one
+                    of <code>object</code>, <code>array</code>, <code>string</code>, <code>number</code>,
+                    <code>integer</code>, <code>boolean</code>, or <code>null</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>The class <code>DataSchema</code> has the following subclasses:</p>
+            <ul>
+              <li>
+                <a href="#arrayschema"><code>ArraySchema</code></a>
+              </li>
+              <li>
+                <a href="#booleanschema"><code>BooleanSchema</code></a>
+              </li>
+              <li>
+                <a href="#numberschema"><code>NumberSchema</code></a>
+              </li>
+              <li>
+                <a href="#integerschema"><code>IntegerSchema</code></a>
+              </li>
+              <li>
+                <a href="#objectschema"><code>ObjectSchema</code></a>
+              </li>
+              <li>
+                <a href="#stringschema"><code>StringSchema</code></a>
+              </li>
+              <li>
+                <a href="#nullschema"><code>NullSchema</code></a>
+              </li>
+            </ul>
+            <p>
+              The <code>format</code> string values are known from a fixed set of values and their corresponding format
+              rules defined in [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-json-schema"
+                  title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
+                  >JSON-SCHEMA</a
+                ></cite
+              >] (Section 7.3 Defined Formats in particular).
+              <span class="rfc2119-assertion" id="td-format-validation-known-values"
+                >Servients MAY use the <code>format</code> value to perform additional validation accordingly.</span
+              >
+              <span class="rfc2119-assertion" id="td-format-validation-other-values"
+                >When a value that is not found in the known set of values is assigned to <code>format</code>, such a
+                validation SHOULD succeed.</span
+              >
+            </p>
+            Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>,
+            <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string,
+            object, array, or null).
+            <p class="note">
+              The <code>format</code> term is not widely implemented by JSON Schema tools. In addition, the term
+              <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by
+              another mechanism or removed in a future JSON Schema version.
+            </p>
+          </section>
+          <section>
+            <h3><code>ArraySchema</code></h3>
+            <p>
+              Metadata describing data of type <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.
+              This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+              value <code>array</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ArraySchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema">
+                  <td><code>items</code></td>
+                  <td>Used to define the characteristics of an array.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a> or <a>Array</a> of
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema">
+                  <td><code>minItems</code></td>
+                  <td>Defines the minimum number of items that have to be in the array.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema">
+                  <td><code>maxItems</code></td>
+                  <td>Defines the maximum number of items that have to be in the array.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>BooleanSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>boolean</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>boolean</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+          </section>
+          <section>
+            <h3><code>NumberSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>number</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>number</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in NumberSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema">
+                  <td><code>minimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--NumberSchema">
+                  <td><code>exclusiveMinimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema">
+                  <td><code>maximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--NumberSchema">
+                  <td><code>exclusiveMaximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--NumberSchema">
+                  <td><code>multipleOf</code></td>
+                  <td>
+                    Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>IntegerSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>integer</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>integer</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in IntegerSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema">
+                  <td><code>minimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--IntegerSchema">
+                  <td><code>exclusiveMinimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema">
+                  <td><code>maximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--IntegerSchema">
+                  <td><code>exclusiveMaximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--IntegerSchema">
+                  <td><code>multipleOf</code></td>
+                  <td>
+                    Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>ObjectSchema</code></h3>
+            <p>
+              Metadata describing data of type
+              <a href="#dfn-object" class="internalDFN" data-link-type="dfn">Object</a>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>object</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ObjectSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema">
+                  <td><code>properties</code></td>
+                  <td>Data schema nested definitions.</td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema">
+                  <td><code>required</code></td>
+                  <td>
+                    Defines which members of the object type are mandatory, i.e. which members are mandatory in the
+                    payload that is to be sent (e.g. input of <code>invokeaction</code>, <code>writeproperty</code>) and
+                    what members will be definitely delivered in the payload that is being received (e.g. output of
+                    <code>invokeaction</code>, <code>readproperty</code>)
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>StringSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>string</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>string</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in StringSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minLength--StringSchema">
+                  <td><code>minLength</code></td>
+                  <td>Specifies the minimum length of a string. Only applicable for associated string types.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maxLength--StringSchema">
+                  <td><code>maxLength</code></td>
+                  <td>Specifies the maximum length of a string. Only applicable for associated string types.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-pattern--StringSchema">
+                  <td><code>pattern</code></td>
+                  <td>
+                    Provides a regular expression to express constraints of the string value. The regular expression
+                    must follow the [[ECMA-262]] dialect.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentEncoding--StringSchema">
+                  <td><code>contentEncoding</code></td>
+                  <td>
+                    Specifies the encoding used to store the contents, as specified in [[RFC2045]] (Section 6.1) and
+                    [[RFC4648]].
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>7bit</code>, <code>8bit</code>, <code>binary</code>, <code>quoted-printable</code>,
+                    <code>base16</code>, <code>base32</code>, or <code>base64</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentMediaType--StringSchema">
+                  <td><code>contentMediaType</code></td>
+                  <td>Specifies the MIME type of the contents of a string value, as described in [[RFC2046]].</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>image/png</code>, or <code>audio/mpeg</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="note">
+              The length of a string (i.e., <code>minLength</code> and <code>maxLength</code>) is defined as the number
+              of Unicode code points, as defined by [[RFC8259]]. Note that some
+              <a href="https://www.w3.org/TR/i18n-glossary/#dfn-grapheme" target="_blank">user-perceived characters</a>
+              are composed of more than one Unicode code point. Arbitrary index values might not fall on these grapheme
+              boundaries, so truncation according to <code>maxLength</code> might alter the appearance or meaning of the
+              string.
+            </p>
+          </section>
+          <section>
+            <h3><code>NullSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>null</code>. This subclass is indicated by the value
+              <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. This Subclass
+              describes only one acceptable value, namely <code>null</code>. It is important to note that
+              <code>null</code> does not mean the absence of a value. It is analogous to <code>null</code> in
+              JavaScript, <code>None</code> in Python, <code>null</code> in Java and <code>nil</code> in Ruby
+              programming languages. It can be used as part of a <code>oneOf</code> declaration, where it is used to
+              indicate, that the data can also be <code>null</code>.
+            </p>
+          </section>
         </section>
 
         <section id="sec-security-vocabulary-definition">
@@ -1692,229 +2647,713 @@
           </p>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>SecurityScheme</code></h3><p><p>Metadata describing the configuration of a security
-          mechanism. <span class="rfc2119-assertion" id="td-security-scheme-name">The value assigned to the name
-          <code>scheme</code> MUST be defined within a 
-          <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
-          included in the <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>,
-          either in the standard <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined
-          in <a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD
-          Information Model</a> or in a <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context
-          Extension</a>.</span>
-          </p><p>
-          <span class="rfc2119-assertion" id="td-security-no-secrets">For all security schemes,
-          any keys, passwords, or other sensitive information directly providing access 
-          MUST NOT be stored in the TD and should instead
-          be shared and stored out-of-band via other mechanisms.</span> 
-          The purpose of a TD is to describe how to access a Thing if and only if a Consumer 
-          already has authorization, and is not meant be used to grant that authorization.
-          </p><p>Each security scheme object used in a TD defines a set of requirements to be met before access can be granted.
-          We say a security scheme is <em>satisfied</em> when all its requirements are met.
-          In some cases requirements from multiple security schemes will have to be met before access can be granted.
-          </p><p>
-          Security schemes generally may require additional authentication
-          parameters, such as a password or key.
-          The location of this information is indicated by the
-          value associated with the name <code>in</code>, often in combination with the value associated with <code>name</code>.
-          The value associated with <code>in</code> can take one of the following values:
-          </p>
-          <dl>
-          <dt><code>header</code>:</dt>
-          <dd>The parameter will be given
-            in a header provided by the protocol, with the name of the header
-            provided by the value of <code>name</code>.</dd>
-          <dt><code>query</code>:</dt>
-          <dd>The parameter will be appended to the URI as a query parameter, with the name of the 
-            query parameter provided by <code>name</code>.</dd>
-          <dt><code>body</code>:</dt>
-          <dd>The parameter will be provided in the body of the request payload, with the data schema element  
-            used provided by <code>name</code>.
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer">When used in the context of a 
-            <code>body</code> security information location, the value of <code>name</code> 
-            MUST be in the form of a JSON pointer [[!RFC6901]] relative to 
-            the root of the input <code>DataSchema</code> for each interaction it is used with.</span> 
-            Since this value is not a fragment identifier, and is not relative to the root of the TD but
-            to whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
-            it is a "pure" JSON pointer.
-            Since this value is not a fragment identifier, it also does not
-            need to URL-encode special characters.
-            The targeted element may or may not already exist at the specified location in the referenced object or array schema (consequently the mechanism is not applicable to simple types).
-            If it does not, it will be inserted. This avoids having to duplicate definitions in the data schemas of
-            every interaction.
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-creatable">When an element
-            of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
-            does not already exist in the indicated schema, it MUST
-            be possible to insert the indicated element
-            at the location indicated by the pointer.</span>
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-array">The JSON pointer
-            used in the <code>body</code> locator MAY
-            use the "<code>-</code>" character to indicate a non-existent array element when 
-            it is necessary to insert an element after the last element of an existing array.
-            </span>
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-type">The element referenced
-            (or created) by a 
-            <code>body</code> security information location
-            MUST be required and of type "<code>string</code>".</span> 
-            If <code>name</code> is not given, it is assumed the entire body
-            is to be used as the security parameter.
-          </dd>
-          <dt><code>cookie</code>:</dt>
-          <dd>The parameter is stored in a cookie identified by the value of   
-            <code>name</code>.
-          </dd>
-          <dt><code>uri</code>:</dt>
-          <dd>The parameter is embedded in the URI itself, which is encoded in the
-          relevant interaction using a URI template variable defined by the value of <code>name</code>.
-          This is more general than the <code>query</code> mechanism but more complex. 
-          <span class="rfc2119-assertion" id="td-security-in-query-over-uri">The value <code>uri</code> 
-          SHOULD be specified 
-          for the name <code>in</code> in a security scheme only if
-          <code>query</code> is not applicable.</span>  
-          <span class="rfc2119-assertion" id="td-security-in-uri-variable">The URIs provided
-          in interactions where a security scheme using <code>uri</code> as the value for <code>in</code>
-          MUST be a URI template including the defined variable.
-          </span>  
-          </dd>
-          <dt><code>auto</code>:</dt>
-          <dd>The location is determined as part of the protocol, or negotiated. 
-          <span class="rfc2119-assertion" id="td-security-security-vocab-auto-in-no-name">If a value of <code>auto</code> 
-          is set for the <code>in</code> field of a <code>SecurityScheme</code>, 
-          then the <code>name</code> field SHOULD NOT be set.</span> 
-          In this case, the application of the <code>SecurityScheme</code> is subject to 
-          the respective specification for the given protocol (e.g. [[!RFC8288]] when using the 
-          <code>BasicSecurityScheme</code> with HTTP).
-          </dd>
-          </dl>
-          <p>
-          If multiple parameters are needed for a security scheme, repeat the security scheme definition for
-          each parameter and combine them using a <code>combo</code> security scheme and <code>allOf</code>.
-          In some cases parameters may not actually be secret but a user may wish to leave them
-          out of the TD to help protect privacy.  As an example of this, some security mechanisms
-          require both a client identifier and a secret key.  In theory, the client identifier is 
-          public however it may be hard to update and pose a tracking risk.  In such a case it can
-          be provided as an additional security parameter so it does not appear in the TD.
-          </p><p>
-          <span class="rfc2119-assertion" id="td-security-uri-variables-distinct">The names of URI variables 
-          declared in a <code>SecurityScheme</code> 
-          MUST be distinct from all other URI variables 
-          declared in the TD.</span></p><table class="def numbered"><caption>Vocabulary Terms in SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme"><td><code>proxy</code></td><td>URI of the proxy server this security
-                configuration provides access to. If not given, the
-                corresponding security configuration is for the
-                endpoint.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme"><td><code>scheme</code></td><td>Identification of the security mechanism being
-                configured.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>nosec</code>, <code>combo</code>, <code>basic</code>, <code>digest</code>, <code>bearer</code>, <code>psk</code>, <code>oauth2</code>, <code>apikey</code>, or <code>auto</code>)</td></tr></tbody></table><p>The class <code>SecurityScheme</code> has the following subclasses:</p><ul><li><a href="#nosecurityscheme"><code>NoSecurityScheme</code></a></li>
-<li><a href="#autosecurityscheme"><code>AutoSecurityScheme</code></a></li>
-<li><a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a></li>
-<li><a href="#basicsecurityscheme"><code>BasicSecurityScheme</code></a></li>
-<li><a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a></li>
-<li><a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a></li>
-<li><a href="#bearersecurityscheme"><code>BearerSecurityScheme</code></a></li>
-<li><a href="#psksecurityscheme"><code>PSKSecurityScheme</code></a></li>
-<li><a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a></li></ul></section>
-<section><h3><code>NoSecurityScheme</code></h3><p>A security configuration corresponding to identified
-          by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-          <code>nosec</code> (i.e., <code>"scheme":
-          "nosec"</code>), indicating there is no authentication or
-          other mechanism required to access the resource.</p></section>
-<section><h3><code>AutoSecurityScheme</code></h3><p>An automatic authentication security configuration identified by the term <code>auto</code> (i.e., <code>"scheme": "auto"</code>). This scheme indicates that the security parameters are going to be negotiated by the underlying protocols at runtime, subject to the respective specifications for the protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).</p></section>
-<section><h3><code>ComboSecurityScheme</code></h3><p>A combination of other security schemes identified by the <a>Vocabulary Term</a> <code>combo</code> (i.e., <code>"scheme": "combo"</code>).  Elements of this scheme define various ways in which other named schemes defined in <code>securityDefinitions</code>, including other <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> definitions, are to be combined to create a new scheme definition.  <span class="rfc2119-assertion" id="td-security-combo-exclusive-oneof-or-allof">Exactly one of either <code>oneOf</code> or <code>allOf</code> <i>vocabulary terms</i> MUST be included.</span> <!-- Redundant, table states "two or more" already <scan class="rfc2119-assertion">The array given as a value associated with either <code>oneOf</code> or <code>allOf</code> MUST have at least two elements.</scan> --> Only security scheme definitions which can be used together can be combined with <code>allOf</code>.  For example, it is not possible in general to combine different OAuth 2.0 flows together using <code>allOf</code> unless one applies to a proxy and one to the endpoint.  Note that when multiple named security scheme definitions are listed in a <code>security</code> field the same semantics apply as in an <code>allOf</code> combination (and the same limitations on allowable combinations).  The <code>oneOf</code> combination is equivalent to using different security schemes on forms that are otherwise identical.  In this sense a <code>oneOf</code> scheme is not an essential feature but it does avoid redundancy in such cases.</p><table class="def numbered"><caption>Vocabulary Terms in ComboSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-oneOf--ComboSecurityScheme"><td><code>oneOf</code></td><td>Array of two or more strings identifying other named security scheme definitions, any one of which, when satisfied, will allow access.  Only one may be chosen for use.</td><td>mandatory</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-allOf--ComboSecurityScheme"><td><code>allOf</code></td><td>Array of two or more strings identifying other named security scheme definitions, all of which must be satisfied for access.</td><td>mandatory</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><!-- <p class="ednote" title="Recursive Use">The 
-<a href="#combosecurityscheme">ComboSecurityScheme</a> may be applied recursively to generate Boolean expressions for combinations of security schemes. One use case for this is when multiple security schemes are needed for a proxy in combination with multiple security schemes for an endpoint.  Suppose for example a proxy accepts either schemes A or B, and then the endpoint accepts either C or D.  Then the possible combinations are AC, AD, BC, and BD.  These could be expressed directly at the <code>Form</code> level but would require four-fold redundancy.  Instead, three <code>combo</code> nodes can be used to combine the four leaf schemes in the correct way into a single scheme.  It is not clear however if other use cases exist for deeper expression trees and if not, we may consider limiting the recursion depth to two.</p>--></section>
-<section><h3><code>BasicSecurityScheme</code></h3><p>Basic Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7617" title="The 'Basic' HTTP Authentication Scheme">RFC7617</a></cite>]
-          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>basic</code> (i.e.,
-          <code>"scheme": "basic"</code>), using an unencrypted
-          username and password.</p><table class="def numbered"><caption>Vocabulary Terms in BasicSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr></tbody></table></section>
-<section><h3><code>DigestSecurityScheme</code></h3><p>Digest Access Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication">RFC7616</a></cite>]
-          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>digest</code> (i.e.,
-          <code>"scheme": "digest"</code>). This scheme is similar
-          to basic authentication but with added features to avoid
-          man-in-the-middle attacks.</p><table class="def numbered"><caption>Vocabulary Terms in DigestSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme"><td><code>qop</code></td><td>Quality of protection.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>auth</code>, or <code>auth-int</code>)</td></tr></tbody></table></section>
-<section><h3><code>APIKeySecurityScheme</code></h3><p>API key authentication security configuration
-          identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-          <code>apikey</code> (i.e., <code>"scheme":
-          "apikey"</code>). 
-          This scheme is to be used when the access token is opaque,
-          for example when a key in an unknown or proprietary format is provided by a cloud service provider.
-          In this case the key may not be using a standard token format.
-          This scheme indicates that the key provided by the service provider 
-          needs to be supplied as part 
-          of service requests using the mechanism indicated by the <code>"in"</code> field.</p><table class="def numbered"><caption>Vocabulary Terms in APIKeySecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, <code>uri</code>, or <code>auto</code>)</td></tr></tbody></table></section>
-<section><h3><code>BearerSecurityScheme</code></h3><p>Bearer Token [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6750" title="The OAuth 2.0 Authorization Framework: Bearer Token Usage">RFC6750</a></cite>]
-          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>bearer</code> (i.e.,
-          <code>"scheme": "bearer"</code>) for situations where
-          bearer tokens are used independently of OAuth2. If the
-          <code>oauth2</code> scheme is specified it is not
-          generally necessary to specify this scheme as well as it
-          is implied. For <code>format</code>, the value
-          <code>jwt</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>],
-          <code>jws</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7797" title="JSON Web Signature (JWS) Unencoded Payload Option">RFC7797</a></cite>],
-          <code>cwt</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)">RFC8392</a></cite>], and
-          <code>jwe</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>], with
-          values for <code>alg</code> interpreted consistently with
-          those standards. <span class="rfc2119-assertion" id="td-security-bearer-format-extensions">Other formats and
-          algorithms for bearer tokens MAY be specified in vocabulary
-          extensions</span>.</p><table class="def numbered"><caption>Vocabulary Terms in BearerSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme"><td><code>alg</code></td><td>Encoding, encryption, or digest algorithm.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>ES256</code>, or <code>ES512-256</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme"><td><code>format</code></td><td>Specifies format of security authentication
-                 information.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)</td></tr></tbody></table></section>
-<section><h3><code>PSKSecurityScheme</code></h3><p>Pre-shared key authentication security configuration
-          identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-          <code>psk</code> (i.e., <code>"scheme":
-          "psk"</code>).
-          This is meant to identify that a standard is used for pre-shared keys such as TLS-PSK [[RFC4279]], 
-          and that the ciphersuite used for keys will be established during protocol negotiation.</p><table class="def numbered"><caption>Vocabulary Terms in PSKSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-identity--PSKSecurityScheme"><td><code>identity</code></td><td>Identifier providing information which can be
-                   used for selection or confirmation.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>OAuth2SecurityScheme</code></h3><p>OAuth 2.0 authentication security configuration
-            for systems conformant with [[!RFC6749]] and [[!RFC8252]], <!-- and
-            (for the <code>device</code> flow) [[!RFC8628]],--> identified
-            by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e.,
-            <code>"scheme": "oauth2"</code>).</p><table class="def numbered"><caption>Vocabulary Terms in OAuth2SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.<!-- In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]. --></td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme"><td><code>token</code></td><td>URI of the token server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme"><td><code>refresh</code></td><td>URI of the refresh server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided
-                as an array. These are provided in tokens returned
-                by an authorization server and associated with
-                forms in order to identify what resources a client
-                may access and how. The values associated with a
-                form SHOULD be chosen from those defined in an
-                <code>OAuth2SecurityScheme</code> active on that
-                form.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme"><td><code>flow</code></td><td>Authorization flow.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>code</code>, or <code>client</code>)</td></tr></tbody></table><p><span class="rfc2119-assertion" id="td-security-oauth2-code-flow">For
-            the <code>code</code> flow both <code>authorization</code> and <code>token</code> <a>vocabulary terms</a>
-            MUST be included.</span> <span class="rfc2119-assertion" id="td-security-oauth2-client-flow">For
-            the <code>client</code> flow <code>token</code> <a>vocabulary term</a> MUST be included.</span>
-            <span class="rfc2119-assertion" id="td-security-oauth2-client-flow-no-auth">For the
-            <code>client</code> flow <code>authorization</code> <a>vocabulary term</a> MUST NOT be included.</span>
-            <!-- <span class="rfc2119-assertion" id="td-security-oauth2-device-flow">For the
+          <section>
+            <h3><code>SecurityScheme</code></h3>
+            <p></p>
+            <p>
+              Metadata describing the configuration of a security mechanism.
+              <span class="rfc2119-assertion" id="td-security-scheme-name"
+                >The value assigned to the name <code>scheme</code> MUST be defined within a
+                <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
+                included in the
+                <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>, either
+                in the standard
+                <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined in
+                <a href="#sec-vocabulary-definition" class="sec-ref"
+                  >§&nbsp;<bdi class="secno">5.</bdi> TD Information Model</a
+                >
+                or in a
+                <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>.</span
+              >
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-security-no-secrets"
+                >For all security schemes, any keys, passwords, or other sensitive information directly providing access
+                MUST NOT be stored in the TD and should instead be shared and stored out-of-band via other
+                mechanisms.</span
+              >
+              The purpose of a TD is to describe how to access a Thing if and only if a Consumer already has
+              authorization, and is not meant be used to grant that authorization.
+            </p>
+            <p>
+              Each security scheme object used in a TD defines a set of requirements to be met before access can be
+              granted. We say a security scheme is <em>satisfied</em> when all its requirements are met. In some cases
+              requirements from multiple security schemes will have to be met before access can be granted.
+            </p>
+            <p>
+              Security schemes generally may require additional authentication parameters, such as a password or key.
+              The location of this information is indicated by the value associated with the name <code>in</code>, often
+              in combination with the value associated with <code>name</code>. The value associated with
+              <code>in</code> can take one of the following values:
+            </p>
+            <dl>
+              <dt><code>header</code>:</dt>
+              <dd>
+                The parameter will be given in a header provided by the protocol, with the name of the header provided
+                by the value of <code>name</code>.
+              </dd>
+              <dt><code>query</code>:</dt>
+              <dd>
+                The parameter will be appended to the URI as a query parameter, with the name of the query parameter
+                provided by <code>name</code>.
+              </dd>
+              <dt><code>body</code>:</dt>
+              <dd>
+                The parameter will be provided in the body of the request payload, with the data schema element used
+                provided by <code>name</code>.
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer"
+                  >When used in the context of a <code>body</code> security information location, the value of
+                  <code>name</code> MUST be in the form of a JSON pointer [[!RFC6901]] relative to the root of the input
+                  <code>DataSchema</code> for each interaction it is used with.</span
+                >
+                Since this value is not a fragment identifier, and is not relative to the root of the TD but to
+                whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
+                it is a "pure" JSON pointer. Since this value is not a fragment identifier, it also does not need to
+                URL-encode special characters. The targeted element may or may not already exist at the specified
+                location in the referenced object or array schema (consequently the mechanism is not applicable to
+                simple types). If it does not, it will be inserted. This avoids having to duplicate definitions in the
+                data schemas of every interaction.
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-creatable"
+                  >When an element of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
+                  does not already exist in the indicated schema, it MUST be possible to insert the indicated element at
+                  the location indicated by the pointer.</span
+                >
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-array"
+                  >The JSON pointer used in the <code>body</code> locator MAY use the "<code>-</code>" character to
+                  indicate a non-existent array element when it is necessary to insert an element after the last element
+                  of an existing array.
+                </span>
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-type"
+                  >The element referenced (or created) by a <code>body</code> security information location MUST be
+                  required and of type "<code>string</code>".</span
+                >
+                If <code>name</code> is not given, it is assumed the entire body is to be used as the security
+                parameter.
+              </dd>
+              <dt><code>cookie</code>:</dt>
+              <dd>The parameter is stored in a cookie identified by the value of <code>name</code>.</dd>
+              <dt><code>uri</code>:</dt>
+              <dd>
+                The parameter is embedded in the URI itself, which is encoded in the relevant interaction using a URI
+                template variable defined by the value of <code>name</code>. This is more general than the
+                <code>query</code> mechanism but more complex.
+                <span class="rfc2119-assertion" id="td-security-in-query-over-uri"
+                  >The value <code>uri</code> SHOULD be specified for the name <code>in</code> in a security scheme only
+                  if <code>query</code> is not applicable.</span
+                >
+                <span class="rfc2119-assertion" id="td-security-in-uri-variable"
+                  >The URIs provided in interactions where a security scheme using <code>uri</code> as the value for
+                  <code>in</code>
+                  MUST be a URI template including the defined variable.
+                </span>
+              </dd>
+              <dt><code>auto</code>:</dt>
+              <dd>
+                The location is determined as part of the protocol, or negotiated.
+                <span class="rfc2119-assertion" id="td-security-security-vocab-auto-in-no-name"
+                  >If a value of <code>auto</code> is set for the <code>in</code> field of a
+                  <code>SecurityScheme</code>, then the <code>name</code> field SHOULD NOT be set.</span
+                >
+                In this case, the application of the <code>SecurityScheme</code> is subject to the respective
+                specification for the given protocol (e.g. [[!RFC8288]] when using the
+                <code>BasicSecurityScheme</code> with HTTP).
+              </dd>
+            </dl>
+            <p>
+              If multiple parameters are needed for a security scheme, repeat the security scheme definition for each
+              parameter and combine them using a <code>combo</code> security scheme and <code>allOf</code>. In some
+              cases parameters may not actually be secret but a user may wish to leave them out of the TD to help
+              protect privacy. As an example of this, some security mechanisms require both a client identifier and a
+              secret key. In theory, the client identifier is public however it may be hard to update and pose a
+              tracking risk. In such a case it can be provided as an additional security parameter so it does not appear
+              in the TD.
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-security-uri-variables-distinct"
+                >The names of URI variables declared in a <code>SecurityScheme</code> MUST be distinct from all other
+                URI variables declared in the TD.</span
+              >
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in SecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme">
+                  <td><code>proxy</code></td>
+                  <td>
+                    URI of the proxy server this security configuration provides access to. If not given, the
+                    corresponding security configuration is for the endpoint.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme">
+                  <td><code>scheme</code></td>
+                  <td>Identification of the security mechanism being configured.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>nosec</code>, <code>combo</code>, <code>basic</code>, <code>digest</code>,
+                    <code>bearer</code>, <code>psk</code>, <code>oauth2</code>, <code>apikey</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>The class <code>SecurityScheme</code> has the following subclasses:</p>
+            <ul>
+              <li>
+                <a href="#nosecurityscheme"><code>NoSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#autosecurityscheme"><code>AutoSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#basicsecurityscheme"><code>BasicSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#bearersecurityscheme"><code>BearerSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#psksecurityscheme"><code>PSKSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a>
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3><code>NoSecurityScheme</code></h3>
+            <p>
+              A security configuration corresponding to identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>nosec</code> (i.e., <code>"scheme": "nosec"</code>), indicating there is no authentication or other
+              mechanism required to access the resource.
+            </p>
+          </section>
+          <section>
+            <h3><code>AutoSecurityScheme</code></h3>
+            <p>
+              An automatic authentication security configuration identified by the term <code>auto</code> (i.e.,
+              <code>"scheme": "auto"</code>). This scheme indicates that the security parameters are going to be
+              negotiated by the underlying protocols at runtime, subject to the respective specifications for the
+              protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).
+            </p>
+          </section>
+          <section>
+            <h3><code>ComboSecurityScheme</code></h3>
+            <p>
+              A combination of other security schemes identified by the <a>Vocabulary Term</a> <code>combo</code> (i.e.,
+              <code>"scheme": "combo"</code>). Elements of this scheme define various ways in which other named schemes
+              defined in <code>securityDefinitions</code>, including other
+              <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> definitions, are to be combined to
+              create a new scheme definition.
+              <span class="rfc2119-assertion" id="td-security-combo-exclusive-oneof-or-allof"
+                >Exactly one of either <code>oneOf</code> or <code>allOf</code> <i>vocabulary terms</i> MUST be
+                included.</span
+              >
+              <!-- Redundant, table states "two or more" already <scan class="rfc2119-assertion">The array given as a value associated with either <code>oneOf</code> or <code>allOf</code> MUST have at least two elements.</scan> -->
+              Only security scheme definitions which can be used together can be combined with <code>allOf</code>. For
+              example, it is not possible in general to combine different OAuth 2.0 flows together using
+              <code>allOf</code> unless one applies to a proxy and one to the endpoint. Note that when multiple named
+              security scheme definitions are listed in a <code>security</code> field the same semantics apply as in an
+              <code>allOf</code> combination (and the same limitations on allowable combinations). The
+              <code>oneOf</code> combination is equivalent to using different security schemes on forms that are
+              otherwise identical. In this sense a <code>oneOf</code> scheme is not an essential feature but it does
+              avoid redundancy in such cases.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ComboSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--ComboSecurityScheme">
+                  <td><code>oneOf</code></td>
+                  <td>
+                    Array of two or more strings identifying other named security scheme definitions, any one of which,
+                    when satisfied, will allow access. Only one may be chosen for use.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-allOf--ComboSecurityScheme">
+                  <td><code>allOf</code></td>
+                  <td>
+                    Array of two or more strings identifying other named security scheme definitions, all of which must
+                    be satisfied for access.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <!-- <p class="ednote" title="Recursive Use">The 
+<a href="#combosecurityscheme">ComboSecurityScheme</a> may be applied recursively to generate Boolean expressions for combinations of security schemes. One use case for this is when multiple security schemes are needed for a proxy in combination with multiple security schemes for an endpoint.  Suppose for example a proxy accepts either schemes A or B, and then the endpoint accepts either C or D.  Then the possible combinations are AC, AD, BC, and BD.  These could be expressed directly at the <code>Form</code> level but would require four-fold redundancy.  Instead, three <code>combo</code> nodes can be used to combine the four leaf schemes in the correct way into a single scheme.  It is not clear however if other use cases exist for deeper expression trees and if not, we may consider limiting the recursion depth to two.</p>-->
+          </section>
+          <section>
+            <h3><code>BasicSecurityScheme</code></h3>
+            <p>
+              Basic Authentication [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-rfc7617"
+                  title="The 'Basic' HTTP Authentication Scheme"
+                  >RFC7617</a
+                ></cite
+              >] security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>basic</code> (i.e., <code>"scheme": "basic"</code>), using an unencrypted username and password.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in BasicSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>DigestSecurityScheme</code></h3>
+            <p>
+              Digest Access Authentication [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication"
+                  >RFC7616</a
+                ></cite
+              >] security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>digest</code> (i.e., <code>"scheme": "digest"</code>). This scheme is similar to basic
+              authentication but with added features to avoid man-in-the-middle attacks.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in DigestSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme">
+                  <td><code>qop</code></td>
+                  <td>Quality of protection.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>auth</code>, or <code>auth-int</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>APIKeySecurityScheme</code></h3>
+            <p>
+              API key authentication security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>apikey</code> (i.e., <code>"scheme": "apikey"</code>). This scheme is to be used when the access
+              token is opaque, for example when a key in an unknown or proprietary format is provided by a cloud service
+              provider. In this case the key may not be using a standard token format. This scheme indicates that the
+              key provided by the service provider needs to be supplied as part of service requests using the mechanism
+              indicated by the <code>"in"</code> field.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in APIKeySecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>,
+                    <code>uri</code>, or <code>auto</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>BearerSecurityScheme</code></h3>
+            <p>
+              Bearer Token [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-rfc6750"
+                  title="The OAuth 2.0 Authorization Framework: Bearer Token Usage"
+                  >RFC6750</a
+                ></cite
+              >] security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>bearer</code> (i.e., <code>"scheme": "bearer"</code>) for situations where bearer tokens are used
+              independently of OAuth2. If the <code>oauth2</code> scheme is specified it is not generally necessary to
+              specify this scheme as well as it is implied. For <code>format</code>, the value
+              <code>jwt</code> indicates conformance with [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)"
+                  >RFC7519</a
+                ></cite
+              >], <code>jws</code> indicates conformance with [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-rfc7797"
+                  title="JSON Web Signature (JWS) Unencoded Payload Option"
+                  >RFC7797</a
+                ></cite
+              >], <code>cwt</code> indicates conformance with [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)"
+                  >RFC8392</a
+                ></cite
+              >], and <code>jwe</code> indicates conformance with [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)"
+                  >RFC7516</a
+                ></cite
+              >], with values for <code>alg</code> interpreted consistently with those standards.
+              <span class="rfc2119-assertion" id="td-security-bearer-format-extensions"
+                >Other formats and algorithms for bearer tokens MAY be specified in vocabulary extensions</span
+              >.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in BearerSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme">
+                  <td><code>authorization</code></td>
+                  <td>URI of the authorization server.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme">
+                  <td><code>alg</code></td>
+                  <td>Encoding, encryption, or digest algorithm.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>ES256</code>, or <code>ES512-256</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme">
+                  <td><code>format</code></td>
+                  <td>Specifies format of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>PSKSecurityScheme</code></h3>
+            <p>
+              Pre-shared key authentication security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>psk</code> (i.e., <code>"scheme": "psk"</code>). This is meant to identify that a standard is used
+              for pre-shared keys such as TLS-PSK [[RFC4279]], and that the ciphersuite used for keys will be
+              established during protocol negotiation.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in PSKSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-identity--PSKSecurityScheme">
+                  <td><code>identity</code></td>
+                  <td>Identifier providing information which can be used for selection or confirmation.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>OAuth2SecurityScheme</code></h3>
+            <p>
+              OAuth 2.0 authentication security configuration for systems conformant with [[!RFC6749]] and [[!RFC8252]],
+              <!-- and
+            (for the <code>device</code> flow) [[!RFC8628]],-->
+              identified by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e., <code>"scheme": "oauth2"</code>).
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in OAuth2SecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme">
+                  <td><code>authorization</code></td>
+                  <td>
+                    URI of the authorization server.<!-- In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]. -->
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme">
+                  <td><code>token</code></td>
+                  <td>URI of the token server.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme">
+                  <td><code>refresh</code></td>
+                  <td>URI of the refresh server.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme">
+                  <td><code>scopes</code></td>
+                  <td>
+                    Set of authorization scope identifiers provided as an array. These are provided in tokens returned
+                    by an authorization server and associated with forms in order to identify what resources a client
+                    may access and how. The values associated with a form SHOULD be chosen from those defined in an
+                    <code>OAuth2SecurityScheme</code> active on that form.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme">
+                  <td><code>flow</code></td>
+                  <td>Authorization flow.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>code</code>, or <code>client</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              <span class="rfc2119-assertion" id="td-security-oauth2-code-flow"
+                >For the <code>code</code> flow both <code>authorization</code> and <code>token</code>
+                <a>vocabulary terms</a> MUST be included.</span
+              >
+              <span class="rfc2119-assertion" id="td-security-oauth2-client-flow"
+                >For the <code>client</code> flow <code>token</code> <a>vocabulary term</a> MUST be included.</span
+              >
+              <span class="rfc2119-assertion" id="td-security-oauth2-client-flow-no-auth"
+                >For the <code>client</code> flow <code>authorization</code> <a>vocabulary term</a> MUST NOT be
+                included.</span
+              >
+              <!-- <span class="rfc2119-assertion" id="td-security-oauth2-device-flow">For the
             <code>device</code> flow both <code>authorization</code> and <code>token</code> <a>vocabulary terms</a>
             MUST be included.</span> In the case of the <code>device</code> flow the value
             provided for <code>authorization</code> <a>vocabulary terms</a> refers to the device authorization endpoint
-            defined in [[!RFC8628]]. --> The mandatory elements for each flow are summarized in the
-            following table:
+            defined in [[!RFC8628]]. -->
+              The mandatory elements for each flow are summarized in the following table:
             </p>
-            <table class="def numbered"> <tr><th>Element</th><th><code>code</code></th><th><code>client</code></th></tr> <tr><td><code>authorization</code></td><td>mandatory</td><td>omit</td><!-- <td>mandatory; refers to device authorization endpoint</td> --></tr> <tr><td><code>token</code></td><td>mandatory</td><td>mandatory</td><!-- <td>mandatory</td> --></tr> <tr><td><code>refresh</code></td><td>optional</td><td>optional</td><!-- <td>optional</td> --></tr> </table>
+            <table class="def numbered">
+              <tr>
+                <th>Element</th>
+                <th><code>code</code></th>
+                <th><code>client</code></th>
+              </tr>
+              <tr>
+                <td><code>authorization</code></td>
+                <td>mandatory</td>
+                <td>omit</td>
+                <!-- <td>mandatory; refers to device authorization endpoint</td> -->
+              </tr>
+              <tr>
+                <td><code>token</code></td>
+                <td>mandatory</td>
+                <td>mandatory</td>
+                <!-- <td>mandatory</td> -->
+              </tr>
+              <tr>
+                <td><code>refresh</code></td>
+                <td>optional</td>
+                <td>optional</td>
+                <!-- <td>optional</td> -->
+              </tr>
+            </table>
             <!-- 
 	    <p class="ednote"> Note that the <code>OAuth2SecurityScheme</code> class definition lists these elements as "optional". 
             In fact whether they are mandatory or not depends on the flow.  The <code>token</code>
@@ -1939,7 +3378,8 @@
             however an alternative design where there is a separate element,
             <code>device_authorization</code>, which MUST be included for the <code>device</code>
             flow (and then the regular authorization endpoint then MUST NOT be used).</p>
-	    --></section>
+	    -->
+          </section>
         </section>
 
         <section id="sec-hypermedia-vocabulary-definition">
@@ -1955,587 +3395,843 @@
           </p>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>Link</code></h3><p>A link can be viewed as a statement of the form
-          "<b><em>link context</em></b> has a <b><em>relation
-          type</em></b> resource at <b><em>link target</em></b>",
-          where the optional <b><em>target attributes</em></b> may
-          further describe the resource.</p><table class="def numbered"><caption>Vocabulary Terms in Link Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Link"><td><code>href</code></td><td>Target IRI of a link or submission target of a
-                form.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-type--Link"><td><code>type</code></td><td>Target attribute providing a hint indicating
-                what the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]
-                of the result of dereferencing the link should
-                be.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-rel--Link"><td><code>rel</code></td><td>A link relation type identifies the semantics
-                of a link.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link"><td><code>anchor</code></td><td>Overrides the link context (by default the
-                Thing itself identified by its <code>id</code>)
-                with the given URI or IRI.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link"><td><code>sizes</code></td><td>Target attribute that specifies one or more sizes for the referenced icon. 
-                    Only applicable for relation type "icon". The value pattern follows 
-                    {Height}x{Width} (e.g., "16x16", "16x16 32x32").</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-hreflang--Link"><td><code>hreflang</code></td><td>The hreflang attribute specifies the language of a linked document. The value of this must be a valid language tag [[BCP47]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><p class="note" title="hreflang type">
-        The <code>hreflang</code> attribute is allowed to be a <code>string</code> or <code>array</code> in this version of the spec. Depending on the result of [[LINKSET-MEDIA-TYPES]] the values of <code>hrefLang</code> can be restricted to <code>array</code> only.
-	</p>
-     <p>Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description
-    is an instance of a specific Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended to reuse existing and established 
-    <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
-    </p>
-        <p>In the following a best practice relation type table is introduced that is recommended to use within WoT <a>Thing Description</a>
-    or <a>Thing Model</a> instances.      
-    </p>
-    <table class="def numbered">
-        <caption>Best practice relation type table</caption>
-        <thead>
-            <tr>
-                <th>Value</th>                
-                <th>Occurrence</th>
-                <th>Explanation</th>
-                <th>Source of value origin</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr >
-                <td>
+          <section>
+            <h3><code>Link</code></h3>
+            <p>
+              A link can be viewed as a statement of the form "<b><em>link context</em></b> has a
+              <b><em>relation type</em></b> resource at <b><em>link target</em></b
+              >", where the optional <b><em>target attributes</em></b> may further describe the resource.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in Link Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-href--Link">
+                  <td><code>href</code></td>
+                  <td>Target IRI of a link or submission target of a form.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-type--Link">
+                  <td><code>type</code></td>
+                  <td>
+                    Target attribute providing a hint indicating what the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >] of the result of dereferencing the link should be.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-rel--Link">
+                  <td><code>rel</code></td>
+                  <td>A link relation type identifies the semantics of a link.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link">
+                  <td><code>anchor</code></td>
+                  <td>
+                    Overrides the link context (by default the Thing itself identified by its <code>id</code>) with the
+                    given URI or IRI.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link">
+                  <td><code>sizes</code></td>
+                  <td>
+                    Target attribute that specifies one or more sizes for the referenced icon. Only applicable for
+                    relation type "icon". The value pattern follows {Height}x{Width} (e.g., "16x16", "16x16 32x32").
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-hreflang--Link">
+                  <td><code>hreflang</code></td>
+                  <td>
+                    The hreflang attribute specifies the language of a linked document. The value of this must be a
+                    valid language tag [[BCP47]].
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="note" title="hreflang type">
+              The <code>hreflang</code> attribute is allowed to be a <code>string</code> or <code>array</code> in this
+              version of the spec. Depending on the result of [[LINKSET-MEDIA-TYPES]] the values of
+              <code>hrefLang</code> can be restricted to <code>array</code> only.
+            </p>
+            <p>
+              Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a
+              Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description is an instance of a specific
+              Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended
+              to reuse existing and established
+              <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
+            </p>
+            <p>
+              In the following a best practice relation type table is introduced that is recommended to use within WoT
+              <a>Thing Description</a> or <a>Thing Model</a> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Best practice relation type table
+              </caption>
+              <thead>
+                <tr>
+                  <th>Value</th>
+                  <th>Occurrence</th>
+                  <th>Explanation</th>
+                  <th>Source of value origin</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
                     <code>icon</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Imports an icon associated to the <a>Thing</a> (e.g., for UI purposes).</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>Imports an icon associated to the <a>Thing</a> (e.g., for UI purposes).</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>service-doc</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Relation to a resource that provide (human-readable) documentation or descriptions.</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>Relation to a resource that provide (human-readable) documentation or descriptions.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>alternate</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Point to alternative representation of the <a>Thing</a> (i.e. RDF-Turtle, human-readable HTML document, ...).</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Point to alternative representation of the <a>Thing</a> (i.e. RDF-Turtle, human-readable HTML
+                    document, ...).
+                  </td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>type</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Indicate that the <a>Thing</a> is an instance of the target resource such as to a <a>Thing Model</a>.</td>
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>
+                    Indicate that the <a>Thing</a> is an instance of the target resource such as to a
+                    <a>Thing Model</a>.
+                  </td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>tm:extends</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Extends an existing definition of the target resource such as a <a>Thing Model</a>. Only applicable for Thing Model definitions.</td>
-                <td>
-                    W3C WoT Thing Model
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>
+                    Extends an existing definition of the target resource such as a <a>Thing Model</a>. Only applicable
+                    for Thing Model definitions.
+                  </td>
+                  <td>W3C WoT Thing Model</td>
+                </tr>
+                <tr>
+                  <td>
                     <code>tm:submodel</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Used to compose one or multiple <a>Thing Models</a>. Only applicable for Thing Model definitions.</td>
-                <td>
-                    W3C WoT Thing Model
-                </td>
-            </tr>                         
-            <tr >
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Used to compose one or multiple <a>Thing Models</a>. Only applicable for Thing Model definitions.
+                  </td>
+                  <td>W3C WoT Thing Model</td>
+                </tr>
+                <tr>
+                  <td>
                     <code>manifest</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Point to the web app manifest of a web application which provides, e.g., a user interface with which a user can interact with the Thing (also see [[APPMANIFEST]]).</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Point to the web app manifest of a web application which provides, e.g., a user interface with which
+                    a user can interact with the Thing (also see [[APPMANIFEST]]).
+                  </td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>proxy-to</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Target resource provide the address of a proxy. Additional security metadata can be provided using the <code>proxy</code> field in a <a href="#securityscheme">SecurityScheme</a>.</td>
-                <td>
-                    W3C WoT Security and WoT Binding Template
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Target resource provide the address of a proxy. Additional security metadata can be provided using
+                    the <code>proxy</code> field in a <a href="#securityscheme">SecurityScheme</a>.
+                  </td>
+                  <td>W3C WoT Security and WoT Binding Template</td>
+                </tr>
+                <tr>
+                  <td>
                     <code>collection</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Points to a collections of <a>Things</a>.</td>
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>Points to a collections of <a>Things</a>.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>item</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Points to a <a>Thing</a> that is member of the current <a>Thing</a> collections.</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>Points to a <a>Thing</a> that is member of the current <a>Thing</a> collections.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>predecessor-version</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Points to a previous <a>Thing Description</a> or <a>Thing Model</a> version.</td>
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>Points to a previous <a>Thing Description</a> or <a>Thing Model</a> version.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>controlledBy</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Refers to a <a>Thing</a> that controls the context <a>Thing</a>.</td>
-                <td>
-                    W3C Thing Description
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    </section>
-<section><h3><code>Form</code></h3><p>A form can be viewed as a statement of "To perform an
-          <b><em>operation type</em></b> operation on <b><em>form
-          context</em></b>, make a <b><em>request method</em></b>
-          request to <b><em>submission target</em></b>" where the
-          optional <b><em>form fields</em></b> may further describe
-          the required request. In Thing Descriptions, the
-          <b><em>form context</em></b> is the surrounding Object,
-          such as Properties, Actions, and Events or the Thing
-          itself for meta-interactions.</p><table class="def numbered"><caption>Vocabulary Terms in Form Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Form"><td><code>href</code></td><td>Target IRI of a link or submission target of a
-                form.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form"><td><code>contentType</code></td><td>Assign a content type based on a media type
-                (e.g., <code>text/plain</code>) and potential
-                parameters (e.g., <code>charset=utf-8</code>) for
-                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form"><td><code>contentCoding</code></td><td>Content coding values indicate an encoding
-                transformation that has been or can be applied to a
-                representation. Content codings are primarily used
-                to allow a representation to be compressed or
-                otherwise usefully transformed without losing the
-                identity of its underlying media type and without
-                loss of information. Examples of content coding
-                include "gzip", "deflate", etc. .</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-security--Form"><td><code>security</code></td><td>Set of security definition names, chosen from
-                those defined in <code>securityDefinitions</code>.
-                These must all be satisfied for access to resources.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided
-                as an array. These are provided in tokens returned
-                by an authorization server and associated with
-                forms in order to identify what resources a client
-                may access and how. The values associated with a
-                form SHOULD be chosen from those defined in an
-                <code>OAuth2SecurityScheme</code> active on that
-                form.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-response--Form"><td><code>response</code></td><td>This optional term can be used if, e.g., the
-                output communication metadata differ from input
-                metadata (e.g., output contentType differ from the
-                input contentType). The response name contains
-                metadata that is only valid for the primary response
-                messages.</td><td>optional</td><td><a href="#expectedresponse"><code>ExpectedResponse</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-additionalResponses--Form"><td><code>additionalResponses</code></td><td>This optional term can be used if additional expected responses
-                are possible, e.g. for error reporting.  Each additional response needs to be 
-                distinguished from others in some way (for example, by specifying
-                a protocol-specific error code), and may also have its own data schema.</td><td>optional</td><td><a>Array</a> of <a href="#additionalexpectedresponse"><code>AdditionalExpectedResponse</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form"><td><code>subprotocol</code></td><td>Indicates the exact mechanism by which an
-                interaction will be accomplished for a given
-                protocol when there are multiple options. For
-                example, for HTTP and Events, it indicates which of
-                several available mechanisms should be used for
-                asynchronous notifications such as long polling
-                (<code>longpoll</code>), WebSub [<cite><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite>]
-                (<code>websub</code>), Server-Sent Events
-                (<code>sse</code>) [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite>] (also known as
-                EventSource). Please note that there is no
-                restriction on the subprotocol selection and other
-                mechanisms can also be announced by this
-                subprotocol term.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-op--Form"><td><code>op</code></td><td>Indicates the semantic intention of performing
-                the operation(s) described by the form. For
-                example, the Property interaction allows get and
-                set operations. The protocol binding may contain a
-                form for the get operation and a different form for
-                the set operation. The op attribute indicates which
-                form is for which and allows the client to select
-                the correct form for the operation required. op can
-                be assigned one or more interaction verb(s) each
-                representing a semantic intention of an
-                operation.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>, <code>unobserveproperty</code>, <code>invokeaction</code>, <code>queryaction</code>, <code>cancelaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>, <code>readallproperties</code>, <code>writeallproperties</code>, <code>readmultipleproperties</code>, <code>writemultipleproperties</code>, <code>observeallproperties</code>, <code>unobserveallproperties</code>, <code>subscribeallevents</code>, <code>unsubscribeallevents</code>, or <code>queryallactions</code>)</td></tr></tbody></table><p>Possible values for the <code>contentCoding</code>
-          property can be found, e.g., in the <a href=
-          "https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
-          IANA HTTP content coding registry</a>.</p>
-          <p>The list of possible operation types of a form is
-          fixed. As of this version of the specification, it only
-          includes the well-known types necessary to implement the
-          WoT interaction model described in [<cite><a class=
-          "bibref" data-link-type="biblio" href=
-          "#bib-wot-architecture11" title=
-          "Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>].
-          Future versions of the standard may extend this list but
-          <span class="rfc2119-assertion" id=
-          "well-known-operation-types-only">operations types
-          MUST be restricted to the values in the
-          table below.</span></p>
-
-        <div id="table-operation-types">
-          <table class="def numbered">
-            <caption>Well-known operation types</caption>
-            <thead>
-              <tr>
-                <th>Operation Type</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>readproperty</td>
-                <td>Identifies the read operation on
-                  Property Affordances to retrieve the
-                  corresponding data.</td>
-              </tr>
-              <tr>
-                <td>writeproperty</td>
-                <td>Identifies the write operation on
-                  Property Affordances to update the
-                  corresponding data.</td>
-              </tr>
-              <tr>
-                <td>observeproperty</td>
-                <td>Identifies the observe operation on
-                  Property Affordances to be notified with
-                  the new data when the Property is
-                  updated.</td>
-              </tr>
-              <tr>
-                <td>unobserveproperty</td>
-                <td>Identifies the unobserve
-                  operation on Property Affordances to stop
-                  the corresponding notifications.</td>
-              </tr>
-              <tr>
-                <td>invokeaction</td>
-                <td>Identifies the invoke operation on
-                  Action Affordances to perform the
-                  corresponding action.</td>
-              </tr>
-              <tr>
-                <td>queryaction</td>
-                <td>Identifies the querying operation on
-                  Action Affordances to get the status of the
-                  corresponding action.</td>
-              </tr>
-              <tr>
-                <td>cancelaction</td>
-                <td>Identifies the cancel operation on
-                  Action Affordances to cancel the ongoing
-                  corresponding action.</td>
-              </tr>
-              <tr>
-                <td>subscribeevent</td>
-                <td>Identifies the subscribe operation
-                  on Event Affordances to be notified by
-                  the Thing when the event occurs.</td>
-              </tr>
-              <tr>
-                <td>unsubscribeevent</td>
-                <td>Identifies the unsubscribe
-                  operation on Event Affordances to stop
-                  the corresponding notifications.</td>
-              </tr>
-              <tr>
-                <td>readallproperties</td>
-                <td>Identifies the readallproperties
-                  operation on a Thing to retrieve the
-                  data of all Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>writeallproperties</td>
-                <td>Identifies the writeallproperties
-                  operation on a Thing to update the
-                  data of all writable Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>readmultipleproperties</td>
-                <td>Identifies the readmultipleproperties
-                  operation on a Thing to retrieve the
-                  data of selected Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>writemultipleproperties</td>
-                <td>Identifies the writemultipleproperties
-                  operation on a Thing to update the
-                  data of selected writable Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>observeallproperties</td>
-                <td>Identifies the observeallproperties operation on
-                  Properties to be notified with new data when any Property is
-                  updated.</td>
-              </tr>
-              <tr>
-                <td>unobserveallproperties</td>
-                <td>Identifies the unobserveallproperties operation on
-                  Properties to stop notifications from all Properties in a 
-                  single interaction.</td>
-              </tr>
-              <tr>
-                <td>queryallactions</td>
-                <td>Identifies the queryallactions operation on a Thing to get the status of
-                 all Actions in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>subscribeallevents</td>
-                <td>Identifies the subscribeallevents operation on Events to subscribe
-                  to notifications from all Events in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>unsubscribeallevents</td>
-                <td>Identifies the unsubscribeallevents operation on Events to unsubscribe
-                  from notifications from all Events in a single interaction.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <p>
-          A <a>Thing Description</a> of a WoT <a>producer</a> may have multiple forms entries with, e.g., different 
-          protocol and/or content types declarations that a <a>Consumer</a> could possibly support. In that case 
-          the Consumer may choose any form entry that works (e.g., the protocol and content type is supported) for them. 
-          When one form is chosen, it is expected that the <a>Consumer</a> will continue to use it as long as possible 
-          for every new interaction with the WoT <a>producer</a>.
-        </p>
-
-        <section id="sec-op-data-schema-mapping" class="informative">
-        <h4>Mapping op Values to Data Schemas</h4>
-
-        <p>
-            Protocols that can be used with TDs follow request-response or eventing mechanisms. 
-            The Data Schema of an affordance generally correlates with the <code>op</code> keywords used in <code>forms</code>.
-            The table below informatively summarizes the available data schema related terms with the <code>op</code> keywords.
-        </p>
-        <ul>
-            <li>Consumer to Thing applies for messages sent by the Consumer to the Thing, such as the value for writing a property.</li>
-            <li>Thing to Consumer applies for messages sent by the Thing to the Consumer, such as the value of a property value as the result of reading a property.</li>
-            <li>In case that there is no correlation with the data schema and the operation, it implies that no payload is required for executing the operation or no 
-            payload is expected as a result of the operation.</li>
-        </ul>
-
-        <table class="def numbered">
-        <caption>Mapping op Values to Data Schemas</caption>
-        <thead>
-            <tr>
-            <th>Operation Type</th>
-            <th>Consumer to Thing DataSchema Correlation</th>
-            <th>Thing to Consumer DataSchema Correlation</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-            <td>readproperty</td>
-            <td>No correlation.</td>
-            <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
-            </tr>
-            <tr>
-            <td>writeproperty</td>
-            <td>All fields in the Property Affordance without <code>"readOnly":true</code>.</td>
-            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-            </tr>
-            <tr>
-            <td>observeproperty</td>
-            <td>No correlation.</td>
-            <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
-            </tr>
-            <tr>
-            <td>unobserveproperty</td>
-            <td>No correlation.</td>
-            <td>No correlation.</td>
-            </tr>
-            <tr>
-            <td>invokeaction</td>
-            <td>Value of the <code>input</code> key.</td>
-            <td>Value of the <code>output</code> key.</td>
-            </tr>
-            <tr>
-            <td>queryaction</td>
-            <td>No correlation.</td>
-            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-            </tr>
-            <tr>
-            <td>cancelaction</td>
-            <td>No correlation.</td>
-            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-            </tr>
-            <tr>
-            <td>subscribeevent</td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code></td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code></td>
-            </tr>
-            <tr>
-            <td>unsubscribeevent</td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code></td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code></td>
-            </tr>
-        </tbody>
-        </table>
-        <p class="note" title="writeproperty and observeproperty relationship">
-            Writing to a property does not necessarily mean that a new value will be sent to the Consumer observing the property. 
-            It depends on the protocol and implementation.
-        </p>
-        <p class="note" title="Further Data Schemas mappings">
-            Further specification of how to map operations to data schemas, as well as mapping meta operations such as <code>readallproperties</code> 
-            can be found in the respective protocol specification of the [[WOT-BINDING-TEMPLATES]].
-        </p>
-        </section>
-
-        <section id="sec-response-usage">
-        <h4>Response-related Terms Usage</h4>
-
-          <p>The optional <code>response</code> name-value pair can
-          be used to provide metadata for the expected response
-          message. 
-          With the core vocabulary, it only includes
-          content type information, but TD Context Extensions could
-          be applied. <span class="rfc2119-assertion" id=
-          "td-expectedResponse-default-contentType">If no
-          <code>response</code> name-value pair is provided, it
-          MUST be assumed
-          that the content type of the response is equal to the
-          content type assigned to the Form instance.</span> Note
-          that <code>contentType</code> within an
-          <code>ExpectedResponse</code> 
-          <a href="#dfn-class" class=
-          "internalDFN" data-link-type="dfn">Class</a> does not
-          have a <a href="#dfn-default-value" class="internalDFN"
-          data-link-type="dfn">Default Value</a>. For instance, if
-          the value of the content type of the form is
-          <code>application/xml</code> the assumed value of the
-          content type of the response will be also
-          <code>application/xml</code>.</p>
-          <p>
-          In some cases additional responses might be possible.
-          One example of this is error responses but in some cases
-          there might also be additional successful responses.
-          In this case, the <code>response</code> name-value pair
-          is still used for the primary response but 
-          <code>additionalResponses</code> may also be provided,
-          whose value is an array of <code>AdditionalExpectedResponse</code>
-          objects.
-          Each additional response must be distinguished in some way from the primary
-          response, either by <code>contentType</code> or by
-          protocol-specific settings such as error code header values.
-          Each additional response may also have a data schema
-          which can differ from the normal output data schema for the
-          interaction.  
-          </p>
-          <p>In some use cases, input and output data might be
-          represented in a different form, for instance an Action
-          that accepts JSON, but returns an image. In such a case,
-          the optional <code>response</code> name-value pair can
-          describe the content type of the expected response.
-          <span class="rfc2119-assertion" id=
-          "td-expectedResponse-contentType">If the content type of
-          the expected response differs from the content type of
-          the form, the <code>Form</code> instance <em class=
-          "rfc2119" title="MUST">MUST</em> include a name-value
-          pair with the name <code>response</code>.</span> 
-          For instance, an <code>ActionAffordance</code> could only
-          accept <code>application/json</code> for its input data,
-          while it will respond with an <code>image/jpeg</code>
-          content type for its output data. In that case the
-          content types differ and the <code>response</code>
-          name-value pair has to be used to provide response
-          content type (<code>image/jpeg</code>) information to the
-          <a href="#dfn-consumer" class="internalDFN"
-          data-link-type="dfn">Consumer</a>.</p>
-          <p>
-          Similar considerations apply to additional responses,
-          although in this case the <code>contentType</code> is optional
-          if it is the same as the input content Type (e.g. JSON).
-          <span class="rfc2119-assertion" id=
-          "td-additionalExpectedResponse-contentType">If the content type of
-          an additional expected response differs from the content type of
-          the form, the <code>Form</code> instance <em class=
-          "rfc2119" title="MUST">MUST</em> include an entry in the array
-          associated with the name <code>additionalResponses</code>
-          that includes a value for the name <code>contentType</code>.</span> 
-          <span class="rfc2119-assertion" id=
-          "td-additionalExpectedResponse-schema">If the data schema of
-          an additional expected response differs from the output data schema of
-          the interaction, the <code>Form</code> instance <em class=
-          "rfc2119" title="MUST">MUST</em> include an entry in the array
-          associated with the name <code>additionalResponses</code> that
-          includes a value for the name <code>schema</code>.</span> 
-          </p>
-          <p>
-            The different cases on the variation of request and response are explained above.
-            The tables at <a href="#contentType-usage"></a> summarize these cases in a concise manner.
-          </p>
+                  </td>
+                  <td>0..*</td>
+                  <td>Refers to a <a>Thing</a> that controls the context <a>Thing</a>.</td>
+                  <td>W3C Thing Description</td>
+                </tr>
+              </tbody>
+            </table>
           </section>
+          <section>
+            <h3><code>Form</code></h3>
+            <p>
+              A form can be viewed as a statement of "To perform an <b><em>operation type</em></b> operation on
+              <b><em>form context</em></b
+              >, make a <b><em>request method</em></b> request to <b><em>submission target</em></b
+              >" where the optional <b><em>form fields</em></b> may further describe the required request. In Thing
+              Descriptions, the <b><em>form context</em></b> is the surrounding Object, such as Properties, Actions, and
+              Events or the Thing itself for meta-interactions.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in Form Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-href--Form">
+                  <td><code>href</code></td>
+                  <td>Target IRI of a link or submission target of a form.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form">
+                  <td><code>contentType</code></td>
+                  <td>
+                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
+                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >].
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form">
+                  <td><code>contentCoding</code></td>
+                  <td>
+                    Content coding values indicate an encoding transformation that has been or can be applied to a
+                    representation. Content codings are primarily used to allow a representation to be compressed or
+                    otherwise usefully transformed without losing the identity of its underlying media type and without
+                    loss of information. Examples of content coding include "gzip", "deflate", etc. .
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-security--Form">
+                  <td><code>security</code></td>
+                  <td>
+                    Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.
+                    These must all be satisfied for access to resources.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form">
+                  <td><code>scopes</code></td>
+                  <td>
+                    Set of authorization scope identifiers provided as an array. These are provided in tokens returned
+                    by an authorization server and associated with forms in order to identify what resources a client
+                    may access and how. The values associated with a form SHOULD be chosen from those defined in an
+                    <code>OAuth2SecurityScheme</code> active on that form.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-response--Form">
+                  <td><code>response</code></td>
+                  <td>
+                    This optional term can be used if, e.g., the output communication metadata differ from input
+                    metadata (e.g., output contentType differ from the input contentType). The response name contains
+                    metadata that is only valid for the primary response messages.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#expectedresponse"><code>ExpectedResponse</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-additionalResponses--Form">
+                  <td><code>additionalResponses</code></td>
+                  <td>
+                    This optional term can be used if additional expected responses are possible, e.g. for error
+                    reporting. Each additional response needs to be distinguished from others in some way (for example,
+                    by specifying a protocol-specific error code), and may also have its own data schema.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#additionalexpectedresponse"><code>AdditionalExpectedResponse</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form">
+                  <td><code>subprotocol</code></td>
+                  <td>
+                    Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when
+                    there are multiple options. For example, for HTTP and Events, it indicates which of several
+                    available mechanisms should be used for asynchronous notifications such as long polling
+                    (<code>longpoll</code>), WebSub [<cite
+                      ><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite
+                    >] (<code>websub</code>), Server-Sent Events (<code>sse</code>) [<cite
+                      ><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite
+                    >] (also known as EventSource). Please note that there is no restriction on the subprotocol
+                    selection and other mechanisms can also be announced by this subprotocol term.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-op--Form">
+                  <td><code>op</code></td>
+                  <td>
+                    Indicates the semantic intention of performing the operation(s) described by the form. For example,
+                    the Property interaction allows get and set operations. The protocol binding may contain a form for
+                    the get operation and a different form for the set operation. The op attribute indicates which form
+                    is for which and allows the client to select the correct form for the operation required. op can be
+                    assigned one or more interaction verb(s) each representing a semantic intention of an operation.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>,
+                    <code>unobserveproperty</code>, <code>invokeaction</code>, <code>queryaction</code>,
+                    <code>cancelaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>,
+                    <code>readallproperties</code>, <code>writeallproperties</code>,
+                    <code>readmultipleproperties</code>, <code>writemultipleproperties</code>,
+                    <code>observeallproperties</code>, <code>unobserveallproperties</code>,
+                    <code>subscribeallevents</code>, <code>unsubscribeallevents</code>, or <code>queryallactions</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              Possible values for the <code>contentCoding</code> property can be found, e.g., in the
+              <a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
+                IANA HTTP content coding registry</a
+              >.
+            </p>
+            <p>
+              The list of possible operation types of a form is fixed. As of this version of the specification, it only
+              includes the well-known types necessary to implement the WoT interaction model described in [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-wot-architecture11"
+                  title="Web of Things (WoT) Architecture 1.1"
+                  >wot-architecture11</a
+                ></cite
+              >]. Future versions of the standard may extend this list but
+              <span class="rfc2119-assertion" id="well-known-operation-types-only"
+                >operations types MUST be restricted to the values in the table below.</span
+              >
+            </p>
+
+            <div id="table-operation-types">
+              <table class="def numbered">
+                <caption>
+                  Well-known operation types
+                </caption>
+                <thead>
+                  <tr>
+                    <th>Operation Type</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>readproperty</td>
+                    <td>Identifies the read operation on Property Affordances to retrieve the corresponding data.</td>
+                  </tr>
+                  <tr>
+                    <td>writeproperty</td>
+                    <td>Identifies the write operation on Property Affordances to update the corresponding data.</td>
+                  </tr>
+                  <tr>
+                    <td>observeproperty</td>
+                    <td>
+                      Identifies the observe operation on Property Affordances to be notified with the new data when the
+                      Property is updated.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unobserveproperty</td>
+                    <td>
+                      Identifies the unobserve operation on Property Affordances to stop the corresponding
+                      notifications.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>invokeaction</td>
+                    <td>Identifies the invoke operation on Action Affordances to perform the corresponding action.</td>
+                  </tr>
+                  <tr>
+                    <td>queryaction</td>
+                    <td>
+                      Identifies the querying operation on Action Affordances to get the status of the corresponding
+                      action.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>cancelaction</td>
+                    <td>
+                      Identifies the cancel operation on Action Affordances to cancel the ongoing corresponding action.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>subscribeevent</td>
+                    <td>
+                      Identifies the subscribe operation on Event Affordances to be notified by the Thing when the event
+                      occurs.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unsubscribeevent</td>
+                    <td>
+                      Identifies the unsubscribe operation on Event Affordances to stop the corresponding notifications.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>readallproperties</td>
+                    <td>
+                      Identifies the readallproperties operation on a Thing to retrieve the data of all Properties in a
+                      single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>writeallproperties</td>
+                    <td>
+                      Identifies the writeallproperties operation on a Thing to update the data of all writable
+                      Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>readmultipleproperties</td>
+                    <td>
+                      Identifies the readmultipleproperties operation on a Thing to retrieve the data of selected
+                      Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>writemultipleproperties</td>
+                    <td>
+                      Identifies the writemultipleproperties operation on a Thing to update the data of selected
+                      writable Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>observeallproperties</td>
+                    <td>
+                      Identifies the observeallproperties operation on Properties to be notified with new data when any
+                      Property is updated.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unobserveallproperties</td>
+                    <td>
+                      Identifies the unobserveallproperties operation on Properties to stop notifications from all
+                      Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>queryallactions</td>
+                    <td>
+                      Identifies the queryallactions operation on a Thing to get the status of all Actions in a single
+                      interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>subscribeallevents</td>
+                    <td>
+                      Identifies the subscribeallevents operation on Events to subscribe to notifications from all
+                      Events in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unsubscribeallevents</td>
+                    <td>
+                      Identifies the unsubscribeallevents operation on Events to unsubscribe from notifications from all
+                      Events in a single interaction.
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <p>
+              A <a>Thing Description</a> of a WoT <a>producer</a> may have multiple forms entries with, e.g., different
+              protocol and/or content types declarations that a <a>Consumer</a> could possibly support. In that case the
+              Consumer may choose any form entry that works (e.g., the protocol and content type is supported) for them.
+              When one form is chosen, it is expected that the <a>Consumer</a> will continue to use it as long as
+              possible for every new interaction with the WoT <a>producer</a>.
+            </p>
+
+            <section id="sec-op-data-schema-mapping" class="informative">
+              <h4>Mapping op Values to Data Schemas</h4>
+
+              <p>
+                Protocols that can be used with TDs follow request-response or eventing mechanisms. The Data Schema of
+                an affordance generally correlates with the <code>op</code> keywords used in <code>forms</code>. The
+                table below informatively summarizes the available data schema related terms with the
+                <code>op</code> keywords.
+              </p>
+              <ul>
+                <li>
+                  Consumer to Thing applies for messages sent by the Consumer to the Thing, such as the value for
+                  writing a property.
+                </li>
+                <li>
+                  Thing to Consumer applies for messages sent by the Thing to the Consumer, such as the value of a
+                  property value as the result of reading a property.
+                </li>
+                <li>
+                  In case that there is no correlation with the data schema and the operation, it implies that no
+                  payload is required for executing the operation or no payload is expected as a result of the
+                  operation.
+                </li>
+              </ul>
+
+              <table class="def numbered">
+                <caption>
+                  Mapping op Values to Data Schemas
+                </caption>
+                <thead>
+                  <tr>
+                    <th>Operation Type</th>
+                    <th>Consumer to Thing DataSchema Correlation</th>
+                    <th>Thing to Consumer DataSchema Correlation</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>readproperty</td>
+                    <td>No correlation.</td>
+                    <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
+                  </tr>
+                  <tr>
+                    <td>writeproperty</td>
+                    <td>All fields in the Property Affordance without <code>"readOnly":true</code>.</td>
+                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+                  </tr>
+                  <tr>
+                    <td>observeproperty</td>
+                    <td>No correlation.</td>
+                    <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
+                  </tr>
+                  <tr>
+                    <td>unobserveproperty</td>
+                    <td>No correlation.</td>
+                    <td>No correlation.</td>
+                  </tr>
+                  <tr>
+                    <td>invokeaction</td>
+                    <td>Value of the <code>input</code> key.</td>
+                    <td>Value of the <code>output</code> key.</td>
+                  </tr>
+                  <tr>
+                    <td>queryaction</td>
+                    <td>No correlation.</td>
+                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+                  </tr>
+                  <tr>
+                    <td>cancelaction</td>
+                    <td>No correlation.</td>
+                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+                  </tr>
+                  <tr>
+                    <td>subscribeevent</td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code>
+                    </td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unsubscribeevent</td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code>
+                    </td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <p class="note" title="writeproperty and observeproperty relationship">
+                Writing to a property does not necessarily mean that a new value will be sent to the Consumer observing
+                the property. It depends on the protocol and implementation.
+              </p>
+              <p class="note" title="Further Data Schemas mappings">
+                Further specification of how to map operations to data schemas, as well as mapping meta operations such
+                as <code>readallproperties</code>
+                can be found in the respective protocol specification of the [[WOT-BINDING-TEMPLATES]].
+              </p>
+            </section>
+
+            <section id="sec-response-usage">
+              <h4>Response-related Terms Usage</h4>
+
+              <p>
+                The optional <code>response</code> name-value pair can be used to provide metadata for the expected
+                response message. With the core vocabulary, it only includes content type information, but TD Context
+                Extensions could be applied.
+                <span class="rfc2119-assertion" id="td-expectedResponse-default-contentType"
+                  >If no <code>response</code> name-value pair is provided, it MUST be assumed that the content type of
+                  the response is equal to the content type assigned to the Form instance.</span
+                >
+                Note that <code>contentType</code> within an
+                <code>ExpectedResponse</code>
+                <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> does not have a
+                <a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">Default Value</a>. For instance,
+                if the value of the content type of the form is <code>application/xml</code> the assumed value of the
+                content type of the response will be also <code>application/xml</code>.
+              </p>
+              <p>
+                In some cases additional responses might be possible. One example of this is error responses but in some
+                cases there might also be additional successful responses. In this case, the
+                <code>response</code> name-value pair is still used for the primary response but
+                <code>additionalResponses</code> may also be provided, whose value is an array of
+                <code>AdditionalExpectedResponse</code> objects. Each additional response must be distinguished in some
+                way from the primary response, either by <code>contentType</code> or by protocol-specific settings such
+                as error code header values. Each additional response may also have a data schema which can differ from
+                the normal output data schema for the interaction.
+              </p>
+              <p>
+                In some use cases, input and output data might be represented in a different form, for instance an
+                Action that accepts JSON, but returns an image. In such a case, the optional
+                <code>response</code> name-value pair can describe the content type of the expected response.
+                <span class="rfc2119-assertion" id="td-expectedResponse-contentType"
+                  >If the content type of the expected response differs from the content type of the form, the
+                  <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include a name-value pair with
+                  the name <code>response</code>.</span
+                >
+                For instance, an <code>ActionAffordance</code> could only accept <code>application/json</code> for its
+                input data, while it will respond with an <code>image/jpeg</code> content type for its output data. In
+                that case the content types differ and the <code>response</code>
+                name-value pair has to be used to provide response content type (<code>image/jpeg</code>) information to
+                the
+                <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumer</a>.
+              </p>
+              <p>
+                Similar considerations apply to additional responses, although in this case the
+                <code>contentType</code> is optional if it is the same as the input content Type (e.g. JSON).
+                <span class="rfc2119-assertion" id="td-additionalExpectedResponse-contentType"
+                  >If the content type of an additional expected response differs from the content type of the form, the
+                  <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include an entry in the array
+                  associated with the name <code>additionalResponses</code> that includes a value for the name
+                  <code>contentType</code>.</span
+                >
+                <span class="rfc2119-assertion" id="td-additionalExpectedResponse-schema"
+                  >If the data schema of an additional expected response differs from the output data schema of the
+                  interaction, the <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include an
+                  entry in the array associated with the name <code>additionalResponses</code> that includes a value for
+                  the name <code>schema</code>.</span
+                >
+              </p>
+              <p>
+                The different cases on the variation of request and response are explained above. The tables at
+                <a href="#contentType-usage"></a> summarize these cases in a concise manner.
+              </p>
+            </section>
           </section>
-<section><h3><code>ExpectedResponse</code></h3><p>Communication metadata describing the expected
-          response message for the primary response.</p><table class="def numbered"><caption>Vocabulary Terms in ExpectedResponse Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type
-                (e.g., <code>text/plain</code>) and potential
-                parameters (e.g., <code>charset=utf-8</code>) for
-                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>AdditionalExpectedResponse</code></h3><p>Communication metadata describing the expected
-          response message for additional responses.</p><table class="def numbered"><caption>Vocabulary Terms in AdditionalExpectedResponse Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-success--AdditionalExpectedResponse"><td><code>success</code></td><td>Signals if an additional response should not be considered an error.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentType--AdditionalExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type
-                (e.g., <code>text/plain</code>) and potential
-                parameters (e.g., <code>charset=utf-8</code>) for
-                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-schema--AdditionalExpectedResponse"><td><code>schema</code></td><td>Used to define the output data schema 
-                for an additional response if it differs from the default
-                output data schema. 
-                Rather than a <code>DataSchema</code> object, the
-                name of a previous definition given in a 
-                <code>schemaDefinitions</code> map must be used.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+          <section>
+            <h3><code>ExpectedResponse</code></h3>
+            <p>Communication metadata describing the expected response message for the primary response.</p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ExpectedResponse Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse">
+                  <td><code>contentType</code></td>
+                  <td>
+                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
+                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >].
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>AdditionalExpectedResponse</code></h3>
+            <p>Communication metadata describing the expected response message for additional responses.</p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in AdditionalExpectedResponse Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-success--AdditionalExpectedResponse">
+                  <td><code>success</code></td>
+                  <td>Signals if an additional response should not be considered an error.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--AdditionalExpectedResponse">
+                  <td><code>contentType</code></td>
+                  <td>
+                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
+                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >].
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-schema--AdditionalExpectedResponse">
+                  <td><code>schema</code></td>
+                  <td>
+                    Used to define the output data schema for an additional response if it differs from the default
+                    output data schema. Rather than a <code>DataSchema</code> object, the name of a previous definition
+                    given in a <code>schemaDefinitions</code> map must be used.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
         </section>
       </section>
       <section id="sec-default-values">
@@ -5356,40 +7052,51 @@
 
     <section id="bindings">
       <h2>Bindings</h2>
-        <p>
-          Every message sent from a Consumer to the Thing and back needs to
-          travel over a network protocol, despite the
-          Property&ndash;Action&ndash;Event abstraction provided by WoT.
-          The operations in the Forms level need to be bound to how the message is meant to look, over the network.
-          Thus, every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>.
-          For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can
-          infer that the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific
-          terms in an instance of this form.
-          Furthermore, the payloads described by the <a>Data Schema</a> in the affordance level need to be serialized to the correct payload format.
-          Similar to how operations are bound to protocol messages, the
-       </p>
+      <p>
+        Every message sent from a Consumer to the Thing and back needs to travel over a network protocol, despite the
+        Property&ndash;Action&ndash;Event abstraction provided by WoT. The operations in the Forms level need to be
+        bound to how the message is meant to look, over the network. Thus, every form in a WoT Thing Description needs
+        to have a submission target, given by the <code>href</code> member, as indicated in <a>Form</a>. For instance,
+        if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can infer that the
+        <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific terms in
+        an instance of this form.
+      </p>
 
-        <p>
-          Many network-level protocols, standards and platforms for connected Things have already been developed, and
-          have millions of devices deployed in the field today. These standards are converging on a common set of
-          transport protocols and transfer layers, but each has peculiar content formats, payload schemas, and data
-          types.
-        </p>
-        <p>
-          Despite using unique formats and data models, the high-level interactions exposed by most connected things can
-          be modeled using the Property, Action, and Event interaction affordances of the WoT Thing Description.
-        </p>
-        <p>
-          Binding Templates enable a Thing Description to be adapted to a specific protocol, data payload formats or
-          platforms that combine both in specific ways. This is done through additional descriptive vocabularies, Thing
-          Models and examples that aim to guide the implementors of Things and Consumers alike.
-        </p>
-        <p>
-          This section acts as a base and explains how other binding templates should be designed. Concrete binding
-          templates are then provided in their respective documents, referred to as subspecifications, that are linked
-          to from this document.
-        </p>
-      </section>
+      <p>
+        Furthermore, the payloads described by the <a>Data Schema</a> in the Affordance Level need to be serialized to a
+        data format and sent on the network protocol. Similar to how operations are bound to protocol messages, the
+        <a>Data Schema</a> is bound to a data format indicated by the <code>contentType</code> or protocol-specific
+        terms provided in the <a>Form</a>. From these terms, a <a>Consumer</a> can infer the required serialization
+        method and transform the application-level data to the data to be sent on the network protocol. Similarly, for
+        messages coming from the <a>Thing</a>, the <a>Consumer</a> can deserialize the data and present it to the
+        application level. For example, a <a>Consumer</a> implemented in Python can read
+        <code>application/json</code> as the value of <code>contentType</code> and serialize a Python dictionary data
+        structure into a JSON object.
+      </p>
+
+      <p>
+        The mechanism above are called Bindings in the Web of Things and a specific example is illustrated in
+        [[[#fig-mechanism]]]. Bindings enable a Thing Description to be adapted to a specific protocol, data payload
+        formats or both in specific ways. This is done through URI Schemes, additional descriptive vocabularies, Thing
+        Models and examples that aim to guide the implementors of Things and Consumers alike.
+      </p>
+
+      <figure id="fig-mechanism">
+        <img
+          src="visualization/binding-mechanism.drawio.svg"
+          alt="Binding Templates mechanism with a TD, Thing and Consumer"
+        />
+        <figcaption>
+          Binding Templates Mechanism inside a TD excerpt with messages of its Thing and a Consumer.
+        </figcaption>
+      </figure>
+
+      <p>
+        This section explains the overall mechanism and gives basic guidance on creating new Bindings. The
+        [[WOT-BINDING-REGISTRY]] contains the a registry (list) of existing Bindings as well the requirements to follow
+        to register new entries to the registry.
+      </p>
+
       <section id="binding-introduction">
         <h4>Introduction to Binding Templates</h4>
         <p>
@@ -5436,16 +7143,6 @@
           message that corresponds to its TD. Other protocols, payload formats or their combination are possible and are
           explained in [[[#binding-overview]]].
         </p>
-
-        <figure id="fig-mechanism">
-          <img
-            src="visualization/binding-mechanism.drawio.svg"
-            alt="Binding Templates mechanism with a TD, Thing and Consumer"
-          />
-          <figcaption>
-            Binding Templates Mechanism inside a TD excerpt with messages of its Thing and a Consumer.
-          </figcaption>
-        </figure>
 
         <p class="ednote">
           The editors also recommend reading the related chapters in [[WOT-ARCHITECTURE]], such as

--- a/index.html
+++ b/index.html
@@ -793,9 +793,9 @@
         </dd>
         <dt><dfn id="dfn-binding-instance">Binding Instance</dfn></dt>
         <dd>
-          A binding instance is a form instance in a Thing Description containing a specific binding. For example, an
-          HTTP Binding instance is a <a>Form</a> which has <code>href</code> starting with <code>http://</code> or
-          <code>https://</code>.
+          A binding instance is a form instance in a Thing Description containing a specific binding, implementing a
+          <a>Binding Specification</a>. For example, an HTTP Binding instance is a <a href="#form">Form</a> which has
+          <code>href</code> starting with <code>http://</code> or <code>https://</code>.
         </dd>
       </dl>
 
@@ -2012,8 +2012,8 @@
           <p>
             In a TD, concrete data formats are specified in Forms (see <a href="#form"></a>) using content types. When
             the value of a content type in an instance of the Form is <code>application/json</code>, the data schema can
-            be processed directly by JSON Schema processors. Otherwise, Web of Things (WoT) Binding Templates
-            [[?WOT-BINDING-TEMPLATES]] defines data schema's available mappings to other content types such as XML
+            be processed directly by JSON Schema processors. Otherwise, entries in Web of Things (WoT) Bindings Registry
+            [[?WOT-BINDINGS-REGISTRY]] defines data schema's available mappings to other content types such as XML
             [[?xml]]. If the content type in an instance of the Form is not <code>application/json</code> and if no
             mapping is defined for the content type, specifying a data schema does not make sense for the content type.
           </p>
@@ -6978,9 +6978,9 @@
 
         <p>
           With the <a>TD Context Extensions</a> in a Thing Description, the communication metadata can be supplemented
-          via <a>Bindings</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added through
-          additional <a>Vocabulary Terms</a> serialized into JSON objects representing a <code>Form</code> instance.
-          Please see <a href="#bindings"></a> for further information.
+          via <a>Binding Specifications</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added
+          through additional <a>Vocabulary Terms</a> serialized into JSON objects representing a
+          <code>Form</code> instance. Please see <a href="#bindings"></a> for further information.
         </p>
       </section>
 
@@ -7062,20 +7062,20 @@
         Every message sent from a Consumer to the Thing and back needs to travel over a network protocol, despite the
         Property&ndash;Action&ndash;Event abstraction provided by WoT. The operations in the Forms level need to be
         bound to how the message is meant to look, over the network. Thus, every form in a WoT Thing Description needs
-        to have a submission target, given by the <code>href</code> member, as indicated in <a>Form</a>. For instance,
-        if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can infer that the
-        <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific terms in
-        an instance of this form. See [[[#protocol-bindings]]] for more explanation and examples.
+        to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>.
+        For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can infer
+        that the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific
+        terms in an instance of this form. See [[[#protocol-bindings]]] for more explanation and examples.
       </p>
 
       <p>
         Furthermore, the payloads described by the <a>Data Schema</a> in the Affordance Level need to be serialized to a
         data format and sent on the network protocol. Similar to how operations are bound to protocol messages, the
         <a>Data Schema</a> is bound to a data format indicated by the <code>contentType</code> or protocol-specific
-        terms provided in the <a>Form</a>. From these terms, a <a>Consumer</a> can infer the required serialization
-        method and transform the application-level data to the data to be sent on the network protocol. Similarly, for
-        messages coming from the <a>Thing</a>, the <a>Consumer</a> can deserialize the data and present it to the
-        application level. For example, a <a>Consumer</a> implemented in Python can read
+        terms provided in the <a href="#form">Form</a>. From these terms, a <a>Consumer</a> can infer the required
+        serialization method and transform the application-level data to the data to be sent on the network protocol.
+        Similarly, for messages coming from the <a>Thing</a>, the <a>Consumer</a> can deserialize the data and present
+        it to the application level. For example, a <a>Consumer</a> implemented in Python can read
         <code>application/json</code> as the value of <code>contentType</code> and serialize a Python dictionary data
         structure into a JSON object. See [[[#payload-bindings]]] for more explanation and examples.
       </p>
@@ -7087,7 +7087,7 @@
         and y equals 100. In order to do so, it creates the correct payload, serializes it and sends it using the
         correct protocol options. The Thing gets the message over the network and responds with a message that
         corresponds to its TD. Other protocols, payload formats or their combination are possible and are explained in
-        [[[#binding-overview]]].
+        [[[#binding-mechanisms]]].
       </p>
 
       <figure id="fig-mechanism">
@@ -7115,9 +7115,9 @@
       <figure id="fig-building-block">
         <img
           src="visualization/binding-templates.svg"
-          alt="Platforms, Protocols and Media Types as building blocks for binding templates and TD"
+          alt="Protocols, Media Types and their combinations as building blocks for TDs"
         />
-        <figcaption>Platforms, Protocols and Media Types as building blocks for binding templates and TD</figcaption>
+        <figcaption>Protocols, Media Types and their combinations as building blocks TDs</figcaption>
       </figure>
 
       <p class="note">
@@ -7288,8 +7288,8 @@
               protocol indicated in <code>href</code> of the forms (or the <code>base</code>). For WebSockets, the
               IANA-registered Websocket Subprotocols [[iana-web-socket-registry]] may be used. For CoAP,
               <code>"subprotocol":"cov:observe"</code> can be used to describe asynchronous observation operations as
-              defined by [[RFC6741]]. The subprotocols can be defined and explained as a part of a protocol or platform
-              binding subspecification.
+              defined by [[RFC6741]]. The subprotocols can be defined and explained as a part of a protocol
+              <a>binding specification</a>.
             </p>
           </section>
 
@@ -7503,31 +7503,26 @@
           </section>
         </section>
 
-        <!-- TODO: Change to combining bindings -->
-        <section id="platform-bindings">
-          <h5>Platform Binding Templates</h5>
+        <section id="bindings-combinations">
+          <h5>Payload and Protocol Bindings</h5>
           <p>
-            There are already various IoT platforms on the market that allows exposing physical and virtual Things to
-            the Internet. These platforms generally require a certain use of a protocol and payload. Thus, they can be
-            seen as a combination of the <a href="#protocol-bindings"></a> and <a href="#payload-bindings"></a>. In
-            these cases, the use of protocol and payload bindings needs to be supported with how they are related to
-            each other in the specific platform.
+            In cases like IoT platforms or standards like OPC-UA or BACnet, the protocol, media type and data structure
+            can be specified. In these cases, their <a>binding specification</a> can either depend on a set of
+            <a href="#protocol-bindings"></a> and <a href="#payload-bindings"></a> or specify protocol, media type and
+            data structure at the same time.
           </p>
 
           <p>
-            For example, Things of a certain platform can require the usage of HTTP and Websockets together with certain
-            JSON payload structures. Thus, Platform Binding <a>subspecification</a>s provide Thing Models and examples
-            of TDs that allow to semantically group multiple binding templates. This allows creation of TDs for these
-            platforms in a consistent manner and makes it easier to develop <a>Consumer</a>s for them.
+            In the case of IoT platforms, there can be a requirement about the usage of HTTP together with certain JSON
+            payload structures. Thus, the corresponding <a>binding specification</a> provides Thing Models and examples
+            of TDs that allow to semantically group multiple bindings. This requires having a
+            <a>binding specification</a> for HTTP and JSON in the first place.
           </p>
 
           <p>
-            Since Platform Binding Templates combine the usage of protocol and payload binding templates, the vocabulary
-            terms and values they can specify are the combination of vocabulary terms in [[[#table-protocol-terms]]] and
-            [[[#table-payload-terms]]]. Similarly, a Platform Binding subspecification SHOULD NOT introduce new protocol
-            binding templates or media types inside its own document. If a Platform Binding subspecification requires
-            the usage of protocol or media type, corresponding protocol or payload binding templates MUST be created
-            first.
+            In the case of standards like OPC-UA or BACnet, the <a>binding specification</a> contains requirements on
+            the protocol, media type and possibly also on data structure. Thus, the <a>binding specification</a> is
+            enough on its own to specify how a <a>binding instance</a> should look like.
           </p>
         </section>
       </section>
@@ -9835,13 +9830,13 @@
       <h2>Example Thing Description Instances with Protocol Bindings</h2>
 
       <p>
-        The following TD examples uses HTTP, CoAP and MQTT Protocol Binding Templates. These TDs have Context Extensions
-        which assume that there is a CoAP and MQTT in RDF vocabulary similar to [[?HTTP-in-RDF10]] that is accessible
-        via the namespaces <code>http://www.example.org/coap-binding#</code> and
+        The following TD examples uses HTTP, CoAP and MQTT Protocol Bindings. These TDs have Context Extensions which
+        assume that there is a CoAP and MQTT in RDF vocabulary similar to [[?HTTP-in-RDF10]] that is accessible via the
+        namespaces <code>http://www.example.org/coap-binding#</code> and
         <code>http://www.example.org/mqtt-binding#</code>, respectively. Please note that the TD context at
         <code>"https://www.w3.org/2022/wot/td/v1.1"</code> already includes the [[?HTTP-in-RDF10]], so HTTP context
-        extensions can be directly used. Note that, each Binding Template <a>subspecification</a> contains the most
-        up-to-date vocabulary terms and examples.
+        extensions can be directly used. Note that, each <a>Binding Specification</a> contains the most up-to-date
+        vocabulary terms and examples.
       </p>
 
       <p>The context extensions we see below have the following instructions to the TD Consumer:</p>
@@ -9879,9 +9874,7 @@
           <li>Protocol Binding: CoAP [[?RFC7252]] over TLS</li>
           <li>
             Comment: Also see
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html"
-              >CoAP Binding Template</a
-            >.
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html">CoAP Binding</a>.
           </li>
         </ul>
 
@@ -10042,9 +10035,7 @@
             Comment: An MQTT client (Thing) frequently publishes the illuminance data (number is serialized in text
             format) to the topic <code>/illuminance</code> by the MQTT broker running behind the address
             <code>192.168.1.187:1883</code>. Also see
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html"
-              >MQTT Binding Template</a
-            >
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html">MQTT Binding</a>
           </li>
         </ul>
         <aside class="example with-default">
@@ -10300,15 +10291,10 @@
           <li>Protocol Binding: HTTP, CoAP [[?RFC7252]], and MQTT [[?MQTT]]</li>
           <li>
             Comment: Each interaction affordance has one form with one protocol. Also see
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html"
-              >HTTP Binding Template</a
-            >,
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html"
-              >CoAP Binding Template</a
-            >, and
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html"
-              >MQTT Binding Template</a
-            >.
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html">HTTP Binding</a>,
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html">CoAP Binding</a>,
+            and
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html">MQTT Binding</a>.
           </li>
         </ul>
 
@@ -10427,15 +10413,10 @@
             <code>concentration</code> event can be subscribed to via CoAP and MQTT. In this case, the Consumer would
             pick the form it can support based on its internal implementation, e.g. whether it has CoAP protocol stack
             or not. Also see
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html"
-              >HTTP Binding Template</a
-            >,
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html"
-              >CoAP Binding Template</a
-            >, and
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html"
-              >MQTT Binding Template</a
-            >.
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html">HTTP Binding</a>,
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html">CoAP Binding</a>,
+            and
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html">MQTT Binding</a>.
           </li>
         </ul>
 

--- a/index.html
+++ b/index.html
@@ -2013,7 +2013,7 @@
             In a TD, concrete data formats are specified in Forms (see <a href="#form"></a>) using content types. When
             the value of a content type in an instance of the Form is <code>application/json</code>, the data schema can
             be processed directly by JSON Schema processors. Otherwise, entries in Web of Things (WoT) Bindings Registry
-            [[?WOT-BINDINGS-REGISTRY]] defines data schema's available mappings to other content types such as XML
+            [[?WOT-BINDINGS-REGISTRY]] define available mappings from data schemas to other content types such as XML
             [[?xml]]. If the content type in an instance of the Form is not <code>application/json</code> and if no
             mapping is defined for the content type, specifying a data schema does not make sense for the content type.
           </p>
@@ -5348,7 +5348,7 @@
             <h3><code>ComboSecurityScheme</code></h3>
 
             <p>
-              To avoid redundancy in this case, e.g. repeating the details of the <code>form</code> elements, a
+              To avoid redundancy in this case, e.g., repeating the details of the <code>form</code> elements, a
               <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> with <code>oneOf</code> can be used
               instead.
             </p>
@@ -6640,7 +6640,7 @@
             that can be checked by looking only at the TD itself.
           </p>
           <p>
-            Minimal Validation is appropriate where validation needs to be self-contained (e.g. devices on isolated
+            Minimal Validation is appropriate where validation needs to be self-contained (e.g., devices on isolated
             networks). It does not attempt to validate context extensions and vocabularies.
           </p>
           <p>
@@ -7070,7 +7070,7 @@
 
       <p>
         Furthermore, the payloads described by the <a>Data Schema</a> in the Affordance Level need to be serialized to a
-        data format and sent on the network protocol. Similar to how operations are bound to protocol messages, the
+        data format and sent on the network protocol. Similar to the way operations are bound to protocol messages, the
         <a>Data Schema</a> is bound to a data format indicated by the <code>contentType</code> or protocol-specific
         terms provided in the <a href="#form">Form</a>. From these terms, a <a>Consumer</a> can infer the required
         serialization method and transform the application-level data to the data to be sent on the network protocol.
@@ -7084,9 +7084,9 @@
         The mechanism above are called Bindings in the Web of Things and a specific example is illustrated in
         [[[#fig-mechanism]]] with an excerpt of a TD of a robot arm with of HTTP and JSON Bindings. Here, the Consumer
         intends to invoke an action of the robot arm (<code>goTo</code>) in order to move it to the position x equals 12
-        and y equals 100. In order to do so, it creates the correct payload, serializes it and sends it using the
-        correct protocol options. The Thing gets the message over the network and responds with a message that
-        corresponds to its TD. Other protocols, payload formats or their combination are possible and are explained in
+        and y equals 100. To do so, it creates the correct payload, serializes it, and sends it using the correct
+        protocol options. The Thing gets the message over the network and responds with a message that corresponds to
+        its TD. Other protocols, payload formats, and/or their combination are possible and are explained in
         [[[#binding-mechanisms]]].
       </p>
 
@@ -7115,9 +7115,9 @@
       <figure id="fig-building-block">
         <img
           src="visualization/binding-templates.svg"
-          alt="Protocols, Media Types and their combinations as building blocks for TDs"
+          alt="Protocols, Media Types, and their combinations, as building blocks for TDs"
         />
-        <figcaption>Protocols, Media Types and their combinations as building blocks TDs</figcaption>
+        <figcaption>Protocols, Media Types, and their combinations, as building blocks for TDs</figcaption>
       </figure>
 
       <p class="note">
@@ -7504,25 +7504,25 @@
         </section>
 
         <section id="bindings-combinations">
-          <h5>Payload and Protocol Bindings</h5>
+          <h5>Protocol and Payload Bindings</h5>
           <p>
-            In cases like IoT platforms or standards like OPC-UA or BACnet, the protocol, media type and data structure
+            In cases like IoT platforms or standards like OPC-UA or BACnet, the protocol, media type, and data structure
             can be specified. In these cases, their <a>binding specification</a> can either depend on a set of
-            <a href="#protocol-bindings"></a> and <a href="#payload-bindings"></a> or specify protocol, media type and
+            <a href="#protocol-bindings"></a> and <a href="#payload-bindings"></a> or specify protocol, media type, and
             data structure at the same time.
           </p>
 
           <p>
-            In the case of IoT platforms, there can be a requirement about the usage of HTTP together with certain JSON
-            payload structures. Thus, the corresponding <a>binding specification</a> provides Thing Models and examples
-            of TDs that allow to semantically group multiple bindings. This requires having a
-            <a>binding specification</a> for HTTP and JSON in the first place.
+            In IoT platforms, there can be a requirement about the use of HTTP together with certain JSON payload
+            structures. Thus, the corresponding <a>binding specification</a> provides Thing Models and examples of TDs
+            that allow semantic grouping of multiple bindings. This requires having a <a>binding specification</a> for
+            HTTP and JSON in the first place.
           </p>
 
           <p>
-            In the case of standards like OPC-UA or BACnet, the <a>binding specification</a> contains requirements on
-            the protocol, media type and possibly also on data structure. Thus, the <a>binding specification</a> is
-            enough on its own to specify how a <a>binding instance</a> should look like.
+            In standards like OPC-UA or BACnet, the <a>binding specification</a> contains requirements on the protocol
+            and media type, and possibly also on data structure. Thus, the <a>binding specification</a> is enough on its
+            own to specify how a <a>binding instance</a> should look.
           </p>
         </section>
       </section>
@@ -7679,7 +7679,7 @@
           <p>
             Per default the Thing Description supports the <a>Protocol Binding</a> based on HTTP by including the HTTP
             RDF vocabulary definitions from <em>HTTP Vocabulary in RDF 1.0</em> [[?HTTP-in-RDF10]]. This vocabulary can
-            be directly used within TD instances by the usage of the prefix <code>htv</code>, which points to
+            be directly used within TD instances by the use of the prefix <code>htv</code>, which points to
             <code>http://www.w3.org/2011/http#</code>. Further details of <a>Protocol Binding</a> based on HTTP can be
             found in [[?WOT-BINDING-TEMPLATES]].
           </p>
@@ -7861,7 +7861,7 @@
             In the case of a <code>forms</code> entry that has multiple <code>op</code> values the usage of the
             <code>htv:methodName</code> is not permitted. A <a>TD Processor</a> will extend the multiple
             <code>op</code> values to separate <code>forms</code> entries and associates a single operation with the
-            default assumption. The address information (e.g. <code>href</code>) and other metadata are taken over in
+            default assumption. The address information (e.g., <code>href</code>) and other metadata are taken over in
             the extended version.
           </p>
 
@@ -8949,7 +8949,7 @@
               typed as string.
             </span>
 
-            After replacing the placeholder, e.g. when creating a Thing Description instance, the original type is
+            After replacing the placeholder, e.g., when creating a Thing Description instance, the original type is
             applied with the corresponding replaced value.
           </p>
 
@@ -9307,7 +9307,7 @@
           the garage door opener and car charger so A can use them. The scope however may be limited so that A cannot
           access certain administrative functions of these Things (for example, to change how long the garage door can
           remain open, or to change the charging rate). In addition, the access should expire after A is expected to
-          have left, e.g. after one week.
+          have left, e.g., after one week.
         </p>
         <dl>
           <dt>Mitigations:</dt>
@@ -9357,7 +9357,7 @@
           substitution, for example inserting the values of these strings into marked places in a HTML template to
           create final HTML, any HTML markup in the original string will be interpreted in the context of the browser
           displaying the dashboard. It is possible for an attacker to embed scripts in HTML in various ways and have
-          these scripts executed upon user interaction or even automatically (e.g. upon page load, or upon an error,
+          these scripts executed upon user interaction or even automatically (e.g., upon page load, or upon an error,
           which can be done intentionally). Since the string will be generated by the TD <a>producer</a> and the
           dashboard will be generated by a different origin, this is a form of cross-site-scripting (XSS) attack.
         </p>
@@ -9581,7 +9581,7 @@
           <dt>Mitigation:</dt>
           <dd>
             The <code>id</code> field in TDs is intentionally not required to be globally unique. There are several
-            cryptographic mechanisms (e.g. random UUIDs) available to generate suitable IDs in a distributed fashion
+            cryptographic mechanisms (e.g., random UUIDs) available to generate suitable IDs in a distributed fashion
             that do not require a central registry. These mechanisms typically have a very low probability of generating
             duplicate identifiers, and this needs to be taken into account in the system design; for example, by
             detecting duplicates and regenerating IDs when necessary. The scope of IDs also does not need to be global:
@@ -9830,12 +9830,12 @@
       <h2>Example Thing Description Instances with Protocol Bindings</h2>
 
       <p>
-        The following TD examples uses HTTP, CoAP and MQTT Protocol Bindings. These TDs have Context Extensions which
-        assume that there is a CoAP and MQTT in RDF vocabulary similar to [[?HTTP-in-RDF10]] that is accessible via the
-        namespaces <code>http://www.example.org/coap-binding#</code> and
+        The following TD example uses HTTP, CoAP, and MQTT Protocol Bindings. These TDs have Context Extensions which
+        assume that there are CoAP-in-RDF and MQTT-in-RDF vocabularies similar to [[?HTTP-in-RDF10]] that are accessible
+        via the namespaces <code>http://www.example.org/coap-binding#</code> and
         <code>http://www.example.org/mqtt-binding#</code>, respectively. Please note that the TD context at
         <code>"https://www.w3.org/2022/wot/td/v1.1"</code> already includes the [[?HTTP-in-RDF10]], so HTTP context
-        extensions can be directly used. Note that, each <a>Binding Specification</a> contains the most up-to-date
+        extensions can be used directly. Note that each <a>Binding Specification</a> contains the most up-to-date
         vocabulary terms and examples.
       </p>
 
@@ -10411,8 +10411,8 @@
             the
             <code>brightness</code> property can be read via HTTP and CoAP, and observed via MQTT;
             <code>concentration</code> event can be subscribed to via CoAP and MQTT. In this case, the Consumer would
-            pick the form it can support based on its internal implementation, e.g. whether it has CoAP protocol stack
-            or not. Also see
+            pick the form it can support based on its internal implementation, e.g., whether it has a CoAP protocol
+            stack or not. Also see
             <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html">HTTP Binding</a>,
             <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html">CoAP Binding</a>,
             and

--- a/index.html
+++ b/index.html
@@ -7082,18 +7082,13 @@
       </p>
 
       <figure id="fig-mechanism">
-        <img
-          src="visualization/binding-mechanism.drawio.svg"
-          alt="Binding Templates mechanism with a TD, Thing and Consumer"
-        />
-        <figcaption>
-          Binding Templates Mechanism inside a TD excerpt with messages of its Thing and a Consumer.
-        </figcaption>
+        <img src="visualization/binding-mechanism.drawio.svg" alt="Bindings mechanism with a TD, Thing and Consumer" />
+        <figcaption>Bindings Mechanism inside a TD excerpt with messages of its Thing and a Consumer.</figcaption>
       </figure>
 
       <p>
         This section explains the overall mechanism and gives basic guidance on creating new Bindings. The
-        [[WOT-BINDING-REGISTRY]] contains the a registry (list) of existing Bindings as well the requirements to follow
+        [[WOT-BINDINGS-REGISTRY]] contains the a registry (list) of existing Bindings as well the requirements to follow
         to register new entries to the registry.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -4722,7 +4722,7 @@
             },
             "unitSystem": {
                 "type": "string",
-                "enum": ["metric_value","imperial_value","uscustomary_value"],
+                "enum": ["metric","imperial","uscustomary"],
                 "description": "System of Measurement that will be used for the values"
             }
         },

--- a/index.html
+++ b/index.html
@@ -1130,862 +1130,363 @@
           <h2>Core Vocabulary Definitions</h2>
 
           <!-- rendered from RDF definitions -->
-          <section>
-            <h3><code>Thing</code></h3>
-            <p>
-              An abstraction of a physical or a virtual entity whose metadata and interfaces are described by a WoT
-              Thing Description, whereas a virtual entity is the composition of one or more Things.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in Thing Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing">
-                  <td><code>@context</code></td>
-                  <td>
-                    JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or
-                    <a>Array</a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing">
-                  <td><code>@type</code></td>
-                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-id--Thing">
-                  <td><code>id</code></td>
-                  <td>
-                    Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI,
-                    URI with local IP address, URN, etc.).
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-title--Thing">
-                  <td><code>title</code></td>
-                  <td>
-                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
-                    language.
-                  </td>
-                  <td>mandatory</td>
-                  <td>any type</td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing">
-                  <td><code>titles</code></td>
-                  <td>
-                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
-                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-description--Thing">
-                  <td><code>description</code></td>
-                  <td>Provides additional (human-readable) information based on a default language.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing">
-                  <td><code>descriptions</code></td>
-                  <td>
-                    Can be used to support (human-readable) information in different languages. Also see
-                    <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-version--Thing">
-                  <td><code>version</code></td>
-                  <td>Provides version information.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#versioninfo"><code>VersionInfo</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-created--Thing">
-                  <td><code>created</code></td>
-                  <td>Provides information when the TD instance was created.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing">
-                  <td><code>modified</code></td>
-                  <td>Provides information when the TD instance was last modified.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-support--Thing">
-                  <td><code>support</code></td>
-                  <td>
-                    Provides information about the TD maintainer as URI scheme (e.g., <code>mailto</code> [[RFC6068]],
-                    <code>tel</code> [[RFC3966]], <code>https</code> [[RFC9112]]).
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-base--Thing">
-                  <td><code>base</code></td>
-                  <td>
-                    Define the base URI that is used for all relative URI references throughout a TD document. In TD
-                    instances, all relative URIs are resolved relative to the base URI using the algorithm defined in
-                    [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-rfc3986"
-                        title="Uniform Resource Identifier (URI): Generic Syntax"
-                        >RFC3986</a
-                      ></cite
-                    >].<br />
-                    <br />
-                    <code>base</code> does not affect the URIs used in <code>@context</code> and the IRIs used within
-                    Linked Data [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-linked-data"
-                        title="Linked Data Design Issues"
-                        >LINKED-DATA</a
-                      ></cite
-                    >] graphs that are relevant when semantic processing is applied to TD instances.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing">
-                  <td><code>properties</code></td>
-                  <td>
-                    All Property-based
-                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
-                      >Interaction Affordances</a
-                    >
-                    of the Thing.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#propertyaffordance"><code>PropertyAffordance</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing">
-                  <td><code>actions</code></td>
-                  <td>
-                    All Action-based
-                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
-                      >Interaction Affordances</a
-                    >
-                    of the Thing.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#actionaffordance"><code>ActionAffordance</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-events--Thing">
-                  <td><code>events</code></td>
-                  <td>
-                    All Event-based
-                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
-                      >Interaction Affordances</a
-                    >
-                    of the Thing.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#eventaffordance"><code>EventAffordance</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-links--Thing">
-                  <td><code>links</code></td>
-                  <td>Provides Web links to arbitrary resources that relate to the specified Thing Description.</td>
-                  <td>optional</td>
-                  <td>
-                    <a>Array</a> of <a href="#link"><code>Link</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing">
-                  <td><code>forms</code></td>
-                  <td>
-                    Set of form hypermedia controls that describe how an operation can be performed. Forms are
-                    serializations of Protocol Bindings. <a>Thing level</a> forms are used to describe endpoints for a
-                    group of interaction affordances.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Array</a> of <a href="#form"><code>Form</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-security--Thing">
-                  <td><code>security</code></td>
-                  <td>
-                    Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.
-                    These must all be satisfied for access to resources.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing">
-                  <td><code>securityDefinitions</code></td>
-                  <td>
-                    Set of named security configurations (definitions only). Not actually applied unless names are used
-                    in a <code>security</code> name-value pair.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a>Map</a> of <a href="#securityscheme"><code>SecurityScheme</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-profile--Thing">
-                  <td><code>profile</code></td>
-                  <td>
-                    Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing
-                    implementation.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-schemaDefinitions--Thing">
-                  <td><code>schemaDefinitions</code></td>
-                  <td>
-                    Set of named data schemas. To be used in a <code>schema</code>
-                    name-value pair inside an
-                    <code>AdditionalExpectedResponse</code> object.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing">
-                  <td><code>uriVariables</code></td>
-                  <td>
-                    Define URI template variables according to [[RFC6570]] as collection based on DataSchema
-                    declarations. The <a>Thing level</a> <code>uriVariables</code> can be used in <a>Thing level</a>
-                    <code>forms</code> or in Interaction Affordances. The individual variables DataSchema cannot be an
-                    ObjectSchema or an ArraySchema since each variable needs to be serialized to a string inside the
-                    <code>href</code> upon the execution of the operation. If the same variable is both declared in
-                    <a>Thing level</a> <code>uriVariables</code> and in Interaction Affordance level, the Interaction
-                    Affordance level variable takes precedence.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:</p>
-            <ul>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-ns-thing-mandatory">
-                  The <code>@context</code>
-                  name-value pair MUST contain the anyURI
-                  <code>https://www.w3.org/2022/wot/td/v1.1</code>
-                  in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly
-                  introduced terms.
-                </span>
-              </li>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-ns-td10-namespace">
-                  When there are possibly TD 1.0 consumers the anyURI
-                  <code>https://www.w3.org/2019/wot/td/v1</code>
-                  MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second
-                  entry.</span
-                >
-              </li>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-ns-td10-namespacev10">
-                  TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0
-                  [[wot-thing-description10]] specification.
-                </span>
-              </li>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-ns-thing-optional"
-                  >When <code>@context</code> is an
-                  <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>, the anyURI
-                  <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class="rfc2119" title="MAY">MAY</em> be followed
-                  by elements of type <code>anyURI</code> or type
-                  <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> in any order, while it is
-                  RECOMMENDED to include only one
-                  <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> with all the name-value pairs in
-                  the <code>@context</code>
-                  <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span
-                >
-              </li>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-ns-thing-map-of-namespaces"
-                  ><a href="#dfn-map" class="internalDFN" data-link-type="dfn">Maps</a> contained in an
-                  <code>@context</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> MAY
-                  contain name-value pairs, where the value is a namespace identifier of type <code>anyURI</code> and
-                  the name a <a href="#dfn-term" class="internalDFN" data-link-type="dfn">Term</a> or prefix denoting
-                  that namespace.</span
-                >
-              </li>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-default-language"
-                  >One <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> contained in an
-                  <code>@context</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> SHOULD
-                  contain a name-value pair that defines the default language for the Thing Description, where the name
-                  is the <a href="#dfn-term" class="internalDFN" data-link-type="dfn">Term</a>
-                  <code>@language</code> and the value is a well-formed language tag as defined by [<cite
-                    ><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages"
-                      >BCP47</a
-                    ></cite
-                  >] (e.g., <code>en</code>, <code>de-AT</code>, <code>gsw-CH</code>, <code>zh-Hans</code>,
-                  <code>zh-Hant-HK</code>, <code>sl-nedis</code>).</span
-                >
-              </li>
-            </ul>
+          <section><h3><code>Thing</code></h3><p>An abstraction of a physical or a virtual entity whose
+          metadata and interfaces are described by a WoT Thing
+          Description, whereas a virtual entity is the composition
+          of one or more Things.</p><table class="def numbered"><caption>Vocabulary Terms in Thing Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing"><td><code>@context</code></td><td>JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-id--Thing"><td><code>id</code></td><td>Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI, URI with local IP address, URN, etc.).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--Thing"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
+                a text for UI representation) based on a default
+                language.</td><td>mandatory</td><td>any type</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing"><td><code>titles</code></td><td>Provides multi-language human-readable titles
+                (e.g., display a text for UI representation in
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-description--Thing"><td><code>description</code></td><td>Provides additional (human-readable)
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-version--Thing"><td><code>version</code></td><td>Provides version information.</td><td>optional</td><td><a href="#versioninfo"><code>VersionInfo</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-created--Thing"><td><code>created</code></td><td>Provides information when the TD instance was
+                created.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing"><td><code>modified</code></td><td>Provides information when the TD instance was
+                last modified.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-support--Thing"><td><code>support</code></td><td>Provides information about the TD maintainer as
+                URI scheme (e.g., <code>mailto</code> [[RFC6068]],
+                <code>tel</code> [[RFC3966]],
+                <code>https</code> [[RFC9112]]).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-base--Thing"><td><code>base</code></td><td>Define the base URI that is used for all
+                relative URI references throughout a TD document.
+                In TD instances, all relative URIs are resolved
+                relative to the base URI using the algorithm
+                defined in [<cite><a class="bibref" data-link-type=
+                "biblio" href='#bib-rfc3986' title=
+                "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>].<br>
+                <br>
+                <code>base</code> does not affect the URIs used in
+                <code>@context</code> and the IRIs used within
+                Linked Data [<cite><a class="bibref"
+                data-link-type="biblio" href='#bib-linked-data'
+                title=
+                "Linked Data Design Issues">LINKED-DATA</a></cite>]
+                graphs that are relevant when semantic processing
+                is applied to TD instances.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing"><td><code>properties</code></td><td>All Property-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
+                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#propertyaffordance"><code>PropertyAffordance</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing"><td><code>actions</code></td><td>All Action-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
+                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#actionaffordance"><code>ActionAffordance</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-events--Thing"><td><code>events</code></td><td>All Event-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
+                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#eventaffordance"><code>EventAffordance</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-links--Thing"><td><code>links</code></td><td>Provides Web links to arbitrary resources that
+                relate to the specified Thing Description.</td><td>optional</td><td><a>Array</a> of <a href="#link"><code>Link</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing"><td><code>forms</code></td><td>Set of form hypermedia controls that describe how 
+                  an operation can be performed. Forms are
+                  serializations of Protocol Bindings. <a>Thing level</a> forms are used to describe endpoints for a group of interaction affordances.</td><td>optional</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-security--Thing"><td><code>security</code></td><td>Set of security definition names, chosen from
+                those defined in <code>securityDefinitions</code>.
+                These must all be satisfied for access to resources.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing"><td><code>securityDefinitions</code></td><td>Set of named security configurations
+                (definitions only). Not actually applied unless
+                names are used in a <code>security</code>
+                name-value pair.</td><td>mandatory</td><td><a>Map</a> of <a href="#securityscheme"><code>SecurityScheme</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-profile--Thing"><td><code>profile</code></td><td>Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing implementation.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-schemaDefinitions--Thing"><td><code>schemaDefinitions</code></td><td>Set of named data schemas.
+                To be used in a <code>schema</code>
+                name-value pair inside an 
+                <code>AdditionalExpectedResponse</code> object.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
+                based on DataSchema declarations. The <a>Thing level</a> <code>uriVariables</code> can be used in <a>Thing level</a> 
+                <code>forms</code> or in Interaction Affordances.
+                The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
+                to be serialized to a string inside the <code>href</code> upon the execution of the operation.
+                If the same variable is both declared in <a>Thing level</a> <code>uriVariables</code> and in Interaction Affordance level,
+                 the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>
+              For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:
+              </p>
+        <ul>
+            <li>
+    <span class="rfc2119-assertion" id=
+          "td-context-ns-thing-mandatory">
 
-            <p>
-              To determine the base direction of all human-readable text in <a>Thing Description</a> and
-              <a>Thing Model</a> instances this specification recommends to follow the [[STRING-META]] guideline about
-              <a href="https://www.w3.org/TR/string-meta/#string_specific_direction"
-                >string-specific directional information</a
-              >
-              when no built-in mechanism for associating base direction metadata is available.
-            </p>
+          The <code>@context</code>
+          name-value pair MUST contain the anyURI
+          <code>https://www.w3.org/2022/wot/td/v1.1</code>
+          in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly introduced terms.
+          </span>
+          </li>
+          <li>
+          <span class="rfc2119-assertion" id=
+          "td-context-ns-td10-namespace"> 
+          When there are possibly TD 1.0 consumers the anyURI
+          <code>https://www.w3.org/2019/wot/td/v1</code>
+          MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second entry.</span>
+          </li>
+          <li>
+          <span class="rfc2119-assertion" id=
+          "td-context-ns-td10-namespacev10"> 
+            TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0 [[wot-thing-description10]] specification. 
+            </span>
+          </li>
+          <li>
+          <span class="rfc2119-assertion" id=
+          "td-context-ns-thing-optional">When <code>@context</code>
+          is an <a href="#dfn-array" class="internalDFN"
+          data-link-type="dfn">Array</a>, the anyURI
+          <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class=
+          "rfc2119" title="MAY">MAY</em> be followed by elements of
+          type <code>anyURI</code> or type <a href="#dfn-map"
+          class="internalDFN" data-link-type="dfn">Map</a> in any
+          order, while it is RECOMMENDED to include only one
+          <a href="#dfn-map" class="internalDFN" data-link-type=
+          "dfn">Map</a> with all the name-value pairs in the
+          <code>@context</code> <a href="#dfn-array" class=
+          "internalDFN" data-link-type="dfn">Array</a>.</span>
+          </li>
+        <li>
+          <span class="rfc2119-assertion" id=
+          "td-context-ns-thing-map-of-namespaces"><a href=
+          "#dfn-map" class="internalDFN" data-link-type=
+          "dfn">Maps</a> contained in an <code>@context</code>
+          <a href="#dfn-array" class="internalDFN" data-link-type=
+          "dfn">Array</a> MAY
+          contain name-value pairs, where the value is a namespace
+          identifier of type <code>anyURI</code> and the name a
+          <a href="#dfn-term" class="internalDFN" data-link-type=
+          "dfn">Term</a> or prefix denoting that namespace.</span>
+          </li>
+          <li>
+          <span class="rfc2119-assertion" id=
+          "td-context-default-language">One <a href="#dfn-map"
+          class="internalDFN" data-link-type="dfn">Map</a>
+          contained in an <code>@context</code> <a href=
+          "#dfn-array" class="internalDFN" data-link-type=
+          "dfn">Array</a> SHOULD contain a name-value pair that
+          defines the default language for the Thing Description,
+          where the name is the <a href="#dfn-term" class=
+          "internalDFN" data-link-type="dfn">Term</a>
+          <code>@language</code> and the value is a well-formed
+          language tag as defined by [<cite><a class="bibref"
+          data-link-type="biblio" href="#bib-bcp47" title=
+          "Tags for Identifying Languages">BCP47</a></cite>] (e.g.,
+          <code>en</code>, <code>de-AT</code>, <code>gsw-CH</code>,
+          <code>zh-Hans</code>, <code>zh-Hant-HK</code>,
+          <code>sl-nedis</code>).</span>
+          </li>
+          </ul>
 
-            <p>
-              <a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TD Processors</a> should be aware of
-              certain special cases when processing bidirectional text.
-              <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
-                <a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TD Processors</a> SHOULD take care
-                to use bidi isolation when presenting strings to users, particularly when embedding in surrounding text
-                (e.g., for Web user interface)</span
-              >. Mixed direction text can occur in any language, even when the language is properly identified.
-            </p>
-            <p>
-              <span class="rfc2119-assertion" id="td-producer-mixed-direction">
-                TD <a>producers</a> SHOULD attempt to provide mixed direction strings in a way that can be displayed
-                successfully by a naive user agent.
-              </span>
-              For example, if an RTL string begins with an LTR run (such as a number or a brand or trade name in Latin
-              script), including an RLM character at the start of the string or wrapping opposite direction runs in bidi
-              controls can assist in proper display.
-            </p>
-            <p>
-              <em>Strings on the Web: Language and Direction Metadata</em> [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-string-meta"
-                  title="Strings on the Web: Language and Direction Metadata"
-                  >string-meta</a
-                ></cite
-              >] provides some guidance and illustrates a number of pitfalls when using bidirectional text.
-            </p>
-            <p id="meta-interactions-of-thing">
-              In addition to the explicitly provided
-              <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-              in the <code>properties</code>, <code>actions</code>, and <code>events</code>
-              <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Maps</a>, a
-              <a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a> can also provide
-              meta-interactions, which are indicated by <code>Form</code> instances in its optional <code>forms</code>
-              <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.
-              <span class="rfc2119-assertion" id="td-op-for-thing"
-                >When the <code>forms</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> of
-                a <a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a> instance contains
-                <code>Form</code> instances, it MUST contain <code>op</code> member with the string values assigned to
-                the name <code>op</code>, either directly or within an
-                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>, MUST be one of the following
-                <em>operation types</em>: <code>readallproperties</code>, <code>writeallproperties</code>,
-                <code>readmultipleproperties</code>, <code>writemultipleproperties</code>,
-                <code>observeallproperties</code>, <code>unobserveallproperties</code>, <code>queryallactions</code>,
-                <code>subscribeallevents</code>, or <code>unsubscribeallevents</code>.</span
-              >
-              (See <a href="#td-forms-readall-example">an example</a> for an usage of <code>form</code> in a Thing
-              instance.)
-            </p>
-            <p>
-              The data schema for each of the property meta-interactions is constructed by combining the data schemas of
-              each <code>PropertyAffordance</code> instance in a single <code>ObjectSchema</code> instance, where the
-              <code>properties</code> <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> of the
-              <code>ObjectSchema</code> instance contains each data schema of the
-              <code>PropertyAffordances</code> identified by the name of the corresponding
-              <code>PropertyAffordances</code> instance.
-            </p>
-            <p>
-              If not specified otherwise (e.g., through a
-              <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>), the request
-              data of the <code>readmultipleproperties</code> operation is an
-              <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> that contains the intended
-              <code>PropertyAffordances</code> instance names, which is serialized to the content type specified by the
-              <code>Form</code> instance.
-            </p>
+          
+          <p>To determine the base direction of all
+          human-readable text in <a>Thing Description</a> 
+          and <a>Thing Model</a> instances this specification 
+           recommends to follow the [[STRING-META]] guideline about 
+           <a href="https://www.w3.org/TR/string-meta/#string_specific_direction">string-specific directional information</a>
+           when no built-in mechanism for associating base direction metadata
+           is available.
+           </p>
+
+          <p><a href="#dfn-td-processor" class="internalDFN"
+          data-link-type="dfn">TD Processors</a> should be aware of
+          certain special cases when processing bidirectional text.
+          <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
+          <a href="#dfn-td-processor" class="internalDFN"
+          data-link-type="dfn">TD Processors</a> SHOULD take care to use bidi isolation when
+          presenting strings to users, particularly when embedding
+          in surrounding text (e.g., for Web user interface)</span>. 
+          Mixed direction text can occur in any language, even when the
+          language is properly identified.</p>
+          <p><span class="rfc2119-assertion" id="td-producer-mixed-direction">
+          TD <a>producers</a> SHOULD attempt to provide mixed direction
+          strings in a way that can be displayed successfully by a
+          naive user agent. </span>
+          For example, if an RTL string begins
+          with an LTR run (such as a number or a brand or trade
+          name in Latin script), including an RLM character at the
+          start of the string or wrapping opposite direction runs
+          in bidi controls can assist in proper display.</p>
+          <p><em>Strings on the Web: Language and Direction
+          Metadata</em> [<cite><a class="bibref" data-link-type=
+          "biblio" href="#bib-string-meta" title=
+          "Strings on the Web: Language and Direction Metadata">string-meta</a></cite>]
+          provides some guidance and illustrates a number of
+          pitfalls when using bidirectional text.</p>
+          <p id="meta-interactions-of-thing">In addition to the
+          explicitly provided <a href="#dfn-interaction-affordance"
+          class="internalDFN" data-link-type="dfn">Interaction
+          Affordances</a> in the <code>properties</code>,
+          <code>actions</code>, and <code>events</code> <a href=
+          "#dfn-map" class="internalDFN" data-link-type=
+          "dfn">Maps</a>, a <a href="#dfn-thing" class=
+          "internalDFN" data-link-type="dfn">Thing</a> can also
+          provide meta-interactions, which are indicated by
+          <code>Form</code> instances in its optional
+          <code>forms</code> <a href="#dfn-array" class=
+          "internalDFN" data-link-type="dfn">Array</a>.
+          <span class="rfc2119-assertion" id="td-op-for-thing">When
+          the <code>forms</code> <a href="#dfn-array" class=
+          "internalDFN" data-link-type="dfn">Array</a> of a
+          <a href="#dfn-thing" class="internalDFN" data-link-type=
+          "dfn">Thing</a> instance contains <code>Form</code>
+          instances, it MUST contain <code>op</code> member with the string values assigned 
+          to the name <code>op</code>, either directly or within an <a href=
+          "#dfn-array" class="internalDFN" data-link-type=
+          "dfn">Array</a>, MUST be one of the following <em>operation
+          types</em>: <code>readallproperties</code>,
+          <code>writeallproperties</code>,
+          <code>readmultipleproperties</code>,
+          <code>writemultipleproperties</code>, <code>observeallproperties</code>,
+          <code>unobserveallproperties</code>, <code>queryallactions</code>, 
+          <code>subscribeallevents</code>, or
+          <code>unsubscribeallevents</code>.</span> (See
+          <a href="#td-forms-readall-example">an example</a> for an
+          usage of <code>form</code> in a Thing instance.)</p>
+          <p>The data schema for each of the property meta-interactions is
+          constructed by combining the data schemas of each
+          <code>PropertyAffordance</code> instance in a single
+          <code>ObjectSchema</code> instance, where the
+          <code>properties</code> <a href="#dfn-map" class=
+          "internalDFN" data-link-type="dfn">Map</a> of the
+          <code>ObjectSchema</code> instance contains each data
+          schema of the <code>PropertyAffordances</code> identified
+          by the name of the corresponding
+          <code>PropertyAffordances</code> instance.</p>
+          <p>If not specified otherwise (e.g., through a <a href=
+          "#dfn-context-ext" class="internalDFN" data-link-type=
+          "dfn">TD Context Extension</a>), the request data of the
+          <code>readmultipleproperties</code> operation is an
+          <a href="#dfn-array" class="internalDFN" data-link-type=
+          "dfn">Array</a> that contains the intended
+          <code>PropertyAffordances</code> instance names, which is
+          serialized to the content type specified by the
+          <code>Form</code> instance.</p></section>
+<section><h3><code>InteractionAffordance</code></h3><p>Metadata of a Thing that shows the possible choices to
+          <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a>, thereby suggesting
+          how <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> may interact with the
+          Thing. There are many types of potential affordances, but
+          <abbr title="World Wide Web Consortium">W3C</abbr> WoT
+          defines three types of Interaction Affordances:
+          Properties, Actions, and Events.</p><table class="def numbered"><caption>Vocabulary Terms in InteractionAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
+                a text for UI representation) based on a default
+                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance"><td><code>titles</code></td><td>Provides multi-language human-readable titles
+                (e.g., display a text for UI representation in
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance"><td><code>description</code></td><td>Provides additional (human-readable)
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance"><td><code>forms</code></td><td>Set of form hypermedia controls that describe
+                how an operation can be performed. Forms are
+                serializations of Protocol Bindings. The array cannot be empty.</td><td>mandatory</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
+                based on DataSchema declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
+                to be serialized to a string inside the <code>href</code> upon the execution of the operation. 
+                If the same variable is both declared in <a>Thing level</a> <code>uriVariables</code>and in Interaction Affordance level, 
+                the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>The class <code>InteractionAffordance</code> has the following subclasses:</p><ul><li><a href="#propertyaffordance"><code>PropertyAffordance</code></a></li>
+<li><a href="#actionaffordance"><code>ActionAffordance</code></a></li>
+<li><a href="#eventaffordance"><code>EventAffordance</code></a></li></ul></section>
+<section><h3><code>PropertyAffordance</code></h3><p>An Interaction Affordance that exposes state of the
+          Thing. This state can then be retrieved (read) and/or updated (write).
+           Things can also choose to
+          make Properties observable by pushing the new state after
+          a change.</p><table class="def numbered"><caption>Vocabulary Terms in PropertyAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance"><td><code>observable</code></td><td>A hint that indicates whether Servients hosting
+                the Thing and Intermediaries should provide a
+                Protocol Binding that supports the <code>observeproperty</code> and <code>unobserveproperty</code> operations 
+                for this Property.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table><p class="note">Property instances are also instances of
+            the class <a href="#dataschema" class="sec-ref">DataSchema</a>. Therefore, it can contain the
+            <code>type</code>, <code>unit</code>,
+            <code>readOnly</code> and <code>writeOnly</code>
+            members, among others.</p><p><code>PropertyAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> and
+          the <code>DataSchema</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+          <span class="rfc2119-assertion" id="td-op-for-property">When a Form instance is within a
+          <code>PropertyAffordance</code> instance, the value
+          assigned to <code>op</code> MUST be one of <code>readproperty</code>,
+          <code>writeproperty</code>, <code>observeproperty</code>,
+          <code>unobserveproperty</code> or an <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
+          containing a combination of these terms.</span></p><p class="note">
+		  It is considered to be good practice that each <code>observeproperty</code> has a corresponding
+		  <code>unobserveproperty</code> unless the protocol supports implicit unsubscription mechanisms
+		  (e.g., heartbeat to detect connection loss).</p><p class="note">
+		  The observation mechanism depends on the underlying protocol or sub-protocol. Having said that, it is not 
+          guaranteed that the current <a>Property</a> value will be provided once the subscription is initiated. Hence, it may be 
+          necessary to read the current <a>Property</a> value before/after the subscription to get a first value. 
+          </p></section>
+<section><h3><code>ActionAffordance</code></h3><p>An Interaction Affordance that allows to invoke a
+          function of the Thing, which manipulates state (e.g.,
+          toggling a lamp on or off) or triggers a process on the
+          Thing (e.g., dim a lamp over time).</p><table class="def numbered"><caption>Vocabulary Terms in ActionAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance"><td><code>input</code></td><td>Used to define the input data schema of the
+                Action.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance"><td><code>output</code></td><td>Used to define the output data schema of the
+                Action.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance"><td><code>safe</code></td><td>Signals if the Action is safe (=true) or not.
+                Used to signal if there is no internal state (cf.
+                resource state) is changed when invoking an Action.
+                In that case responses can be cached as
+                example.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance"><td><code>idempotent</code></td><td>Indicates whether the Action is idempotent
+                (=true) or not. Informs whether the Action can be
+                called repeatedly with the same result, if present,
+                based on the same input.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-synchronous--ActionAffordance"><td><code>synchronous</code></td><td>Indicates whether the action is synchronous (=true) or not. 
+                A synchronous action means that the response of action contains all the information 
+                about the result of the action and no further querying about the status of the action 
+                is needed. Lack of this keyword means that no claim on the synchronicity of the 
+                action can be made.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table><p><code>ActionAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+          <span class="rfc2119-assertion" id="td-op-for-action">When a Form instance is within an
+          <code>ActionAffordance</code> instance, the value
+          assigned to op MUST
+          either be <code>invokeaction</code>, <code>queryaction</code>, 
+          <code>cancelaction</code> or an 
+          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
+          containing a combination of these terms.
+          </span></p></section>
+<section><h3><code>EventAffordance</code></h3><p>An Interaction Affordance that describes an event
+          source, which asynchronously pushes event data to
+          <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating
+          alerts).</p><table class="def numbered"><caption>Vocabulary Terms in EventAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance"><td><code>subscription</code></td><td>Defines data that needs to be passed upon
+                subscription, e.g., filters or message format for
+                setting up Webhooks.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance"><td><code>data</code></td><td>Defines the data schema of the Event instance
+                messages pushed by the Thing.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-dataResponse--EventAffordance"><td><code>dataResponse</code></td><td>Defines the data schema of the Event response messages sent by the consumer in a response to a data message.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance"><td><code>cancellation</code></td><td>Defines any data that needs to be passed to
+                cancel a subscription, e.g., a specific message to
+                remove a Webhook.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p><code>EventAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+          <span class="rfc2119-assertion" id="td-op-for-event">When
+          a Form instance is within an <code>EventAffordance</code>
+          instance, the value assigned to <code>op</code>
+          MUST be either
+          <code>subscribeevent</code>,
+          <code>unsubscribeevent</code>, or both terms within an
+          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span></p><p class="note">
+		  It is considered to be good practice that each <code>subscribeevent</code> has a corresponding <code>unsubscribeevent</code> unless the protocol
+		  supports implicit unsubscription mechanisms (e.g., heartbeat to detect connection loss).</p>
+          <p>
+            EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs interested Consumers about state changes.
+            However, a main difference of EventAffordances is that not every change of the associated resource needs to trigger an event message to be emitted, e.g. a critical threshold for a numeric value.
+        Furthermore, EventAffordances allow for more complex subscribing and unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and <code>cancellation</code> DataSchema definitions.
+            Not all protocols might support these more advanced mechanisms, however, which is why in some scenarios, events may be very similar to observable PropertyAffordances.
+            In these cases, the choice between a Property and a Event for modelling the Affordance should be made based on the semantics of the underlying resource; for example, if the state of the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the appropriate choice.
+          </p>
           </section>
-          <section>
-            <h3><code>InteractionAffordance</code></h3>
-            <p>
-              Metadata of a Thing that shows the possible choices to
-              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a>, thereby suggesting how
-              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> may interact with the
-              Thing. There are many types of potential affordances, but
-              <abbr title="World Wide Web Consortium">W3C</abbr> WoT defines three types of Interaction Affordances:
-              Properties, Actions, and Events.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in InteractionAffordance Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance">
-                  <td><code>@type</code></td>
-                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance">
-                  <td><code>title</code></td>
-                  <td>
-                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
-                    language.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance">
-                  <td><code>titles</code></td>
-                  <td>
-                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
-                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance">
-                  <td><code>description</code></td>
-                  <td>Provides additional (human-readable) information based on a default language.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance">
-                  <td><code>descriptions</code></td>
-                  <td>
-                    Can be used to support (human-readable) information in different languages. Also see
-                    <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance">
-                  <td><code>forms</code></td>
-                  <td>
-                    Set of form hypermedia controls that describe how an operation can be performed. Forms are
-                    serializations of Protocol Bindings. The array cannot be empty.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a>Array</a> of <a href="#form"><code>Form</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance">
-                  <td><code>uriVariables</code></td>
-                  <td>
-                    Define URI template variables according to [[RFC6570]] as collection based on DataSchema
-                    declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since
-                    each variable needs to be serialized to a string inside the <code>href</code> upon the execution of
-                    the operation. If the same variable is both declared in <a>Thing level</a>
-                    <code>uriVariables</code>and in Interaction Affordance level, the Interaction Affordance level
-                    variable takes precedence.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>The class <code>InteractionAffordance</code> has the following subclasses:</p>
-            <ul>
-              <li>
-                <a href="#propertyaffordance"><code>PropertyAffordance</code></a>
-              </li>
-              <li>
-                <a href="#actionaffordance"><code>ActionAffordance</code></a>
-              </li>
-              <li>
-                <a href="#eventaffordance"><code>EventAffordance</code></a>
-              </li>
-            </ul>
-          </section>
-          <section>
-            <h3><code>PropertyAffordance</code></h3>
-            <p>
-              An Interaction Affordance that exposes state of the Thing. This state can then be retrieved (read) and/or
-              updated (write). Things can also choose to make Properties observable by pushing the new state after a
-              change.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in PropertyAffordance Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance">
-                  <td><code>observable</code></td>
-                  <td>
-                    A hint that indicates whether Servients hosting the Thing and Intermediaries should provide a
-                    Protocol Binding that supports the <code>observeproperty</code> and
-                    <code>unobserveproperty</code> operations for this Property.
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p class="note">
-              Property instances are also instances of the class <a href="#dataschema" class="sec-ref">DataSchema</a>.
-              Therefore, it can contain the <code>type</code>, <code>unit</code>, <code>readOnly</code> and
-              <code>writeOnly</code> members, among others.
-            </p>
-            <p>
-              <code>PropertyAffordance</code> is a
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-              <code>InteractionAffordance</code>
-              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> and the <code>DataSchema</code>
-              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-              <span class="rfc2119-assertion" id="td-op-for-property"
-                >When a Form instance is within a <code>PropertyAffordance</code> instance, the value assigned to
-                <code>op</code> MUST be one of <code>readproperty</code>, <code>writeproperty</code>,
-                <code>observeproperty</code>, <code>unobserveproperty</code> or an
-                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> containing a combination of
-                these terms.</span
-              >
-            </p>
-            <p class="note">
-              It is considered to be good practice that each <code>observeproperty</code> has a corresponding
-              <code>unobserveproperty</code> unless the protocol supports implicit unsubscription mechanisms (e.g.,
-              heartbeat to detect connection loss).
-            </p>
-            <p class="note">
-              The observation mechanism depends on the underlying protocol or sub-protocol. Having said that, it is not
-              guaranteed that the current <a>Property</a> value will be provided once the subscription is initiated.
-              Hence, it may be necessary to read the current <a>Property</a> value before/after the subscription to get
-              a first value.
-            </p>
-          </section>
-          <section>
-            <h3><code>ActionAffordance</code></h3>
-            <p>
-              An Interaction Affordance that allows to invoke a function of the Thing, which manipulates state (e.g.,
-              toggling a lamp on or off) or triggers a process on the Thing (e.g., dim a lamp over time).
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in ActionAffordance Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance">
-                  <td><code>input</code></td>
-                  <td>Used to define the input data schema of the Action.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance">
-                  <td><code>output</code></td>
-                  <td>Used to define the output data schema of the Action.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance">
-                  <td><code>safe</code></td>
-                  <td>
-                    Signals if the Action is safe (=true) or not. Used to signal if there is no internal state (cf.
-                    resource state) is changed when invoking an Action. In that case responses can be cached as example.
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance">
-                  <td><code>idempotent</code></td>
-                  <td>
-                    Indicates whether the Action is idempotent (=true) or not. Informs whether the Action can be called
-                    repeatedly with the same result, if present, based on the same input.
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-synchronous--ActionAffordance">
-                  <td><code>synchronous</code></td>
-                  <td>
-                    Indicates whether the action is synchronous (=true) or not. A synchronous action means that the
-                    response of action contains all the information about the result of the action and no further
-                    querying about the status of the action is needed. Lack of this keyword means that no claim on the
-                    synchronicity of the action can be made.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              <code>ActionAffordance</code> is a
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-              <code>InteractionAffordance</code>
-              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-              <span class="rfc2119-assertion" id="td-op-for-action"
-                >When a Form instance is within an <code>ActionAffordance</code> instance, the value assigned to op MUST
-                either be <code>invokeaction</code>, <code>queryaction</code>, <code>cancelaction</code> or an
-                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
-                containing a combination of these terms.
-              </span>
-            </p>
-          </section>
-          <section>
-            <h3><code>EventAffordance</code></h3>
-            <p>
-              An Interaction Affordance that describes an event source, which asynchronously pushes event data to
-              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating alerts).
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in EventAffordance Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance">
-                  <td><code>subscription</code></td>
-                  <td>
-                    Defines data that needs to be passed upon subscription, e.g., filters or message format for setting
-                    up Webhooks.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance">
-                  <td><code>data</code></td>
-                  <td>Defines the data schema of the Event instance messages pushed by the Thing.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-dataResponse--EventAffordance">
-                  <td><code>dataResponse</code></td>
-                  <td>
-                    Defines the data schema of the Event response messages sent by the consumer in a response to a data
-                    message.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance">
-                  <td><code>cancellation</code></td>
-                  <td>
-                    Defines any data that needs to be passed to cancel a subscription, e.g., a specific message to
-                    remove a Webhook.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              <code>EventAffordance</code> is a
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-              <code>InteractionAffordance</code>
-              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-              <span class="rfc2119-assertion" id="td-op-for-event"
-                >When a Form instance is within an <code>EventAffordance</code> instance, the value assigned to
-                <code>op</code>
-                MUST be either
-                <code>subscribeevent</code>, <code>unsubscribeevent</code>, or both terms within an
-                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span
-              >
-            </p>
-            <p class="note">
-              It is considered to be good practice that each <code>subscribeevent</code> has a corresponding
-              <code>unsubscribeevent</code> unless the protocol supports implicit unsubscription mechanisms (e.g.,
-              heartbeat to detect connection loss).
-            </p>
-            <p>
-              EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs
-              interested Consumers about state changes. However, a main difference of EventAffordances is that not every
-              change of the associated resource needs to trigger an event message to be emitted, e.g. a critical
-              threshold for a numeric value. Furthermore, EventAffordances allow for more complex subscribing and
-              unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and
-              <code>cancellation</code> DataSchema definitions. Not all protocols might support these more advanced
-              mechanisms, however, which is why in some scenarios, events may be very similar to observable
-              PropertyAffordances. In these cases, the choice between a Property and a Event for modelling the
-              Affordance should be made based on the semantics of the underlying resource; for example, if the state of
-              the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the
-              appropriate choice.
-            </p>
-          </section>
-          <section>
-            <h3><code>VersionInfo</code></h3>
-            <p>
-              Metadata of a Thing that provides version information about the TD document. If required, additional
-              version information such as firmware and hardware version (term definitions outside of the TD namespace)
-              can be extended via the
-              <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a> mechanism.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in VersionInfo Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo">
-                  <td><code>instance</code></td>
-                  <td>Provides a version indicator of this TD.</td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-model--VersionInfo">
-                  <td><code>model</code></td>
-                  <td>Provides a version indicator of the underlying TM.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              It is recommended that the values within <code>instances</code> and <code>model</code> of the
-              <code>VersionInfo</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> follow
-              the semantic versioning pattern, where a sequence of three numbers separated by a dot indicates the major
-              version, minor version, and patch version, respectively. See [<cite
-                ><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0"
-                  >SEMVER</a
-                ></cite
-              >] for details.
-            </p>
-          </section>
-          <section>
-            <h3><code>MultiLanguage</code></h3>
-            <p></p>
-            <p>
-              A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags
-              described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of
-              this container in a Thing Description instance.
-            </p>
-            <p>
-              <span class="rfc2119-assertion" id="td-multilanguage-language-tag"
-                >Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in
-                [[!BCP47]].</span
-              >
-              <span class="rfc2119-assertion" id="td-multilanguage-value">
-                Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>.
-              </span>
-            </p>
-          </section>
+<section><h3><code>VersionInfo</code></h3><p>Metadata of a Thing that provides version information
+          about the TD document. If required, additional version
+          information such as firmware and hardware version (term
+          definitions outside of the TD namespace) can be extended
+          via the <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>
+          mechanism.</p><table class="def numbered"><caption>Vocabulary Terms in VersionInfo Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo"><td><code>instance</code></td><td>Provides a version indicator of this TD.
+                </td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-model--VersionInfo"><td><code>model</code></td><td>Provides a version indicator of the underlying TM.
+                </td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><p>It is recommended that the values within <code>instances</code> and <code>model</code> of
+          the <code>VersionInfo</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> follow the
+          semantic versioning pattern, where a sequence of three
+          numbers separated by a dot indicates the major version,
+          minor version, and patch version, respectively. See
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0">SEMVER</a></cite>] for
+          details.</p></section>
+<section><h3><code>MultiLanguage</code></h3><p><p>A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
+            <p><span class="rfc2119-assertion" id="td-multilanguage-language-tag">Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in [[!BCP47]].</span>
+            <span class="rfc2119-assertion" id="td-multilanguage-value"> Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>. </span> 
+            </p></section>
         </section>
 
         <section id="sec-data-schema-vocabulary-definition">
@@ -2051,579 +1552,122 @@
           </table>
 
           <!-- rendered from RDF definitions -->
-          <section>
-            <h3><code>DataSchema</code></h3>
-            <p>Metadata that describes the data format used. It can be used for validation.</p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in DataSchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema">
-                  <td><code>@type</code></td>
-                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema">
-                  <td><code>title</code></td>
-                  <td>
-                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
-                    language.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema">
-                  <td><code>titles</code></td>
-                  <td>
-                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
-                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema">
-                  <td><code>description</code></td>
-                  <td>Provides additional (human-readable) information based on a default language.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema">
-                  <td><code>descriptions</code></td>
-                  <td>
-                    Can be used to support (human-readable) information in different languages. Also see
-                    <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema">
-                  <td><code>const</code></td>
-                  <td>Provides a constant value.</td>
-                  <td>optional</td>
-                  <td>any type</td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema">
-                  <td><code>default</code></td>
-                  <td>
-                    Supply a default value. The value SHOULD validate against the data schema in which it resides.
-                  </td>
-                  <td>optional</td>
-                  <td>any type</td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema">
-                  <td><code>unit</code></td>
-                  <td>
-                    Provides unit information that is used, e.g., in international science, engineering, and business.
-                    To preserve uniqueness, it is recommended that the value of the unit points to a semantic definition
-                    (also see Section
-                    <a href="#semantic-annotations-example-version-units" class="internalDFN" data-link-type="dfn"
-                      >Semantic Annotations</a
-                    >).
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema">
-                  <td><code>oneOf</code></td>
-                  <td>
-                    Used to ensure that the data is valid against one of the specified schemas in the array. This can be
-                    used to describe multiple input or output schemas.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema">
-                  <td><code>enum</code></td>
-                  <td>Restricted set of values provided as an array.</td>
-                  <td>optional</td>
-                  <td><a>Array</a> of any type</td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema">
-                  <td><code>readOnly</code></td>
-                  <td>
-                    Boolean value that is a hint to indicate whether a property interaction / value is read only (=true)
-                    or not (=false).
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema">
-                  <td><code>writeOnly</code></td>
-                  <td>
-                    Boolean value that is a hint to indicate whether a property interaction / value is write only
-                    (=true) or not (=false).
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema">
-                  <td><code>format</code></td>
-                  <td>
-                    Allows validation based on a format pattern such as "date-time", "email", "uri", etc. (Also see
-                    below.)
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-type--DataSchema">
-                  <td><code>type</code></td>
-                  <td>
-                    Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number,
-                    string, object, array, or null).
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> (one
-                    of <code>object</code>, <code>array</code>, <code>string</code>, <code>number</code>,
-                    <code>integer</code>, <code>boolean</code>, or <code>null</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>The class <code>DataSchema</code> has the following subclasses:</p>
-            <ul>
-              <li>
-                <a href="#arrayschema"><code>ArraySchema</code></a>
-              </li>
-              <li>
-                <a href="#booleanschema"><code>BooleanSchema</code></a>
-              </li>
-              <li>
-                <a href="#numberschema"><code>NumberSchema</code></a>
-              </li>
-              <li>
-                <a href="#integerschema"><code>IntegerSchema</code></a>
-              </li>
-              <li>
-                <a href="#objectschema"><code>ObjectSchema</code></a>
-              </li>
-              <li>
-                <a href="#stringschema"><code>StringSchema</code></a>
-              </li>
-              <li>
-                <a href="#nullschema"><code>NullSchema</code></a>
-              </li>
-            </ul>
-            <p>
-              The <code>format</code> string values are known from a fixed set of values and their corresponding format
-              rules defined in [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-json-schema"
-                  title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
-                  >JSON-SCHEMA</a
-                ></cite
-              >] (Section 7.3 Defined Formats in particular).
-              <span class="rfc2119-assertion" id="td-format-validation-known-values"
-                >Servients MAY use the <code>format</code> value to perform additional validation accordingly.</span
-              >
-              <span class="rfc2119-assertion" id="td-format-validation-other-values"
-                >When a value that is not found in the known set of values is assigned to <code>format</code>, such a
-                validation SHOULD succeed.</span
-              >
-            </p>
-            Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>,
-            <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string,
-            object, array, or null).
-            <p class="note">
-              The <code>format</code> term is not widely implemented by JSON Schema tools. In addition, the term
-              <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by
-              another mechanism or removed in a future JSON Schema version.
-            </p>
-          </section>
-          <section>
-            <h3><code>ArraySchema</code></h3>
-            <p>
-              Metadata describing data of type <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.
-              This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-              value <code>array</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in ArraySchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema">
-                  <td><code>items</code></td>
-                  <td>Used to define the characteristics of an array.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a> or <a>Array</a> of
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema">
-                  <td><code>minItems</code></td>
-                  <td>Defines the minimum number of items that have to be in the array.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
-                      ><code>unsignedInt</code></a
-                    >
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema">
-                  <td><code>maxItems</code></td>
-                  <td>Defines the maximum number of items that have to be in the array.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
-                      ><code>unsignedInt</code></a
-                    >
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>BooleanSchema</code></h3>
-            <p>
-              Metadata describing data of type <code>boolean</code>. This
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
-              <code>boolean</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-          </section>
-          <section>
-            <h3><code>NumberSchema</code></h3>
-            <p>
-              Metadata describing data of type <code>number</code>. This
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
-              <code>number</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in NumberSchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema">
-                  <td><code>minimum</code></td>
-                  <td>
-                    Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--NumberSchema">
-                  <td><code>exclusiveMinimum</code></td>
-                  <td>
-                    Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema">
-                  <td><code>maximum</code></td>
-                  <td>
-                    Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--NumberSchema">
-                  <td><code>exclusiveMaximum</code></td>
-                  <td>
-                    Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--NumberSchema">
-                  <td><code>multipleOf</code></td>
-                  <td>
-                    Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>IntegerSchema</code></h3>
-            <p>
-              Metadata describing data of type <code>integer</code>. This
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
-              <code>integer</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in IntegerSchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema">
-                  <td><code>minimum</code></td>
-                  <td>
-                    Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--IntegerSchema">
-                  <td><code>exclusiveMinimum</code></td>
-                  <td>
-                    Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema">
-                  <td><code>maximum</code></td>
-                  <td>
-                    Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--IntegerSchema">
-                  <td><code>exclusiveMaximum</code></td>
-                  <td>
-                    Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--IntegerSchema">
-                  <td><code>multipleOf</code></td>
-                  <td>
-                    Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>ObjectSchema</code></h3>
-            <p>
-              Metadata describing data of type
-              <a href="#dfn-object" class="internalDFN" data-link-type="dfn">Object</a>. This
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
-              <code>object</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in ObjectSchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema">
-                  <td><code>properties</code></td>
-                  <td>Data schema nested definitions.</td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema">
-                  <td><code>required</code></td>
-                  <td>
-                    Defines which members of the object type are mandatory, i.e. which members are mandatory in the
-                    payload that is to be sent (e.g. input of <code>invokeaction</code>, <code>writeproperty</code>) and
-                    what members will be definitely delivered in the payload that is being received (e.g. output of
-                    <code>invokeaction</code>, <code>readproperty</code>)
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>StringSchema</code></h3>
-            <p>
-              Metadata describing data of type <code>string</code>. This
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
-              <code>string</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in StringSchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-minLength--StringSchema">
-                  <td><code>minLength</code></td>
-                  <td>Specifies the minimum length of a string. Only applicable for associated string types.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
-                      ><code>unsignedInt</code></a
-                    >
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-maxLength--StringSchema">
-                  <td><code>maxLength</code></td>
-                  <td>Specifies the maximum length of a string. Only applicable for associated string types.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
-                      ><code>unsignedInt</code></a
-                    >
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-pattern--StringSchema">
-                  <td><code>pattern</code></td>
-                  <td>
-                    Provides a regular expression to express constraints of the string value. The regular expression
-                    must follow the [[ECMA-262]] dialect.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentEncoding--StringSchema">
-                  <td><code>contentEncoding</code></td>
-                  <td>
-                    Specifies the encoding used to store the contents, as specified in [[RFC2045]] (Section 6.1) and
-                    [[RFC4648]].
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>7bit</code>, <code>8bit</code>, <code>binary</code>, <code>quoted-printable</code>,
-                    <code>base16</code>, <code>base32</code>, or <code>base64</code>)
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentMediaType--StringSchema">
-                  <td><code>contentMediaType</code></td>
-                  <td>Specifies the MIME type of the contents of a string value, as described in [[RFC2046]].</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>image/png</code>, or <code>audio/mpeg</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p class="note">
-              The length of a string (i.e., <code>minLength</code> and <code>maxLength</code>) is defined as the number
-              of Unicode code points, as defined by [[RFC8259]]. Note that some
-              <a href="https://www.w3.org/TR/i18n-glossary/#dfn-grapheme" target="_blank">user-perceived characters</a>
-              are composed of more than one Unicode code point. Arbitrary index values might not fall on these grapheme
-              boundaries, so truncation according to <code>maxLength</code> might alter the appearance or meaning of the
-              string.
-            </p>
-          </section>
-          <section>
-            <h3><code>NullSchema</code></h3>
-            <p>
-              Metadata describing data of type <code>null</code>. This subclass is indicated by the value
-              <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. This Subclass
-              describes only one acceptable value, namely <code>null</code>. It is important to note that
-              <code>null</code> does not mean the absence of a value. It is analogous to <code>null</code> in
-              JavaScript, <code>None</code> in Python, <code>null</code> in Java and <code>nil</code> in Ruby
-              programming languages. It can be used as part of a <code>oneOf</code> declaration, where it is used to
-              indicate, that the data can also be <code>null</code>.
-            </p>
-          </section>
+          <section><h3><code>DataSchema</code></h3><p>Metadata that describes the data format used. It can
+          be used for validation.</p><table class="def numbered"><caption>Vocabulary Terms in DataSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
+                a text for UI representation) based on a default
+                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema"><td><code>titles</code></td><td>Provides multi-language human-readable titles
+                (e.g., display a text for UI representation in
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema"><td><code>description</code></td><td>Provides additional (human-readable)
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema"><td><code>const</code></td><td>Provides a constant value.</td><td>optional</td><td>any type</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema"><td><code>default</code></td><td>Supply a default value. The value SHOULD validate against the data schema in which it resides.</td><td>optional</td><td>any type</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema"><td><code>unit</code></td><td>Provides unit information that is used, e.g.,
+                in international science, engineering, and
+                business. To preserve uniqueness, it is recommended that 
+                the value of the unit points to a semantic definition (also see Section <a href="#semantic-annotations-example-version-units"
+          class="internalDFN" data-link-type="dfn">Semantic Annotations</a>).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema"><td><code>oneOf</code></td><td>Used to ensure that the data is valid against
+                one of the specified schemas in the array.  This can be used to describe multiple input or output schemas.</td><td>optional</td><td><a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema"><td><code>enum</code></td><td>Restricted set of values provided as an
+                array.</td><td>optional</td><td><a>Array</a> of any type</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema"><td><code>readOnly</code></td><td>Boolean value that is a hint to indicate
+                whether a property interaction / value is read only
+                (=true) or not (=false).</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema"><td><code>writeOnly</code></td><td>Boolean value that is a hint to indicate
+                whether a property interaction / value is write
+                only (=true) or not (=false).</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema"><td><code>format</code></td><td>Allows validation based on a format pattern
+                such as "date-time", "email", "uri", etc. (Also see
+                below.)</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-type--DataSchema"><td><code>type</code></td><td>Assignment of JSON-based data types compatible
+                with JSON Schema (one of boolean, integer, number,
+                string, object, array, or null).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> (one of <code>object</code>, <code>array</code>, <code>string</code>, <code>number</code>, <code>integer</code>, <code>boolean</code>, or <code>null</code>)</td></tr></tbody></table><p>The class <code>DataSchema</code> has the following subclasses:</p><ul><li><a href="#arrayschema"><code>ArraySchema</code></a></li>
+<li><a href="#booleanschema"><code>BooleanSchema</code></a></li>
+<li><a href="#numberschema"><code>NumberSchema</code></a></li>
+<li><a href="#integerschema"><code>IntegerSchema</code></a></li>
+<li><a href="#objectschema"><code>ObjectSchema</code></a></li>
+<li><a href="#stringschema"><code>StringSchema</code></a></li>
+<li><a href="#nullschema"><code>NullSchema</code></a></li></ul><p>The <code>format</code> string values are known from a
+          fixed set of values and their corresponding format rules
+          defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]
+          (Section 7.3 Defined Formats in particular). <span class="rfc2119-assertion" id="td-format-validation-known-values">Servients MAY use the
+          <code>format</code> value to perform additional
+          validation accordingly.</span> <span class="rfc2119-assertion" id="td-format-validation-other-values">When a value that is
+          not found in the known set of values is assigned to
+          <code>format</code>, such a validation SHOULD succeed.</span></p>
+          Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>, <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string, object, array, or null).
+          <p class="note">The <code>format</code> term is not widely implemented by JSON Schema tools. 
+          In addition, the term <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by another mechanism or removed in a future JSON Schema version.</p></section>
+<section><h3><code>ArraySchema</code></h3><p>Metadata describing data of type <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>. This
+          <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>array</code> assigned to <code>type</code> in
+          <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in ArraySchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema"><td><code>items</code></td><td>Used to define the characteristics of an
+                array.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a> or <a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema"><td><code>minItems</code></td><td>Defines the minimum number of items that have
+                to be in the array.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema"><td><code>maxItems</code></td><td>Defines the maximum number of items that have
+                to be in the array.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr></tbody></table></section>
+<section><h3><code>BooleanSchema</code></h3><p>Metadata describing data of type <code>boolean</code>.
+          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>boolean</code> assigned to <code>type</code>
+          in <code>DataSchema</code> instances.</p></section>
+<section><h3><code>NumberSchema</code></h3><p>Metadata describing data of type <code>number</code>.
+          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>number</code> assigned to <code>type</code>
+          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in NumberSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema"><td><code>minimum</code></td><td>Specifies a minimum numeric value, representing an inclusive lower limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--NumberSchema"><td><code>exclusiveMinimum</code></td><td>Specifies a minimum numeric value, representing an exclusive lower limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema"><td><code>maximum</code></td><td>Specifies a maximum numeric value, representing an inclusive upper limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--NumberSchema"><td><code>exclusiveMaximum</code></td><td>Specifies a maximum numeric value, representing an exclusive upper limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--NumberSchema"><td><code>multipleOf</code></td><td>Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr></tbody></table></section>
+<section><h3><code>IntegerSchema</code></h3><p>Metadata describing data of type <code>integer</code>.
+          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>integer</code> assigned to <code>type</code>
+          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in IntegerSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema"><td><code>minimum</code></td><td>Specifies a minimum numeric value, representing an inclusive lower limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--IntegerSchema"><td><code>exclusiveMinimum</code></td><td>Specifies a minimum numeric value, representing an exclusive lower limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema"><td><code>maximum</code></td><td>Specifies a maximum numeric value, representing an inclusive upper limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--IntegerSchema"><td><code>exclusiveMaximum</code></td><td>Specifies a maximum numeric value, representing an exclusive upper limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--IntegerSchema"><td><code>multipleOf</code></td><td>Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr></tbody></table></section>
+<section><h3><code>ObjectSchema</code></h3><p>Metadata describing data of type <a href="#dfn-object" class="internalDFN" data-link-type="dfn">Object</a>.
+          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>object</code> assigned to <code>type</code>
+          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in ObjectSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema"><td><code>properties</code></td><td>Data schema nested definitions.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema"><td><code>required</code></td><td>Defines which members of the object type are mandatory, i.e. which members are mandatory in the payload that is to be sent (e.g. input of <code>invokeaction</code>, <code>writeproperty</code>) and what members will be definitely delivered in the payload that is being received (e.g. output of <code>invokeaction</code>, <code>readproperty</code>)</td><td>optional</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+<section><h3><code>StringSchema</code></h3><p>Metadata describing data of type <code>string</code>.
+          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>string</code> assigned to <code>type</code>
+          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in StringSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minLength--StringSchema"><td><code>minLength</code></td><td>Specifies the minimum length of a string. Only applicable for associated string types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-maxLength--StringSchema"><td><code>maxLength</code></td><td>Specifies the maximum length of a string. Only applicable for associated string types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-pattern--StringSchema"><td><code>pattern</code></td><td>Provides a regular expression to express constraints of the string value. The regular expression must follow the [[ECMA-262]] dialect.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-contentEncoding--StringSchema"><td><code>contentEncoding</code></td><td>Specifies the encoding used to store the contents, as specified in [[RFC2045]] (Section 6.1) and [[RFC4648]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>7bit</code>, <code>8bit</code>, <code>binary</code>, <code>quoted-printable</code>, <code>base16</code>, <code>base32</code>, or <code>base64</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-contentMediaType--StringSchema"><td><code>contentMediaType</code></td><td>Specifies the MIME type of the contents of a string value, as described in [[RFC2046]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>image/png</code>, or <code>audio/mpeg</code>)</td></tr></tbody></table><p class="note">The length of a string (i.e., <code>minLength</code> and
+        <code>maxLength</code>) is defined as the number
+        of Unicode code points, as defined by [[RFC8259]].
+		Note that some <a href="https://www.w3.org/TR/i18n-glossary/#dfn-grapheme" target="_blank">user-perceived characters</a> are composed of more than one Unicode code point. Arbitrary index values might not fall on these grapheme boundaries, so truncation according to <code>maxLength</code> might alter the appearance or meaning of the string.
+		</p></section>
+<section><h3><code>NullSchema</code></h3><p>Metadata describing data of type <code>null</code>. This subclass is indicated by the value <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. 
+    This Subclass describes only one acceptable value, namely <code>null</code>. 
+    It is important to note that <code>null</code> does not mean the absence of a value. It is analogous to <code>null</code> in JavaScript, <code>None</code> in Python, <code>null</code> in Java and <code>nil</code> in Ruby programming languages. 
+    It can be used as part of a <code>oneOf</code> declaration, where it is used to indicate, that the data can also be <code>null</code>.</p></section>
         </section>
 
         <section id="sec-security-vocabulary-definition">
@@ -2647,713 +1691,229 @@
           </p>
 
           <!-- rendered from RDF definitions -->
-          <section>
-            <h3><code>SecurityScheme</code></h3>
-            <p></p>
-            <p>
-              Metadata describing the configuration of a security mechanism.
-              <span class="rfc2119-assertion" id="td-security-scheme-name"
-                >The value assigned to the name <code>scheme</code> MUST be defined within a
-                <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
-                included in the
-                <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>, either
-                in the standard
-                <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined in
-                <a href="#sec-vocabulary-definition" class="sec-ref"
-                  >§&nbsp;<bdi class="secno">5.</bdi> TD Information Model</a
-                >
-                or in a
-                <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>.</span
-              >
-            </p>
-            <p>
-              <span class="rfc2119-assertion" id="td-security-no-secrets"
-                >For all security schemes, any keys, passwords, or other sensitive information directly providing access
-                MUST NOT be stored in the TD and should instead be shared and stored out-of-band via other
-                mechanisms.</span
-              >
-              The purpose of a TD is to describe how to access a Thing if and only if a Consumer already has
-              authorization, and is not meant be used to grant that authorization.
-            </p>
-            <p>
-              Each security scheme object used in a TD defines a set of requirements to be met before access can be
-              granted. We say a security scheme is <em>satisfied</em> when all its requirements are met. In some cases
-              requirements from multiple security schemes will have to be met before access can be granted.
-            </p>
-            <p>
-              Security schemes generally may require additional authentication parameters, such as a password or key.
-              The location of this information is indicated by the value associated with the name <code>in</code>, often
-              in combination with the value associated with <code>name</code>. The value associated with
-              <code>in</code> can take one of the following values:
-            </p>
-            <dl>
-              <dt><code>header</code>:</dt>
-              <dd>
-                The parameter will be given in a header provided by the protocol, with the name of the header provided
-                by the value of <code>name</code>.
-              </dd>
-              <dt><code>query</code>:</dt>
-              <dd>
-                The parameter will be appended to the URI as a query parameter, with the name of the query parameter
-                provided by <code>name</code>.
-              </dd>
-              <dt><code>body</code>:</dt>
-              <dd>
-                The parameter will be provided in the body of the request payload, with the data schema element used
-                provided by <code>name</code>.
-                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer"
-                  >When used in the context of a <code>body</code> security information location, the value of
-                  <code>name</code> MUST be in the form of a JSON pointer [[!RFC6901]] relative to the root of the input
-                  <code>DataSchema</code> for each interaction it is used with.</span
-                >
-                Since this value is not a fragment identifier, and is not relative to the root of the TD but to
-                whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
-                it is a "pure" JSON pointer. Since this value is not a fragment identifier, it also does not need to
-                URL-encode special characters. The targeted element may or may not already exist at the specified
-                location in the referenced object or array schema (consequently the mechanism is not applicable to
-                simple types). If it does not, it will be inserted. This avoids having to duplicate definitions in the
-                data schemas of every interaction.
-                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-creatable"
-                  >When an element of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
-                  does not already exist in the indicated schema, it MUST be possible to insert the indicated element at
-                  the location indicated by the pointer.</span
-                >
-                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-array"
-                  >The JSON pointer used in the <code>body</code> locator MAY use the "<code>-</code>" character to
-                  indicate a non-existent array element when it is necessary to insert an element after the last element
-                  of an existing array.
-                </span>
-                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-type"
-                  >The element referenced (or created) by a <code>body</code> security information location MUST be
-                  required and of type "<code>string</code>".</span
-                >
-                If <code>name</code> is not given, it is assumed the entire body is to be used as the security
-                parameter.
-              </dd>
-              <dt><code>cookie</code>:</dt>
-              <dd>The parameter is stored in a cookie identified by the value of <code>name</code>.</dd>
-              <dt><code>uri</code>:</dt>
-              <dd>
-                The parameter is embedded in the URI itself, which is encoded in the relevant interaction using a URI
-                template variable defined by the value of <code>name</code>. This is more general than the
-                <code>query</code> mechanism but more complex.
-                <span class="rfc2119-assertion" id="td-security-in-query-over-uri"
-                  >The value <code>uri</code> SHOULD be specified for the name <code>in</code> in a security scheme only
-                  if <code>query</code> is not applicable.</span
-                >
-                <span class="rfc2119-assertion" id="td-security-in-uri-variable"
-                  >The URIs provided in interactions where a security scheme using <code>uri</code> as the value for
-                  <code>in</code>
-                  MUST be a URI template including the defined variable.
-                </span>
-              </dd>
-              <dt><code>auto</code>:</dt>
-              <dd>
-                The location is determined as part of the protocol, or negotiated.
-                <span class="rfc2119-assertion" id="td-security-security-vocab-auto-in-no-name"
-                  >If a value of <code>auto</code> is set for the <code>in</code> field of a
-                  <code>SecurityScheme</code>, then the <code>name</code> field SHOULD NOT be set.</span
-                >
-                In this case, the application of the <code>SecurityScheme</code> is subject to the respective
-                specification for the given protocol (e.g. [[!RFC8288]] when using the
-                <code>BasicSecurityScheme</code> with HTTP).
-              </dd>
-            </dl>
-            <p>
-              If multiple parameters are needed for a security scheme, repeat the security scheme definition for each
-              parameter and combine them using a <code>combo</code> security scheme and <code>allOf</code>. In some
-              cases parameters may not actually be secret but a user may wish to leave them out of the TD to help
-              protect privacy. As an example of this, some security mechanisms require both a client identifier and a
-              secret key. In theory, the client identifier is public however it may be hard to update and pose a
-              tracking risk. In such a case it can be provided as an additional security parameter so it does not appear
-              in the TD.
-            </p>
-            <p>
-              <span class="rfc2119-assertion" id="td-security-uri-variables-distinct"
-                >The names of URI variables declared in a <code>SecurityScheme</code> MUST be distinct from all other
-                URI variables declared in the TD.</span
-              >
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in SecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme">
-                  <td><code>@type</code></td>
-                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme">
-                  <td><code>description</code></td>
-                  <td>Provides additional (human-readable) information based on a default language.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme">
-                  <td><code>descriptions</code></td>
-                  <td>
-                    Can be used to support (human-readable) information in different languages. Also see
-                    <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme">
-                  <td><code>proxy</code></td>
-                  <td>
-                    URI of the proxy server this security configuration provides access to. If not given, the
-                    corresponding security configuration is for the endpoint.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme">
-                  <td><code>scheme</code></td>
-                  <td>Identification of the security mechanism being configured.</td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>nosec</code>, <code>combo</code>, <code>basic</code>, <code>digest</code>,
-                    <code>bearer</code>, <code>psk</code>, <code>oauth2</code>, <code>apikey</code>, or
-                    <code>auto</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>The class <code>SecurityScheme</code> has the following subclasses:</p>
-            <ul>
-              <li>
-                <a href="#nosecurityscheme"><code>NoSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#autosecurityscheme"><code>AutoSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#basicsecurityscheme"><code>BasicSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#bearersecurityscheme"><code>BearerSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#psksecurityscheme"><code>PSKSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a>
-              </li>
-            </ul>
-          </section>
-          <section>
-            <h3><code>NoSecurityScheme</code></h3>
-            <p>
-              A security configuration corresponding to identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>nosec</code> (i.e., <code>"scheme": "nosec"</code>), indicating there is no authentication or other
-              mechanism required to access the resource.
-            </p>
-          </section>
-          <section>
-            <h3><code>AutoSecurityScheme</code></h3>
-            <p>
-              An automatic authentication security configuration identified by the term <code>auto</code> (i.e.,
-              <code>"scheme": "auto"</code>). This scheme indicates that the security parameters are going to be
-              negotiated by the underlying protocols at runtime, subject to the respective specifications for the
-              protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).
-            </p>
-          </section>
-          <section>
-            <h3><code>ComboSecurityScheme</code></h3>
-            <p>
-              A combination of other security schemes identified by the <a>Vocabulary Term</a> <code>combo</code> (i.e.,
-              <code>"scheme": "combo"</code>). Elements of this scheme define various ways in which other named schemes
-              defined in <code>securityDefinitions</code>, including other
-              <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> definitions, are to be combined to
-              create a new scheme definition.
-              <span class="rfc2119-assertion" id="td-security-combo-exclusive-oneof-or-allof"
-                >Exactly one of either <code>oneOf</code> or <code>allOf</code> <i>vocabulary terms</i> MUST be
-                included.</span
-              >
-              <!-- Redundant, table states "two or more" already <scan class="rfc2119-assertion">The array given as a value associated with either <code>oneOf</code> or <code>allOf</code> MUST have at least two elements.</scan> -->
-              Only security scheme definitions which can be used together can be combined with <code>allOf</code>. For
-              example, it is not possible in general to combine different OAuth 2.0 flows together using
-              <code>allOf</code> unless one applies to a proxy and one to the endpoint. Note that when multiple named
-              security scheme definitions are listed in a <code>security</code> field the same semantics apply as in an
-              <code>allOf</code> combination (and the same limitations on allowable combinations). The
-              <code>oneOf</code> combination is equivalent to using different security schemes on forms that are
-              otherwise identical. In this sense a <code>oneOf</code> scheme is not an essential feature but it does
-              avoid redundancy in such cases.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in ComboSecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--ComboSecurityScheme">
-                  <td><code>oneOf</code></td>
-                  <td>
-                    Array of two or more strings identifying other named security scheme definitions, any one of which,
-                    when satisfied, will allow access. Only one may be chosen for use.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-allOf--ComboSecurityScheme">
-                  <td><code>allOf</code></td>
-                  <td>
-                    Array of two or more strings identifying other named security scheme definitions, all of which must
-                    be satisfied for access.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <!-- <p class="ednote" title="Recursive Use">The 
-<a href="#combosecurityscheme">ComboSecurityScheme</a> may be applied recursively to generate Boolean expressions for combinations of security schemes. One use case for this is when multiple security schemes are needed for a proxy in combination with multiple security schemes for an endpoint.  Suppose for example a proxy accepts either schemes A or B, and then the endpoint accepts either C or D.  Then the possible combinations are AC, AD, BC, and BD.  These could be expressed directly at the <code>Form</code> level but would require four-fold redundancy.  Instead, three <code>combo</code> nodes can be used to combine the four leaf schemes in the correct way into a single scheme.  It is not clear however if other use cases exist for deeper expression trees and if not, we may consider limiting the recursion depth to two.</p>-->
-          </section>
-          <section>
-            <h3><code>BasicSecurityScheme</code></h3>
-            <p>
-              Basic Authentication [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-rfc7617"
-                  title="The 'Basic' HTTP Authentication Scheme"
-                  >RFC7617</a
-                ></cite
-              >] security configuration identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>basic</code> (i.e., <code>"scheme": "basic"</code>), using an unencrypted username and password.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in BasicSecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme">
-                  <td><code>name</code></td>
-                  <td>Name for query, header, cookie, or uri parameters.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme">
-                  <td><code>in</code></td>
-                  <td>Specifies the location of security authentication information.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
-                    <code>auto</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>DigestSecurityScheme</code></h3>
-            <p>
-              Digest Access Authentication [<cite
-                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication"
-                  >RFC7616</a
-                ></cite
-              >] security configuration identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>digest</code> (i.e., <code>"scheme": "digest"</code>). This scheme is similar to basic
-              authentication but with added features to avoid man-in-the-middle attacks.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in DigestSecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme">
-                  <td><code>name</code></td>
-                  <td>Name for query, header, cookie, or uri parameters.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme">
-                  <td><code>in</code></td>
-                  <td>Specifies the location of security authentication information.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
-                    <code>auto</code>)
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme">
-                  <td><code>qop</code></td>
-                  <td>Quality of protection.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>auth</code>, or <code>auth-int</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>APIKeySecurityScheme</code></h3>
-            <p>
-              API key authentication security configuration identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>apikey</code> (i.e., <code>"scheme": "apikey"</code>). This scheme is to be used when the access
-              token is opaque, for example when a key in an unknown or proprietary format is provided by a cloud service
-              provider. In this case the key may not be using a standard token format. This scheme indicates that the
-              key provided by the service provider needs to be supplied as part of service requests using the mechanism
-              indicated by the <code>"in"</code> field.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in APIKeySecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme">
-                  <td><code>name</code></td>
-                  <td>Name for query, header, cookie, or uri parameters.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme">
-                  <td><code>in</code></td>
-                  <td>Specifies the location of security authentication information.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>,
-                    <code>uri</code>, or <code>auto</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>BearerSecurityScheme</code></h3>
-            <p>
-              Bearer Token [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-rfc6750"
-                  title="The OAuth 2.0 Authorization Framework: Bearer Token Usage"
-                  >RFC6750</a
-                ></cite
-              >] security configuration identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>bearer</code> (i.e., <code>"scheme": "bearer"</code>) for situations where bearer tokens are used
-              independently of OAuth2. If the <code>oauth2</code> scheme is specified it is not generally necessary to
-              specify this scheme as well as it is implied. For <code>format</code>, the value
-              <code>jwt</code> indicates conformance with [<cite
-                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)"
-                  >RFC7519</a
-                ></cite
-              >], <code>jws</code> indicates conformance with [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-rfc7797"
-                  title="JSON Web Signature (JWS) Unencoded Payload Option"
-                  >RFC7797</a
-                ></cite
-              >], <code>cwt</code> indicates conformance with [<cite
-                ><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)"
-                  >RFC8392</a
-                ></cite
-              >], and <code>jwe</code> indicates conformance with [<cite
-                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)"
-                  >RFC7516</a
-                ></cite
-              >], with values for <code>alg</code> interpreted consistently with those standards.
-              <span class="rfc2119-assertion" id="td-security-bearer-format-extensions"
-                >Other formats and algorithms for bearer tokens MAY be specified in vocabulary extensions</span
-              >.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in BearerSecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme">
-                  <td><code>authorization</code></td>
-                  <td>URI of the authorization server.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme">
-                  <td><code>name</code></td>
-                  <td>Name for query, header, cookie, or uri parameters.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme">
-                  <td><code>in</code></td>
-                  <td>Specifies the location of security authentication information.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
-                    <code>auto</code>)
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme">
-                  <td><code>alg</code></td>
-                  <td>Encoding, encryption, or digest algorithm.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>ES256</code>, or <code>ES512-256</code>)
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme">
-                  <td><code>format</code></td>
-                  <td>Specifies format of security authentication information.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>PSKSecurityScheme</code></h3>
-            <p>
-              Pre-shared key authentication security configuration identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>psk</code> (i.e., <code>"scheme": "psk"</code>). This is meant to identify that a standard is used
-              for pre-shared keys such as TLS-PSK [[RFC4279]], and that the ciphersuite used for keys will be
-              established during protocol negotiation.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in PSKSecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-identity--PSKSecurityScheme">
-                  <td><code>identity</code></td>
-                  <td>Identifier providing information which can be used for selection or confirmation.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>OAuth2SecurityScheme</code></h3>
-            <p>
-              OAuth 2.0 authentication security configuration for systems conformant with [[!RFC6749]] and [[!RFC8252]],
-              <!-- and
-            (for the <code>device</code> flow) [[!RFC8628]],-->
-              identified by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e., <code>"scheme": "oauth2"</code>).
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in OAuth2SecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme">
-                  <td><code>authorization</code></td>
-                  <td>
-                    URI of the authorization server.<!-- In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]. -->
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme">
-                  <td><code>token</code></td>
-                  <td>URI of the token server.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme">
-                  <td><code>refresh</code></td>
-                  <td>URI of the refresh server.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme">
-                  <td><code>scopes</code></td>
-                  <td>
-                    Set of authorization scope identifiers provided as an array. These are provided in tokens returned
-                    by an authorization server and associated with forms in order to identify what resources a client
-                    may access and how. The values associated with a form SHOULD be chosen from those defined in an
-                    <code>OAuth2SecurityScheme</code> active on that form.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme">
-                  <td><code>flow</code></td>
-                  <td>Authorization flow.</td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>code</code>, or <code>client</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              <span class="rfc2119-assertion" id="td-security-oauth2-code-flow"
-                >For the <code>code</code> flow both <code>authorization</code> and <code>token</code>
-                <a>vocabulary terms</a> MUST be included.</span
-              >
-              <span class="rfc2119-assertion" id="td-security-oauth2-client-flow"
-                >For the <code>client</code> flow <code>token</code> <a>vocabulary term</a> MUST be included.</span
-              >
-              <span class="rfc2119-assertion" id="td-security-oauth2-client-flow-no-auth"
-                >For the <code>client</code> flow <code>authorization</code> <a>vocabulary term</a> MUST NOT be
-                included.</span
-              >
-              <!-- <span class="rfc2119-assertion" id="td-security-oauth2-device-flow">For the
+          <section><h3><code>SecurityScheme</code></h3><p><p>Metadata describing the configuration of a security
+          mechanism. <span class="rfc2119-assertion" id="td-security-scheme-name">The value assigned to the name
+          <code>scheme</code> MUST be defined within a 
+          <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
+          included in the <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>,
+          either in the standard <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined
+          in <a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD
+          Information Model</a> or in a <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context
+          Extension</a>.</span>
+          </p><p>
+          <span class="rfc2119-assertion" id="td-security-no-secrets">For all security schemes,
+          any keys, passwords, or other sensitive information directly providing access 
+          MUST NOT be stored in the TD and should instead
+          be shared and stored out-of-band via other mechanisms.</span> 
+          The purpose of a TD is to describe how to access a Thing if and only if a Consumer 
+          already has authorization, and is not meant be used to grant that authorization.
+          </p><p>Each security scheme object used in a TD defines a set of requirements to be met before access can be granted.
+          We say a security scheme is <em>satisfied</em> when all its requirements are met.
+          In some cases requirements from multiple security schemes will have to be met before access can be granted.
+          </p><p>
+          Security schemes generally may require additional authentication
+          parameters, such as a password or key.
+          The location of this information is indicated by the
+          value associated with the name <code>in</code>, often in combination with the value associated with <code>name</code>.
+          The value associated with <code>in</code> can take one of the following values:
+          </p>
+          <dl>
+          <dt><code>header</code>:</dt>
+          <dd>The parameter will be given
+            in a header provided by the protocol, with the name of the header
+            provided by the value of <code>name</code>.</dd>
+          <dt><code>query</code>:</dt>
+          <dd>The parameter will be appended to the URI as a query parameter, with the name of the 
+            query parameter provided by <code>name</code>.</dd>
+          <dt><code>body</code>:</dt>
+          <dd>The parameter will be provided in the body of the request payload, with the data schema element  
+            used provided by <code>name</code>.
+            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer">When used in the context of a 
+            <code>body</code> security information location, the value of <code>name</code> 
+            MUST be in the form of a JSON pointer [[!RFC6901]] relative to 
+            the root of the input <code>DataSchema</code> for each interaction it is used with.</span> 
+            Since this value is not a fragment identifier, and is not relative to the root of the TD but
+            to whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
+            it is a "pure" JSON pointer.
+            Since this value is not a fragment identifier, it also does not
+            need to URL-encode special characters.
+            The targeted element may or may not already exist at the specified location in the referenced object or array schema (consequently the mechanism is not applicable to simple types).
+            If it does not, it will be inserted. This avoids having to duplicate definitions in the data schemas of
+            every interaction.
+            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-creatable">When an element
+            of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
+            does not already exist in the indicated schema, it MUST
+            be possible to insert the indicated element
+            at the location indicated by the pointer.</span>
+            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-array">The JSON pointer
+            used in the <code>body</code> locator MAY
+            use the "<code>-</code>" character to indicate a non-existent array element when 
+            it is necessary to insert an element after the last element of an existing array.
+            </span>
+            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-type">The element referenced
+            (or created) by a 
+            <code>body</code> security information location
+            MUST be required and of type "<code>string</code>".</span> 
+            If <code>name</code> is not given, it is assumed the entire body
+            is to be used as the security parameter.
+          </dd>
+          <dt><code>cookie</code>:</dt>
+          <dd>The parameter is stored in a cookie identified by the value of   
+            <code>name</code>.
+          </dd>
+          <dt><code>uri</code>:</dt>
+          <dd>The parameter is embedded in the URI itself, which is encoded in the
+          relevant interaction using a URI template variable defined by the value of <code>name</code>.
+          This is more general than the <code>query</code> mechanism but more complex. 
+          <span class="rfc2119-assertion" id="td-security-in-query-over-uri">The value <code>uri</code> 
+          SHOULD be specified 
+          for the name <code>in</code> in a security scheme only if
+          <code>query</code> is not applicable.</span>  
+          <span class="rfc2119-assertion" id="td-security-in-uri-variable">The URIs provided
+          in interactions where a security scheme using <code>uri</code> as the value for <code>in</code>
+          MUST be a URI template including the defined variable.
+          </span>  
+          </dd>
+          <dt><code>auto</code>:</dt>
+          <dd>The location is determined as part of the protocol, or negotiated. 
+          <span class="rfc2119-assertion" id="td-security-security-vocab-auto-in-no-name">If a value of <code>auto</code> 
+          is set for the <code>in</code> field of a <code>SecurityScheme</code>, 
+          then the <code>name</code> field SHOULD NOT be set.</span> 
+          In this case, the application of the <code>SecurityScheme</code> is subject to 
+          the respective specification for the given protocol (e.g. [[!RFC8288]] when using the 
+          <code>BasicSecurityScheme</code> with HTTP).
+          </dd>
+          </dl>
+          <p>
+          If multiple parameters are needed for a security scheme, repeat the security scheme definition for
+          each parameter and combine them using a <code>combo</code> security scheme and <code>allOf</code>.
+          In some cases parameters may not actually be secret but a user may wish to leave them
+          out of the TD to help protect privacy.  As an example of this, some security mechanisms
+          require both a client identifier and a secret key.  In theory, the client identifier is 
+          public however it may be hard to update and pose a tracking risk.  In such a case it can
+          be provided as an additional security parameter so it does not appear in the TD.
+          </p><p>
+          <span class="rfc2119-assertion" id="td-security-uri-variables-distinct">The names of URI variables 
+          declared in a <code>SecurityScheme</code> 
+          MUST be distinct from all other URI variables 
+          declared in the TD.</span></p><table class="def numbered"><caption>Vocabulary Terms in SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable)
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme"><td><code>proxy</code></td><td>URI of the proxy server this security
+                configuration provides access to. If not given, the
+                corresponding security configuration is for the
+                endpoint.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme"><td><code>scheme</code></td><td>Identification of the security mechanism being
+                configured.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>nosec</code>, <code>combo</code>, <code>basic</code>, <code>digest</code>, <code>bearer</code>, <code>psk</code>, <code>oauth2</code>, <code>apikey</code>, or <code>auto</code>)</td></tr></tbody></table><p>The class <code>SecurityScheme</code> has the following subclasses:</p><ul><li><a href="#nosecurityscheme"><code>NoSecurityScheme</code></a></li>
+<li><a href="#autosecurityscheme"><code>AutoSecurityScheme</code></a></li>
+<li><a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a></li>
+<li><a href="#basicsecurityscheme"><code>BasicSecurityScheme</code></a></li>
+<li><a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a></li>
+<li><a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a></li>
+<li><a href="#bearersecurityscheme"><code>BearerSecurityScheme</code></a></li>
+<li><a href="#psksecurityscheme"><code>PSKSecurityScheme</code></a></li>
+<li><a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a></li></ul></section>
+<section><h3><code>NoSecurityScheme</code></h3><p>A security configuration corresponding to identified
+          by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+          <code>nosec</code> (i.e., <code>"scheme":
+          "nosec"</code>), indicating there is no authentication or
+          other mechanism required to access the resource.</p></section>
+<section><h3><code>AutoSecurityScheme</code></h3><p>An automatic authentication security configuration identified by the term <code>auto</code> (i.e., <code>"scheme": "auto"</code>). This scheme indicates that the security parameters are going to be negotiated by the underlying protocols at runtime, subject to the respective specifications for the protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).</p></section>
+<section><h3><code>ComboSecurityScheme</code></h3><p>A combination of other security schemes identified by the <a>Vocabulary Term</a> <code>combo</code> (i.e., <code>"scheme": "combo"</code>).  Elements of this scheme define various ways in which other named schemes defined in <code>securityDefinitions</code>, including other <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> definitions, are to be combined to create a new scheme definition.  <span class="rfc2119-assertion" id="td-security-combo-exclusive-oneof-or-allof">Exactly one of either <code>oneOf</code> or <code>allOf</code> <i>vocabulary terms</i> MUST be included.</span> <!-- Redundant, table states "two or more" already <scan class="rfc2119-assertion">The array given as a value associated with either <code>oneOf</code> or <code>allOf</code> MUST have at least two elements.</scan> --> Only security scheme definitions which can be used together can be combined with <code>allOf</code>.  For example, it is not possible in general to combine different OAuth 2.0 flows together using <code>allOf</code> unless one applies to a proxy and one to the endpoint.  Note that when multiple named security scheme definitions are listed in a <code>security</code> field the same semantics apply as in an <code>allOf</code> combination (and the same limitations on allowable combinations).  The <code>oneOf</code> combination is equivalent to using different security schemes on forms that are otherwise identical.  In this sense a <code>oneOf</code> scheme is not an essential feature but it does avoid redundancy in such cases.</p><table class="def numbered"><caption>Vocabulary Terms in ComboSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-oneOf--ComboSecurityScheme"><td><code>oneOf</code></td><td>Array of two or more strings identifying other named security scheme definitions, any one of which, when satisfied, will allow access.  Only one may be chosen for use.</td><td>mandatory</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-allOf--ComboSecurityScheme"><td><code>allOf</code></td><td>Array of two or more strings identifying other named security scheme definitions, all of which must be satisfied for access.</td><td>mandatory</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><!-- <p class="ednote" title="Recursive Use">The 
+<a href="#combosecurityscheme">ComboSecurityScheme</a> may be applied recursively to generate Boolean expressions for combinations of security schemes. One use case for this is when multiple security schemes are needed for a proxy in combination with multiple security schemes for an endpoint.  Suppose for example a proxy accepts either schemes A or B, and then the endpoint accepts either C or D.  Then the possible combinations are AC, AD, BC, and BD.  These could be expressed directly at the <code>Form</code> level but would require four-fold redundancy.  Instead, three <code>combo</code> nodes can be used to combine the four leaf schemes in the correct way into a single scheme.  It is not clear however if other use cases exist for deeper expression trees and if not, we may consider limiting the recursion depth to two.</p>--></section>
+<section><h3><code>BasicSecurityScheme</code></h3><p>Basic Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7617" title="The 'Basic' HTTP Authentication Scheme">RFC7617</a></cite>]
+          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>basic</code> (i.e.,
+          <code>"scheme": "basic"</code>), using an unencrypted
+          username and password.</p><table class="def numbered"><caption>Vocabulary Terms in BasicSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
+               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr></tbody></table></section>
+<section><h3><code>DigestSecurityScheme</code></h3><p>Digest Access Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication">RFC7616</a></cite>]
+          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>digest</code> (i.e.,
+          <code>"scheme": "digest"</code>). This scheme is similar
+          to basic authentication but with added features to avoid
+          man-in-the-middle attacks.</p><table class="def numbered"><caption>Vocabulary Terms in DigestSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
+               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme"><td><code>qop</code></td><td>Quality of protection.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>auth</code>, or <code>auth-int</code>)</td></tr></tbody></table></section>
+<section><h3><code>APIKeySecurityScheme</code></h3><p>API key authentication security configuration
+          identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+          <code>apikey</code> (i.e., <code>"scheme":
+          "apikey"</code>). 
+          This scheme is to be used when the access token is opaque,
+          for example when a key in an unknown or proprietary format is provided by a cloud service provider.
+          In this case the key may not be using a standard token format.
+          This scheme indicates that the key provided by the service provider 
+          needs to be supplied as part 
+          of service requests using the mechanism indicated by the <code>"in"</code> field.</p><table class="def numbered"><caption>Vocabulary Terms in APIKeySecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
+               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme"><td><code>in</code></td><td>Specifies the location of security
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, <code>uri</code>, or <code>auto</code>)</td></tr></tbody></table></section>
+<section><h3><code>BearerSecurityScheme</code></h3><p>Bearer Token [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6750" title="The OAuth 2.0 Authorization Framework: Bearer Token Usage">RFC6750</a></cite>]
+          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>bearer</code> (i.e.,
+          <code>"scheme": "bearer"</code>) for situations where
+          bearer tokens are used independently of OAuth2. If the
+          <code>oauth2</code> scheme is specified it is not
+          generally necessary to specify this scheme as well as it
+          is implied. For <code>format</code>, the value
+          <code>jwt</code> indicates conformance with
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>],
+          <code>jws</code> indicates conformance with
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7797" title="JSON Web Signature (JWS) Unencoded Payload Option">RFC7797</a></cite>],
+          <code>cwt</code> indicates conformance with
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)">RFC8392</a></cite>], and
+          <code>jwe</code> indicates conformance with
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>], with
+          values for <code>alg</code> interpreted consistently with
+          those standards. <span class="rfc2119-assertion" id="td-security-bearer-format-extensions">Other formats and
+          algorithms for bearer tokens MAY be specified in vocabulary
+          extensions</span>.</p><table class="def numbered"><caption>Vocabulary Terms in BearerSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
+               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme"><td><code>alg</code></td><td>Encoding, encryption, or digest algorithm.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>ES256</code>, or <code>ES512-256</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme"><td><code>format</code></td><td>Specifies format of security authentication
+                 information.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)</td></tr></tbody></table></section>
+<section><h3><code>PSKSecurityScheme</code></h3><p>Pre-shared key authentication security configuration
+          identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+          <code>psk</code> (i.e., <code>"scheme":
+          "psk"</code>).
+          This is meant to identify that a standard is used for pre-shared keys such as TLS-PSK [[RFC4279]], 
+          and that the ciphersuite used for keys will be established during protocol negotiation.</p><table class="def numbered"><caption>Vocabulary Terms in PSKSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-identity--PSKSecurityScheme"><td><code>identity</code></td><td>Identifier providing information which can be
+                   used for selection or confirmation.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+<section><h3><code>OAuth2SecurityScheme</code></h3><p>OAuth 2.0 authentication security configuration
+            for systems conformant with [[!RFC6749]] and [[!RFC8252]], <!-- and
+            (for the <code>device</code> flow) [[!RFC8628]],--> identified
+            by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e.,
+            <code>"scheme": "oauth2"</code>).</p><table class="def numbered"><caption>Vocabulary Terms in OAuth2SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.<!-- In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]. --></td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme"><td><code>token</code></td><td>URI of the token server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme"><td><code>refresh</code></td><td>URI of the refresh server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided
+                as an array. These are provided in tokens returned
+                by an authorization server and associated with
+                forms in order to identify what resources a client
+                may access and how. The values associated with a
+                form SHOULD be chosen from those defined in an
+                <code>OAuth2SecurityScheme</code> active on that
+                form.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme"><td><code>flow</code></td><td>Authorization flow.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>code</code>, or <code>client</code>)</td></tr></tbody></table><p><span class="rfc2119-assertion" id="td-security-oauth2-code-flow">For
+            the <code>code</code> flow both <code>authorization</code> and <code>token</code> <a>vocabulary terms</a>
+            MUST be included.</span> <span class="rfc2119-assertion" id="td-security-oauth2-client-flow">For
+            the <code>client</code> flow <code>token</code> <a>vocabulary term</a> MUST be included.</span>
+            <span class="rfc2119-assertion" id="td-security-oauth2-client-flow-no-auth">For the
+            <code>client</code> flow <code>authorization</code> <a>vocabulary term</a> MUST NOT be included.</span>
+            <!-- <span class="rfc2119-assertion" id="td-security-oauth2-device-flow">For the
             <code>device</code> flow both <code>authorization</code> and <code>token</code> <a>vocabulary terms</a>
             MUST be included.</span> In the case of the <code>device</code> flow the value
             provided for <code>authorization</code> <a>vocabulary terms</a> refers to the device authorization endpoint
-            defined in [[!RFC8628]]. -->
-              The mandatory elements for each flow are summarized in the following table:
+            defined in [[!RFC8628]]. --> The mandatory elements for each flow are summarized in the
+            following table:
             </p>
-            <table class="def numbered">
-              <tr>
-                <th>Element</th>
-                <th><code>code</code></th>
-                <th><code>client</code></th>
-              </tr>
-              <tr>
-                <td><code>authorization</code></td>
-                <td>mandatory</td>
-                <td>omit</td>
-                <!-- <td>mandatory; refers to device authorization endpoint</td> -->
-              </tr>
-              <tr>
-                <td><code>token</code></td>
-                <td>mandatory</td>
-                <td>mandatory</td>
-                <!-- <td>mandatory</td> -->
-              </tr>
-              <tr>
-                <td><code>refresh</code></td>
-                <td>optional</td>
-                <td>optional</td>
-                <!-- <td>optional</td> -->
-              </tr>
-            </table>
+            <table class="def numbered"> <tr><th>Element</th><th><code>code</code></th><th><code>client</code></th></tr> <tr><td><code>authorization</code></td><td>mandatory</td><td>omit</td><!-- <td>mandatory; refers to device authorization endpoint</td> --></tr> <tr><td><code>token</code></td><td>mandatory</td><td>mandatory</td><!-- <td>mandatory</td> --></tr> <tr><td><code>refresh</code></td><td>optional</td><td>optional</td><!-- <td>optional</td> --></tr> </table>
             <!-- 
 	    <p class="ednote"> Note that the <code>OAuth2SecurityScheme</code> class definition lists these elements as "optional". 
             In fact whether they are mandatory or not depends on the flow.  The <code>token</code>
@@ -3378,8 +1938,7 @@
             however an alternative design where there is a separate element,
             <code>device_authorization</code>, which MUST be included for the <code>device</code>
             flow (and then the regular authorization endpoint then MUST NOT be used).</p>
-	    -->
-          </section>
+	    --></section>
         </section>
 
         <section id="sec-hypermedia-vocabulary-definition">
@@ -3395,843 +1954,587 @@
           </p>
 
           <!-- rendered from RDF definitions -->
-          <section>
-            <h3><code>Link</code></h3>
-            <p>
-              A link can be viewed as a statement of the form "<b><em>link context</em></b> has a
-              <b><em>relation type</em></b> resource at <b><em>link target</em></b
-              >", where the optional <b><em>target attributes</em></b> may further describe the resource.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in Link Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-href--Link">
-                  <td><code>href</code></td>
-                  <td>Target IRI of a link or submission target of a form.</td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-type--Link">
-                  <td><code>type</code></td>
-                  <td>
-                    Target attribute providing a hint indicating what the media type [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-rfc2046"
-                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
-                        >RFC2046</a
-                      ></cite
-                    >] of the result of dereferencing the link should be.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-rel--Link">
-                  <td><code>rel</code></td>
-                  <td>A link relation type identifies the semantics of a link.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link">
-                  <td><code>anchor</code></td>
-                  <td>
-                    Overrides the link context (by default the Thing itself identified by its <code>id</code>) with the
-                    given URI or IRI.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link">
-                  <td><code>sizes</code></td>
-                  <td>
-                    Target attribute that specifies one or more sizes for the referenced icon. Only applicable for
-                    relation type "icon". The value pattern follows {Height}x{Width} (e.g., "16x16", "16x16 32x32").
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-hreflang--Link">
-                  <td><code>hreflang</code></td>
-                  <td>
-                    The hreflang attribute specifies the language of a linked document. The value of this must be a
-                    valid language tag [[BCP47]].
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p class="note" title="hreflang type">
-              The <code>hreflang</code> attribute is allowed to be a <code>string</code> or <code>array</code> in this
-              version of the spec. Depending on the result of [[LINKSET-MEDIA-TYPES]] the values of
-              <code>hrefLang</code> can be restricted to <code>array</code> only.
-            </p>
-            <p>
-              Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a
-              Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description is an instance of a specific
-              Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended
-              to reuse existing and established
-              <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
-            </p>
-            <p>
-              In the following a best practice relation type table is introduced that is recommended to use within WoT
-              <a>Thing Description</a> or <a>Thing Model</a> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Best practice relation type table
-              </caption>
-              <thead>
-                <tr>
-                  <th>Value</th>
-                  <th>Occurrence</th>
-                  <th>Explanation</th>
-                  <th>Source of value origin</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>
+          <section><h3><code>Link</code></h3><p>A link can be viewed as a statement of the form
+          "<b><em>link context</em></b> has a <b><em>relation
+          type</em></b> resource at <b><em>link target</em></b>",
+          where the optional <b><em>target attributes</em></b> may
+          further describe the resource.</p><table class="def numbered"><caption>Vocabulary Terms in Link Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Link"><td><code>href</code></td><td>Target IRI of a link or submission target of a
+                form.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-type--Link"><td><code>type</code></td><td>Target attribute providing a hint indicating
+                what the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]
+                of the result of dereferencing the link should
+                be.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-rel--Link"><td><code>rel</code></td><td>A link relation type identifies the semantics
+                of a link.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link"><td><code>anchor</code></td><td>Overrides the link context (by default the
+                Thing itself identified by its <code>id</code>)
+                with the given URI or IRI.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link"><td><code>sizes</code></td><td>Target attribute that specifies one or more sizes for the referenced icon. 
+                    Only applicable for relation type "icon". The value pattern follows 
+                    {Height}x{Width} (e.g., "16x16", "16x16 32x32").</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-hreflang--Link"><td><code>hreflang</code></td><td>The hreflang attribute specifies the language of a linked document. The value of this must be a valid language tag [[BCP47]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><p class="note" title="hreflang type">
+        The <code>hreflang</code> attribute is allowed to be a <code>string</code> or <code>array</code> in this version of the spec. Depending on the result of [[LINKSET-MEDIA-TYPES]] the values of <code>hrefLang</code> can be restricted to <code>array</code> only.
+	</p>
+     <p>Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description
+    is an instance of a specific Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended to reuse existing and established 
+    <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
+    </p>
+        <p>In the following a best practice relation type table is introduced that is recommended to use within WoT <a>Thing Description</a>
+    or <a>Thing Model</a> instances.      
+    </p>
+    <table class="def numbered">
+        <caption>Best practice relation type table</caption>
+        <thead>
+            <tr>
+                <th>Value</th>                
+                <th>Occurrence</th>
+                <th>Explanation</th>
+                <th>Source of value origin</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr >
+                <td>
                     <code>icon</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>Imports an icon associated to the <a>Thing</a> (e.g., for UI purposes).</td>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Imports an icon associated to the <a>Thing</a> (e.g., for UI purposes).</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr >
+                <td>
                     <code>service-doc</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>Relation to a resource that provide (human-readable) documentation or descriptions.</td>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Relation to a resource that provide (human-readable) documentation or descriptions.</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr >
+                <td>
                     <code>alternate</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>
-                    Point to alternative representation of the <a>Thing</a> (i.e. RDF-Turtle, human-readable HTML
-                    document, ...).
-                  </td>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Point to alternative representation of the <a>Thing</a> (i.e. RDF-Turtle, human-readable HTML document, ...).</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr >
+                <td>
                     <code>type</code>
-                  </td>
-                  <td>0..1</td>
-                  <td>
-                    Indicate that the <a>Thing</a> is an instance of the target resource such as to a
-                    <a>Thing Model</a>.
-                  </td>
-                  <td>
+                </td>
+                <td>
+                    0..1
+                </td>
+                <td>Indicate that the <a>Thing</a> is an instance of the target resource such as to a <a>Thing Model</a>.</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr >
+                <td>
                     <code>tm:extends</code>
-                  </td>
-                  <td>0..1</td>
-                  <td>
-                    Extends an existing definition of the target resource such as a <a>Thing Model</a>. Only applicable
-                    for Thing Model definitions.
-                  </td>
-                  <td>W3C WoT Thing Model</td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+                <td>
+                    0..1
+                </td>
+                <td>Extends an existing definition of the target resource such as a <a>Thing Model</a>. Only applicable for Thing Model definitions.</td>
+                <td>
+                    W3C WoT Thing Model
+                </td>
+            </tr>
+            <tr >
+                <td>
                     <code>tm:submodel</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>
-                    Used to compose one or multiple <a>Thing Models</a>. Only applicable for Thing Model definitions.
-                  </td>
-                  <td>W3C WoT Thing Model</td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Used to compose one or multiple <a>Thing Models</a>. Only applicable for Thing Model definitions.</td>
+                <td>
+                    W3C WoT Thing Model
+                </td>
+            </tr>                         
+            <tr >
+                <td>
                     <code>manifest</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>
-                    Point to the web app manifest of a web application which provides, e.g., a user interface with which
-                    a user can interact with the Thing (also see [[APPMANIFEST]]).
-                  </td>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Point to the web app manifest of a web application which provides, e.g., a user interface with which a user can interact with the Thing (also see [[APPMANIFEST]]).</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <code>proxy-to</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>
-                    Target resource provide the address of a proxy. Additional security metadata can be provided using
-                    the <code>proxy</code> field in a <a href="#securityscheme">SecurityScheme</a>.
-                  </td>
-                  <td>W3C WoT Security and WoT Binding Template</td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Target resource provide the address of a proxy. Additional security metadata can be provided using the <code>proxy</code> field in a <a href="#securityscheme">SecurityScheme</a>.</td>
+                <td>
+                    W3C WoT Security and WoT Binding Template
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <code>collection</code>
-                  </td>
-                  <td>0..1</td>
-                  <td>Points to a collections of <a>Things</a>.</td>
-                  <td>
+                </td>
+                <td>
+                    0..1
+                </td>
+                <td>Points to a collections of <a>Things</a>.</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <code>item</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>Points to a <a>Thing</a> that is member of the current <a>Thing</a> collections.</td>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Points to a <a>Thing</a> that is member of the current <a>Thing</a> collections.</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <code>predecessor-version</code>
-                  </td>
-                  <td>0..1</td>
-                  <td>Points to a previous <a>Thing Description</a> or <a>Thing Model</a> version.</td>
-                  <td>
+                </td>
+                <td>
+                    0..1
+                </td>
+                <td>Points to a previous <a>Thing Description</a> or <a>Thing Model</a> version.</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <code>controlledBy</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>Refers to a <a>Thing</a> that controls the context <a>Thing</a>.</td>
-                  <td>W3C Thing Description</td>
-                </tr>
-              </tbody>
-            </table>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Refers to a <a>Thing</a> that controls the context <a>Thing</a>.</td>
+                <td>
+                    W3C Thing Description
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    </section>
+<section><h3><code>Form</code></h3><p>A form can be viewed as a statement of "To perform an
+          <b><em>operation type</em></b> operation on <b><em>form
+          context</em></b>, make a <b><em>request method</em></b>
+          request to <b><em>submission target</em></b>" where the
+          optional <b><em>form fields</em></b> may further describe
+          the required request. In Thing Descriptions, the
+          <b><em>form context</em></b> is the surrounding Object,
+          such as Properties, Actions, and Events or the Thing
+          itself for meta-interactions.</p><table class="def numbered"><caption>Vocabulary Terms in Form Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Form"><td><code>href</code></td><td>Target IRI of a link or submission target of a
+                form.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form"><td><code>contentType</code></td><td>Assign a content type based on a media type
+                (e.g., <code>text/plain</code>) and potential
+                parameters (e.g., <code>charset=utf-8</code>) for
+                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form"><td><code>contentCoding</code></td><td>Content coding values indicate an encoding
+                transformation that has been or can be applied to a
+                representation. Content codings are primarily used
+                to allow a representation to be compressed or
+                otherwise usefully transformed without losing the
+                identity of its underlying media type and without
+                loss of information. Examples of content coding
+                include "gzip", "deflate", etc. .</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-security--Form"><td><code>security</code></td><td>Set of security definition names, chosen from
+                those defined in <code>securityDefinitions</code>.
+                These must all be satisfied for access to resources.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided
+                as an array. These are provided in tokens returned
+                by an authorization server and associated with
+                forms in order to identify what resources a client
+                may access and how. The values associated with a
+                form SHOULD be chosen from those defined in an
+                <code>OAuth2SecurityScheme</code> active on that
+                form.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-response--Form"><td><code>response</code></td><td>This optional term can be used if, e.g., the
+                output communication metadata differ from input
+                metadata (e.g., output contentType differ from the
+                input contentType). The response name contains
+                metadata that is only valid for the primary response
+                messages.</td><td>optional</td><td><a href="#expectedresponse"><code>ExpectedResponse</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-additionalResponses--Form"><td><code>additionalResponses</code></td><td>This optional term can be used if additional expected responses
+                are possible, e.g. for error reporting.  Each additional response needs to be 
+                distinguished from others in some way (for example, by specifying
+                a protocol-specific error code), and may also have its own data schema.</td><td>optional</td><td><a>Array</a> of <a href="#additionalexpectedresponse"><code>AdditionalExpectedResponse</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form"><td><code>subprotocol</code></td><td>Indicates the exact mechanism by which an
+                interaction will be accomplished for a given
+                protocol when there are multiple options. For
+                example, for HTTP and Events, it indicates which of
+                several available mechanisms should be used for
+                asynchronous notifications such as long polling
+                (<code>longpoll</code>), WebSub [<cite><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite>]
+                (<code>websub</code>), Server-Sent Events
+                (<code>sse</code>) [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite>] (also known as
+                EventSource). Please note that there is no
+                restriction on the subprotocol selection and other
+                mechanisms can also be announced by this
+                subprotocol term.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-op--Form"><td><code>op</code></td><td>Indicates the semantic intention of performing
+                the operation(s) described by the form. For
+                example, the Property interaction allows get and
+                set operations. The protocol binding may contain a
+                form for the get operation and a different form for
+                the set operation. The op attribute indicates which
+                form is for which and allows the client to select
+                the correct form for the operation required. op can
+                be assigned one or more interaction verb(s) each
+                representing a semantic intention of an
+                operation.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>, <code>unobserveproperty</code>, <code>invokeaction</code>, <code>queryaction</code>, <code>cancelaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>, <code>readallproperties</code>, <code>writeallproperties</code>, <code>readmultipleproperties</code>, <code>writemultipleproperties</code>, <code>observeallproperties</code>, <code>unobserveallproperties</code>, <code>subscribeallevents</code>, <code>unsubscribeallevents</code>, or <code>queryallactions</code>)</td></tr></tbody></table><p>Possible values for the <code>contentCoding</code>
+          property can be found, e.g., in the <a href=
+          "https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
+          IANA HTTP content coding registry</a>.</p>
+          <p>The list of possible operation types of a form is
+          fixed. As of this version of the specification, it only
+          includes the well-known types necessary to implement the
+          WoT interaction model described in [<cite><a class=
+          "bibref" data-link-type="biblio" href=
+          "#bib-wot-architecture11" title=
+          "Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>].
+          Future versions of the standard may extend this list but
+          <span class="rfc2119-assertion" id=
+          "well-known-operation-types-only">operations types
+          MUST be restricted to the values in the
+          table below.</span></p>
+
+        <div id="table-operation-types">
+          <table class="def numbered">
+            <caption>Well-known operation types</caption>
+            <thead>
+              <tr>
+                <th>Operation Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>readproperty</td>
+                <td>Identifies the read operation on
+                  Property Affordances to retrieve the
+                  corresponding data.</td>
+              </tr>
+              <tr>
+                <td>writeproperty</td>
+                <td>Identifies the write operation on
+                  Property Affordances to update the
+                  corresponding data.</td>
+              </tr>
+              <tr>
+                <td>observeproperty</td>
+                <td>Identifies the observe operation on
+                  Property Affordances to be notified with
+                  the new data when the Property is
+                  updated.</td>
+              </tr>
+              <tr>
+                <td>unobserveproperty</td>
+                <td>Identifies the unobserve
+                  operation on Property Affordances to stop
+                  the corresponding notifications.</td>
+              </tr>
+              <tr>
+                <td>invokeaction</td>
+                <td>Identifies the invoke operation on
+                  Action Affordances to perform the
+                  corresponding action.</td>
+              </tr>
+              <tr>
+                <td>queryaction</td>
+                <td>Identifies the querying operation on
+                  Action Affordances to get the status of the
+                  corresponding action.</td>
+              </tr>
+              <tr>
+                <td>cancelaction</td>
+                <td>Identifies the cancel operation on
+                  Action Affordances to cancel the ongoing
+                  corresponding action.</td>
+              </tr>
+              <tr>
+                <td>subscribeevent</td>
+                <td>Identifies the subscribe operation
+                  on Event Affordances to be notified by
+                  the Thing when the event occurs.</td>
+              </tr>
+              <tr>
+                <td>unsubscribeevent</td>
+                <td>Identifies the unsubscribe
+                  operation on Event Affordances to stop
+                  the corresponding notifications.</td>
+              </tr>
+              <tr>
+                <td>readallproperties</td>
+                <td>Identifies the readallproperties
+                  operation on a Thing to retrieve the
+                  data of all Properties in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>writeallproperties</td>
+                <td>Identifies the writeallproperties
+                  operation on a Thing to update the
+                  data of all writable Properties in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>readmultipleproperties</td>
+                <td>Identifies the readmultipleproperties
+                  operation on a Thing to retrieve the
+                  data of selected Properties in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>writemultipleproperties</td>
+                <td>Identifies the writemultipleproperties
+                  operation on a Thing to update the
+                  data of selected writable Properties in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>observeallproperties</td>
+                <td>Identifies the observeallproperties operation on
+                  Properties to be notified with new data when any Property is
+                  updated.</td>
+              </tr>
+              <tr>
+                <td>unobserveallproperties</td>
+                <td>Identifies the unobserveallproperties operation on
+                  Properties to stop notifications from all Properties in a 
+                  single interaction.</td>
+              </tr>
+              <tr>
+                <td>queryallactions</td>
+                <td>Identifies the queryallactions operation on a Thing to get the status of
+                 all Actions in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>subscribeallevents</td>
+                <td>Identifies the subscribeallevents operation on Events to subscribe
+                  to notifications from all Events in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>unsubscribeallevents</td>
+                <td>Identifies the unsubscribeallevents operation on Events to unsubscribe
+                  from notifications from all Events in a single interaction.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p>
+          A <a>Thing Description</a> of a WoT <a>producer</a> may have multiple forms entries with, e.g., different 
+          protocol and/or content types declarations that a <a>Consumer</a> could possibly support. In that case 
+          the Consumer may choose any form entry that works (e.g., the protocol and content type is supported) for them. 
+          When one form is chosen, it is expected that the <a>Consumer</a> will continue to use it as long as possible 
+          for every new interaction with the WoT <a>producer</a>.
+        </p>
+
+        <section id="sec-op-data-schema-mapping" class="informative">
+        <h4>Mapping op Values to Data Schemas</h4>
+
+        <p>
+            Protocols that can be used with TDs follow request-response or eventing mechanisms. 
+            The Data Schema of an affordance generally correlates with the <code>op</code> keywords used in <code>forms</code>.
+            The table below informatively summarizes the available data schema related terms with the <code>op</code> keywords.
+        </p>
+        <ul>
+            <li>Consumer to Thing applies for messages sent by the Consumer to the Thing, such as the value for writing a property.</li>
+            <li>Thing to Consumer applies for messages sent by the Thing to the Consumer, such as the value of a property value as the result of reading a property.</li>
+            <li>In case that there is no correlation with the data schema and the operation, it implies that no payload is required for executing the operation or no 
+            payload is expected as a result of the operation.</li>
+        </ul>
+
+        <table class="def numbered">
+        <caption>Mapping op Values to Data Schemas</caption>
+        <thead>
+            <tr>
+            <th>Operation Type</th>
+            <th>Consumer to Thing DataSchema Correlation</th>
+            <th>Thing to Consumer DataSchema Correlation</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+            <td>readproperty</td>
+            <td>No correlation.</td>
+            <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
+            </tr>
+            <tr>
+            <td>writeproperty</td>
+            <td>All fields in the Property Affordance without <code>"readOnly":true</code>.</td>
+            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+            </tr>
+            <tr>
+            <td>observeproperty</td>
+            <td>No correlation.</td>
+            <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
+            </tr>
+            <tr>
+            <td>unobserveproperty</td>
+            <td>No correlation.</td>
+            <td>No correlation.</td>
+            </tr>
+            <tr>
+            <td>invokeaction</td>
+            <td>Value of the <code>input</code> key.</td>
+            <td>Value of the <code>output</code> key.</td>
+            </tr>
+            <tr>
+            <td>queryaction</td>
+            <td>No correlation.</td>
+            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+            </tr>
+            <tr>
+            <td>cancelaction</td>
+            <td>No correlation.</td>
+            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+            </tr>
+            <tr>
+            <td>subscribeevent</td>
+            <td>Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code></td>
+            <td>Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code></td>
+            </tr>
+            <tr>
+            <td>unsubscribeevent</td>
+            <td>Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code></td>
+            <td>Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code></td>
+            </tr>
+        </tbody>
+        </table>
+        <p class="note" title="writeproperty and observeproperty relationship">
+            Writing to a property does not necessarily mean that a new value will be sent to the Consumer observing the property. 
+            It depends on the protocol and implementation.
+        </p>
+        <p class="note" title="Further Data Schemas mappings">
+            Further specification of how to map operations to data schemas, as well as mapping meta operations such as <code>readallproperties</code> 
+            can be found in the respective protocol specification of the [[WOT-BINDING-TEMPLATES]].
+        </p>
+        </section>
+
+        <section id="sec-response-usage">
+        <h4>Response-related Terms Usage</h4>
+
+          <p>The optional <code>response</code> name-value pair can
+          be used to provide metadata for the expected response
+          message. 
+          With the core vocabulary, it only includes
+          content type information, but TD Context Extensions could
+          be applied. <span class="rfc2119-assertion" id=
+          "td-expectedResponse-default-contentType">If no
+          <code>response</code> name-value pair is provided, it
+          MUST be assumed
+          that the content type of the response is equal to the
+          content type assigned to the Form instance.</span> Note
+          that <code>contentType</code> within an
+          <code>ExpectedResponse</code> 
+          <a href="#dfn-class" class=
+          "internalDFN" data-link-type="dfn">Class</a> does not
+          have a <a href="#dfn-default-value" class="internalDFN"
+          data-link-type="dfn">Default Value</a>. For instance, if
+          the value of the content type of the form is
+          <code>application/xml</code> the assumed value of the
+          content type of the response will be also
+          <code>application/xml</code>.</p>
+          <p>
+          In some cases additional responses might be possible.
+          One example of this is error responses but in some cases
+          there might also be additional successful responses.
+          In this case, the <code>response</code> name-value pair
+          is still used for the primary response but 
+          <code>additionalResponses</code> may also be provided,
+          whose value is an array of <code>AdditionalExpectedResponse</code>
+          objects.
+          Each additional response must be distinguished in some way from the primary
+          response, either by <code>contentType</code> or by
+          protocol-specific settings such as error code header values.
+          Each additional response may also have a data schema
+          which can differ from the normal output data schema for the
+          interaction.  
+          </p>
+          <p>In some use cases, input and output data might be
+          represented in a different form, for instance an Action
+          that accepts JSON, but returns an image. In such a case,
+          the optional <code>response</code> name-value pair can
+          describe the content type of the expected response.
+          <span class="rfc2119-assertion" id=
+          "td-expectedResponse-contentType">If the content type of
+          the expected response differs from the content type of
+          the form, the <code>Form</code> instance <em class=
+          "rfc2119" title="MUST">MUST</em> include a name-value
+          pair with the name <code>response</code>.</span> 
+          For instance, an <code>ActionAffordance</code> could only
+          accept <code>application/json</code> for its input data,
+          while it will respond with an <code>image/jpeg</code>
+          content type for its output data. In that case the
+          content types differ and the <code>response</code>
+          name-value pair has to be used to provide response
+          content type (<code>image/jpeg</code>) information to the
+          <a href="#dfn-consumer" class="internalDFN"
+          data-link-type="dfn">Consumer</a>.</p>
+          <p>
+          Similar considerations apply to additional responses,
+          although in this case the <code>contentType</code> is optional
+          if it is the same as the input content Type (e.g. JSON).
+          <span class="rfc2119-assertion" id=
+          "td-additionalExpectedResponse-contentType">If the content type of
+          an additional expected response differs from the content type of
+          the form, the <code>Form</code> instance <em class=
+          "rfc2119" title="MUST">MUST</em> include an entry in the array
+          associated with the name <code>additionalResponses</code>
+          that includes a value for the name <code>contentType</code>.</span> 
+          <span class="rfc2119-assertion" id=
+          "td-additionalExpectedResponse-schema">If the data schema of
+          an additional expected response differs from the output data schema of
+          the interaction, the <code>Form</code> instance <em class=
+          "rfc2119" title="MUST">MUST</em> include an entry in the array
+          associated with the name <code>additionalResponses</code> that
+          includes a value for the name <code>schema</code>.</span> 
+          </p>
+          <p>
+            The different cases on the variation of request and response are explained above.
+            The tables at <a href="#contentType-usage"></a> summarize these cases in a concise manner.
+          </p>
           </section>
-          <section>
-            <h3><code>Form</code></h3>
-            <p>
-              A form can be viewed as a statement of "To perform an <b><em>operation type</em></b> operation on
-              <b><em>form context</em></b
-              >, make a <b><em>request method</em></b> request to <b><em>submission target</em></b
-              >" where the optional <b><em>form fields</em></b> may further describe the required request. In Thing
-              Descriptions, the <b><em>form context</em></b> is the surrounding Object, such as Properties, Actions, and
-              Events or the Thing itself for meta-interactions.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in Form Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-href--Form">
-                  <td><code>href</code></td>
-                  <td>Target IRI of a link or submission target of a form.</td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form">
-                  <td><code>contentType</code></td>
-                  <td>
-                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
-                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-rfc2046"
-                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
-                        >RFC2046</a
-                      ></cite
-                    >].
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form">
-                  <td><code>contentCoding</code></td>
-                  <td>
-                    Content coding values indicate an encoding transformation that has been or can be applied to a
-                    representation. Content codings are primarily used to allow a representation to be compressed or
-                    otherwise usefully transformed without losing the identity of its underlying media type and without
-                    loss of information. Examples of content coding include "gzip", "deflate", etc. .
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-security--Form">
-                  <td><code>security</code></td>
-                  <td>
-                    Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.
-                    These must all be satisfied for access to resources.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form">
-                  <td><code>scopes</code></td>
-                  <td>
-                    Set of authorization scope identifiers provided as an array. These are provided in tokens returned
-                    by an authorization server and associated with forms in order to identify what resources a client
-                    may access and how. The values associated with a form SHOULD be chosen from those defined in an
-                    <code>OAuth2SecurityScheme</code> active on that form.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-response--Form">
-                  <td><code>response</code></td>
-                  <td>
-                    This optional term can be used if, e.g., the output communication metadata differ from input
-                    metadata (e.g., output contentType differ from the input contentType). The response name contains
-                    metadata that is only valid for the primary response messages.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#expectedresponse"><code>ExpectedResponse</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-additionalResponses--Form">
-                  <td><code>additionalResponses</code></td>
-                  <td>
-                    This optional term can be used if additional expected responses are possible, e.g. for error
-                    reporting. Each additional response needs to be distinguished from others in some way (for example,
-                    by specifying a protocol-specific error code), and may also have its own data schema.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Array</a> of <a href="#additionalexpectedresponse"><code>AdditionalExpectedResponse</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form">
-                  <td><code>subprotocol</code></td>
-                  <td>
-                    Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when
-                    there are multiple options. For example, for HTTP and Events, it indicates which of several
-                    available mechanisms should be used for asynchronous notifications such as long polling
-                    (<code>longpoll</code>), WebSub [<cite
-                      ><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite
-                    >] (<code>websub</code>), Server-Sent Events (<code>sse</code>) [<cite
-                      ><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite
-                    >] (also known as EventSource). Please note that there is no restriction on the subprotocol
-                    selection and other mechanisms can also be announced by this subprotocol term.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-op--Form">
-                  <td><code>op</code></td>
-                  <td>
-                    Indicates the semantic intention of performing the operation(s) described by the form. For example,
-                    the Property interaction allows get and set operations. The protocol binding may contain a form for
-                    the get operation and a different form for the set operation. The op attribute indicates which form
-                    is for which and allows the client to select the correct form for the operation required. op can be
-                    assigned one or more interaction verb(s) each representing a semantic intention of an operation.
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>,
-                    <code>unobserveproperty</code>, <code>invokeaction</code>, <code>queryaction</code>,
-                    <code>cancelaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>,
-                    <code>readallproperties</code>, <code>writeallproperties</code>,
-                    <code>readmultipleproperties</code>, <code>writemultipleproperties</code>,
-                    <code>observeallproperties</code>, <code>unobserveallproperties</code>,
-                    <code>subscribeallevents</code>, <code>unsubscribeallevents</code>, or <code>queryallactions</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              Possible values for the <code>contentCoding</code> property can be found, e.g., in the
-              <a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
-                IANA HTTP content coding registry</a
-              >.
-            </p>
-            <p>
-              The list of possible operation types of a form is fixed. As of this version of the specification, it only
-              includes the well-known types necessary to implement the WoT interaction model described in [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-wot-architecture11"
-                  title="Web of Things (WoT) Architecture 1.1"
-                  >wot-architecture11</a
-                ></cite
-              >]. Future versions of the standard may extend this list but
-              <span class="rfc2119-assertion" id="well-known-operation-types-only"
-                >operations types MUST be restricted to the values in the table below.</span
-              >
-            </p>
-
-            <div id="table-operation-types">
-              <table class="def numbered">
-                <caption>
-                  Well-known operation types
-                </caption>
-                <thead>
-                  <tr>
-                    <th>Operation Type</th>
-                    <th>Description</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>readproperty</td>
-                    <td>Identifies the read operation on Property Affordances to retrieve the corresponding data.</td>
-                  </tr>
-                  <tr>
-                    <td>writeproperty</td>
-                    <td>Identifies the write operation on Property Affordances to update the corresponding data.</td>
-                  </tr>
-                  <tr>
-                    <td>observeproperty</td>
-                    <td>
-                      Identifies the observe operation on Property Affordances to be notified with the new data when the
-                      Property is updated.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>unobserveproperty</td>
-                    <td>
-                      Identifies the unobserve operation on Property Affordances to stop the corresponding
-                      notifications.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>invokeaction</td>
-                    <td>Identifies the invoke operation on Action Affordances to perform the corresponding action.</td>
-                  </tr>
-                  <tr>
-                    <td>queryaction</td>
-                    <td>
-                      Identifies the querying operation on Action Affordances to get the status of the corresponding
-                      action.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>cancelaction</td>
-                    <td>
-                      Identifies the cancel operation on Action Affordances to cancel the ongoing corresponding action.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>subscribeevent</td>
-                    <td>
-                      Identifies the subscribe operation on Event Affordances to be notified by the Thing when the event
-                      occurs.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>unsubscribeevent</td>
-                    <td>
-                      Identifies the unsubscribe operation on Event Affordances to stop the corresponding notifications.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>readallproperties</td>
-                    <td>
-                      Identifies the readallproperties operation on a Thing to retrieve the data of all Properties in a
-                      single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>writeallproperties</td>
-                    <td>
-                      Identifies the writeallproperties operation on a Thing to update the data of all writable
-                      Properties in a single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>readmultipleproperties</td>
-                    <td>
-                      Identifies the readmultipleproperties operation on a Thing to retrieve the data of selected
-                      Properties in a single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>writemultipleproperties</td>
-                    <td>
-                      Identifies the writemultipleproperties operation on a Thing to update the data of selected
-                      writable Properties in a single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>observeallproperties</td>
-                    <td>
-                      Identifies the observeallproperties operation on Properties to be notified with new data when any
-                      Property is updated.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>unobserveallproperties</td>
-                    <td>
-                      Identifies the unobserveallproperties operation on Properties to stop notifications from all
-                      Properties in a single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>queryallactions</td>
-                    <td>
-                      Identifies the queryallactions operation on a Thing to get the status of all Actions in a single
-                      interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>subscribeallevents</td>
-                    <td>
-                      Identifies the subscribeallevents operation on Events to subscribe to notifications from all
-                      Events in a single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>unsubscribeallevents</td>
-                    <td>
-                      Identifies the unsubscribeallevents operation on Events to unsubscribe from notifications from all
-                      Events in a single interaction.
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            <p>
-              A <a>Thing Description</a> of a WoT <a>producer</a> may have multiple forms entries with, e.g., different
-              protocol and/or content types declarations that a <a>Consumer</a> could possibly support. In that case the
-              Consumer may choose any form entry that works (e.g., the protocol and content type is supported) for them.
-              When one form is chosen, it is expected that the <a>Consumer</a> will continue to use it as long as
-              possible for every new interaction with the WoT <a>producer</a>.
-            </p>
-
-            <section id="sec-op-data-schema-mapping" class="informative">
-              <h4>Mapping op Values to Data Schemas</h4>
-
-              <p>
-                Protocols that can be used with TDs follow request-response or eventing mechanisms. The Data Schema of
-                an affordance generally correlates with the <code>op</code> keywords used in <code>forms</code>. The
-                table below informatively summarizes the available data schema related terms with the
-                <code>op</code> keywords.
-              </p>
-              <ul>
-                <li>
-                  Consumer to Thing applies for messages sent by the Consumer to the Thing, such as the value for
-                  writing a property.
-                </li>
-                <li>
-                  Thing to Consumer applies for messages sent by the Thing to the Consumer, such as the value of a
-                  property value as the result of reading a property.
-                </li>
-                <li>
-                  In case that there is no correlation with the data schema and the operation, it implies that no
-                  payload is required for executing the operation or no payload is expected as a result of the
-                  operation.
-                </li>
-              </ul>
-
-              <table class="def numbered">
-                <caption>
-                  Mapping op Values to Data Schemas
-                </caption>
-                <thead>
-                  <tr>
-                    <th>Operation Type</th>
-                    <th>Consumer to Thing DataSchema Correlation</th>
-                    <th>Thing to Consumer DataSchema Correlation</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>readproperty</td>
-                    <td>No correlation.</td>
-                    <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
-                  </tr>
-                  <tr>
-                    <td>writeproperty</td>
-                    <td>All fields in the Property Affordance without <code>"readOnly":true</code>.</td>
-                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-                  </tr>
-                  <tr>
-                    <td>observeproperty</td>
-                    <td>No correlation.</td>
-                    <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
-                  </tr>
-                  <tr>
-                    <td>unobserveproperty</td>
-                    <td>No correlation.</td>
-                    <td>No correlation.</td>
-                  </tr>
-                  <tr>
-                    <td>invokeaction</td>
-                    <td>Value of the <code>input</code> key.</td>
-                    <td>Value of the <code>output</code> key.</td>
-                  </tr>
-                  <tr>
-                    <td>queryaction</td>
-                    <td>No correlation.</td>
-                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-                  </tr>
-                  <tr>
-                    <td>cancelaction</td>
-                    <td>No correlation.</td>
-                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-                  </tr>
-                  <tr>
-                    <td>subscribeevent</td>
-                    <td>
-                      Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code>
-                    </td>
-                    <td>
-                      Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>unsubscribeevent</td>
-                    <td>
-                      Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code>
-                    </td>
-                    <td>
-                      Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <p class="note" title="writeproperty and observeproperty relationship">
-                Writing to a property does not necessarily mean that a new value will be sent to the Consumer observing
-                the property. It depends on the protocol and implementation.
-              </p>
-              <p class="note" title="Further Data Schemas mappings">
-                Further specification of how to map operations to data schemas, as well as mapping meta operations such
-                as <code>readallproperties</code>
-                can be found in the respective protocol specification of the [[WOT-BINDING-TEMPLATES]].
-              </p>
-            </section>
-
-            <section id="sec-response-usage">
-              <h4>Response-related Terms Usage</h4>
-
-              <p>
-                The optional <code>response</code> name-value pair can be used to provide metadata for the expected
-                response message. With the core vocabulary, it only includes content type information, but TD Context
-                Extensions could be applied.
-                <span class="rfc2119-assertion" id="td-expectedResponse-default-contentType"
-                  >If no <code>response</code> name-value pair is provided, it MUST be assumed that the content type of
-                  the response is equal to the content type assigned to the Form instance.</span
-                >
-                Note that <code>contentType</code> within an
-                <code>ExpectedResponse</code>
-                <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> does not have a
-                <a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">Default Value</a>. For instance,
-                if the value of the content type of the form is <code>application/xml</code> the assumed value of the
-                content type of the response will be also <code>application/xml</code>.
-              </p>
-              <p>
-                In some cases additional responses might be possible. One example of this is error responses but in some
-                cases there might also be additional successful responses. In this case, the
-                <code>response</code> name-value pair is still used for the primary response but
-                <code>additionalResponses</code> may also be provided, whose value is an array of
-                <code>AdditionalExpectedResponse</code> objects. Each additional response must be distinguished in some
-                way from the primary response, either by <code>contentType</code> or by protocol-specific settings such
-                as error code header values. Each additional response may also have a data schema which can differ from
-                the normal output data schema for the interaction.
-              </p>
-              <p>
-                In some use cases, input and output data might be represented in a different form, for instance an
-                Action that accepts JSON, but returns an image. In such a case, the optional
-                <code>response</code> name-value pair can describe the content type of the expected response.
-                <span class="rfc2119-assertion" id="td-expectedResponse-contentType"
-                  >If the content type of the expected response differs from the content type of the form, the
-                  <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include a name-value pair with
-                  the name <code>response</code>.</span
-                >
-                For instance, an <code>ActionAffordance</code> could only accept <code>application/json</code> for its
-                input data, while it will respond with an <code>image/jpeg</code> content type for its output data. In
-                that case the content types differ and the <code>response</code>
-                name-value pair has to be used to provide response content type (<code>image/jpeg</code>) information to
-                the
-                <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumer</a>.
-              </p>
-              <p>
-                Similar considerations apply to additional responses, although in this case the
-                <code>contentType</code> is optional if it is the same as the input content Type (e.g. JSON).
-                <span class="rfc2119-assertion" id="td-additionalExpectedResponse-contentType"
-                  >If the content type of an additional expected response differs from the content type of the form, the
-                  <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include an entry in the array
-                  associated with the name <code>additionalResponses</code> that includes a value for the name
-                  <code>contentType</code>.</span
-                >
-                <span class="rfc2119-assertion" id="td-additionalExpectedResponse-schema"
-                  >If the data schema of an additional expected response differs from the output data schema of the
-                  interaction, the <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include an
-                  entry in the array associated with the name <code>additionalResponses</code> that includes a value for
-                  the name <code>schema</code>.</span
-                >
-              </p>
-              <p>
-                The different cases on the variation of request and response are explained above. The tables at
-                <a href="#contentType-usage"></a> summarize these cases in a concise manner.
-              </p>
-            </section>
           </section>
-          <section>
-            <h3><code>ExpectedResponse</code></h3>
-            <p>Communication metadata describing the expected response message for the primary response.</p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in ExpectedResponse Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse">
-                  <td><code>contentType</code></td>
-                  <td>
-                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
-                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-rfc2046"
-                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
-                        >RFC2046</a
-                      ></cite
-                    >].
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>AdditionalExpectedResponse</code></h3>
-            <p>Communication metadata describing the expected response message for additional responses.</p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in AdditionalExpectedResponse Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-success--AdditionalExpectedResponse">
-                  <td><code>success</code></td>
-                  <td>Signals if an additional response should not be considered an error.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--AdditionalExpectedResponse">
-                  <td><code>contentType</code></td>
-                  <td>
-                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
-                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-rfc2046"
-                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
-                        >RFC2046</a
-                      ></cite
-                    >].
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-schema--AdditionalExpectedResponse">
-                  <td><code>schema</code></td>
-                  <td>
-                    Used to define the output data schema for an additional response if it differs from the default
-                    output data schema. Rather than a <code>DataSchema</code> object, the name of a previous definition
-                    given in a <code>schemaDefinitions</code> map must be used.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
+<section><h3><code>ExpectedResponse</code></h3><p>Communication metadata describing the expected
+          response message for the primary response.</p><table class="def numbered"><caption>Vocabulary Terms in ExpectedResponse Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type
+                (e.g., <code>text/plain</code>) and potential
+                parameters (e.g., <code>charset=utf-8</code>) for
+                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+<section><h3><code>AdditionalExpectedResponse</code></h3><p>Communication metadata describing the expected
+          response message for additional responses.</p><table class="def numbered"><caption>Vocabulary Terms in AdditionalExpectedResponse Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-success--AdditionalExpectedResponse"><td><code>success</code></td><td>Signals if an additional response should not be considered an error.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-contentType--AdditionalExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type
+                (e.g., <code>text/plain</code>) and potential
+                parameters (e.g., <code>charset=utf-8</code>) for
+                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-schema--AdditionalExpectedResponse"><td><code>schema</code></td><td>Used to define the output data schema 
+                for an additional response if it differs from the default
+                output data schema. 
+                Rather than a <code>DataSchema</code> object, the
+                name of a previous definition given in a 
+                <code>schemaDefinitions</code> map must be used.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
         </section>
       </section>
       <section id="sec-default-values">

--- a/index.html
+++ b/index.html
@@ -791,6 +791,12 @@
           A binding specification is a document that specifies a binding for a protocol, a payload format, or both. All
           bindings follow the rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
         </dd>
+        <dt><dfn id="dfn-binding-instance">Binding Instance</dfn></dt>
+        <dd>
+          A binding instance is a form instance in a Thing Description containing a specific binding. For example, an
+          HTTP Binding instance is a <a>Form</a> which has <code>href</code> starting with <code>http://</code> or
+          <code>https://</code>.
+        </dd>
       </dl>
 
       <p>These definitions are further developed in <a href="#preliminary-definitions"></a>.</p>
@@ -7059,7 +7065,7 @@
         to have a submission target, given by the <code>href</code> member, as indicated in <a>Form</a>. For instance,
         if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can infer that the
         <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific terms in
-        an instance of this form.
+        an instance of this form. See [[[#protocol-bindings]]] for more explanation and examples.
       </p>
 
       <p>
@@ -7071,14 +7077,17 @@
         messages coming from the <a>Thing</a>, the <a>Consumer</a> can deserialize the data and present it to the
         application level. For example, a <a>Consumer</a> implemented in Python can read
         <code>application/json</code> as the value of <code>contentType</code> and serialize a Python dictionary data
-        structure into a JSON object.
+        structure into a JSON object. See [[[#payload-bindings]]] for more explanation and examples.
       </p>
 
       <p>
         The mechanism above are called Bindings in the Web of Things and a specific example is illustrated in
-        [[[#fig-mechanism]]]. Bindings enable a Thing Description to be adapted to a specific protocol, data payload
-        formats or both in specific ways. This is done through URI Schemes, additional descriptive vocabularies, Thing
-        Models and examples that aim to guide the implementors of Things and Consumers alike.
+        [[[#fig-mechanism]]] with an excerpt of a TD of a robot arm with of HTTP and JSON Bindings. Here, the Consumer
+        intends to invoke an action of the robot arm (<code>goTo</code>) in order to move it to the position x equals 12
+        and y equals 100. In order to do so, it creates the correct payload, serializes it and sends it using the
+        correct protocol options. The Thing gets the message over the network and responds with a message that
+        corresponds to its TD. Other protocols, payload formats or their combination are possible and are explained in
+        [[[#binding-overview]]].
       </p>
 
       <figure id="fig-mechanism">
@@ -7087,119 +7096,44 @@
       </figure>
 
       <p>
-        This section explains the overall mechanism and gives basic guidance on creating new Bindings. The
-        [[WOT-BINDINGS-REGISTRY]] contains the a registry (list) of existing Bindings as well the requirements to follow
-        to register new entries to the registry.
+        In summary, Bindings enable a Thing Description to be adapted to a specific protocol, data payload formats or
+        both in specific ways. This is done through URI Schemes, additional descriptive vocabularies, Thing Models and
+        examples that aim to guide the implementors of Things and Consumers alike. This section explains the overall
+        mechanism and gives basic guidance on creating new Bindings. The [[WOT-BINDINGS-REGISTRY]] contains the a
+        registry (list) of existing Bindings as well the requirements to follow to register new entries to the registry.
       </p>
 
-      <section id="binding-introduction">
-        <h4>Introduction to Binding Templates</h4>
-        <p>
-          IoT addresses multiple use cases from different application domains, while requiring different deployment
-          patterns for devices. This results in different protocols and media types, creating the central challenge for
-          the Web of Things: enabling interactions with the plethora of different <a>IoT platforms</a> and devices that
-          do not follow any particular standard, but provide an eligible interface over a suitable network protocol. WoT
-          is addressing this challenge through Binding Templates.
-        </p>
+      <p>
+        When producting a TD for a particular IoT device, the corresponding Binding can be used to look up the
+        communication metadata that is to be provided in the <a>Thing Description</a>. [[[#fig-building-block]]] shows
+        how Bindings are used. Based on the protocol or media type, a TD is created. The Consumer that is processing a
+        TD implements the required Bindings that are present in the TD by including a corresponding protocol stack and
+        media type encoder/decoder by configuring the stack (or its messages) according to the information given in the
+        TD such as serialization format of the messages and header options.
+      </p>
 
-        <p>
-          Binding Templates consist of multiple specifications, referred to as a <a>subspecification</a> in this
-          document, that enable an application client (a WoT <a>Consumer</a>) to interact, using WoT Thing
-          Description[[WOT-THING-DESCRIPTION]] (TD), with Things that exhibit diverse protocols, payload formats and a
-          combination of these in platforms and frameworks. The mechanism that allows Consumers to interact with a
-          variety of Things is called the Binding Mechanism, without which TDs could not build Hypermedia Controls as
-          explained in the [[WOT-ARCHITECTURE]].
-        </p>
+      <figure id="fig-building-block">
+        <img
+          src="visualization/binding-templates.svg"
+          alt="Platforms, Protocols and Media Types as building blocks for binding templates and TD"
+        />
+        <figcaption>Platforms, Protocols and Media Types as building blocks for binding templates and TD</figcaption>
+      </figure>
 
-        <p>
-          When describing a particular IoT device or platform, the corresponding Binding Template can be used to look up
-          the communication metadata that is to be provided in the <a>Thing Description</a> to support that platform.
-          [[[#fig-building-block]]] shows how Binding Templates are used. Based on the protocol, media type or platform
-          binding template, a TD is created. The Consumer that is processing a TD implements the required Binding
-          Template that is present in the TD by including a corresponding protocol stack, media type encoder/decoder or
-          platform stack and by configuring the stack (or its messages) according to the information given in the TD
-          such as serialization format of the messages and header options.
-        </p>
+      <p class="note">
+        The editors of this specification also recommend reading the related chapters in [[WOT-ARCHITECTURE]], such as
+        <a href="https://www.w3.org/TR/wot-architecture11/#sec-binding-templates"
+          >WoT Binding Templates Building Block</a
+        >, <a href="https://www.w3.org/TR/wot-architecture11/#sec-hypermedia-controls">Hypermedia Controls</a>,
+        <a href="https://www.w3.org/TR/wot-architecture11/#sec-protocol-bindings">Protocol Bindings</a> and
+        <a href="https://www.w3.org/TR/wot-architecture11/#media-types">Media Types</a>.
+      </p>
 
-        <figure id="fig-building-block">
-          <img
-            src="visualization/binding-templates.svg"
-            alt="Platforms, Protocols and Media Types as building blocks for binding templates and TD"
-          />
-          <figcaption>Platforms, Protocols and Media Types as building blocks for binding templates and TD</figcaption>
-        </figure>
-
-        <p>
-          Each Interaction Affordance in a TD needs to have a binding to a protocol and to a payload format.
-          [[[#fig-mechanism]]] below illustrates an excerpt of a TD of a robot arm with of HTTP and JSON bindings. Here,
-          the Consumer intends to invoke an action of the robot arm (<code>goTo</code>) in order to move it to the
-          position x equals 12 and y equals 100. In order to do so, it creates the correct payload, serializes it and
-          sends it using the correct protocol options. The Thing gets the message over the network and responds with a
-          message that corresponds to its TD. Other protocols, payload formats or their combination are possible and are
-          explained in [[[#binding-overview]]].
-        </p>
-
-        <p class="ednote">
-          The editors also recommend reading the related chapters in [[WOT-ARCHITECTURE]], such as
-          <a href="https://www.w3.org/TR/wot-architecture11/#sec-binding-templates"
-            >WoT Binding Templates Building Block</a
-          >, <a href="https://www.w3.org/TR/wot-architecture11/#sec-hypermedia-controls">Hypermedia Controls</a>,
-          <a href="https://www.w3.org/TR/wot-architecture11/#sec-protocol-bindings">Protocol Bindings</a> and
-          <a href="https://www.w3.org/TR/wot-architecture11/#media-types">Media Types</a>.
-        </p>
-      </section>
-
-      <section id="binding-overview">
-        <h4>Binding Template Mechanisms</h4>
-
-        <p>
-          TDs can be bound to specific protocols, payload formats and platforms. This is possible through the three core
-          mechanisms that allow WoT to be used in various domains and scenarios. This section explains how these binding
-          mechanism types are structured, should be specified, and links to corresponding binding documents
-          (subspecifications). These 3 types of mechanisms are:
-        </p>
-        <ul>
-          <li>
-            <b>Protocols</b>: Application layer protocols (e.g., HTTP[[?RFC7231]], CoAP[[?RFC7252]], MQTT[[?MQTT]],
-            etc.) whose different message types are mapped to the WoT Thing Description[[WOT-THING-DESCRIPTION]] forms
-            via reusable vocabulary and extensions.
-          </li>
-          <li>
-            <b>Payloads</b>: Different payload formats and media types [[IANA-MEDIA-TYPES]] which can be represented in
-            a TD via Data Schemas or forms.
-          </li>
-          <li>
-            <b>Platforms</b>: Platforms and frameworks who combine the use of protocols and payloads in a certain way,
-            which can be represented via entire Thing Models described by the [[WOT-THING-DESCRIPTION]] or examples of
-            TDs.
-          </li>
-        </ul>
-
-        <p>
-          Each <a>Binding Template Subspecification</a> is an independent document that has a separate list of authors
-          and publication date. This section explains the binding mechanism by giving requirements per respective
-          binding category and links to the respective subspecification. These can be found in sections
-          [[[#protocol-bindings]]], [[[#payload-bindings]]] and [[[#platform-bindings]]].
-        </p>
-
-        <figure id="fig-overview">
-          <img
-            src="visualization/binding-templates-overview.drawio.svg"
-            alt="Binding Templates Overview and the relationships between each document type"
-          />
-          <figcaption>Binding Templates Overview and the Relationships between each Document Type</figcaption>
-        </figure>
-
-        <p>
-          Each Protocol and Payload Binding Template is specified in a way that they stay independent from each other.
-          This means that each document can be read independently from the other and can be also developed
-          independently. However, Platform Binding Templates are dependent on the Protocol and Payload Binding
-          Templates, since a given platform uses different protocols and payload formats that need to be specified first
-          in their respective binding templates and referred to within a Platform Binding Template.
-        </p>
+      <section id="binding-mechanisms">
+        <h4>Binding Mechanisms</h4>
 
         <section id="protocol-bindings">
-          <h5>Protocol Binding Templates</h5>
+          <h5>Protocol Bindings</h5>
           <p>
             [[WOT-THING-DESCRIPTION]] defines abstract operations such as <code>readproperty</code>,
             <code>invokeaction</code>
@@ -7220,22 +7154,22 @@
           </p>
           <p>
             Common methods found in REST and PubSub protocols are GET, PUT, POST, DELETE, PUBLISH, and SUBSCRIBE.
-            Binding Templates describe how these existing methods and associated vocabularies can be used in a
+            Binding specifications describe how these existing methods and associated vocabularies can be used in a
             <a>Thing Description</a> to bind to the WoT operations. This is done by defining the URI scheme of the
             protocol and mapping the protocol methods to the abstract WoT operations such as <code>readproperty</code>,
             <code>invokeaction</code> and <code>subscribeevent</code>. In some cases, additional instructions are
             provided to explain how the vocabulary terms should be used in different cases of protocol usage.
           </p>
           <p>
-            The examples below show the binding of the <code>readproperty</code> operation for the HTTP and Modbus
-            protocols. Please note that these are examples and please always refer to the corresponding binding to learn
-            about the relevant vocabulary terms and their values.
+            The examples below show binding instances of the <code>readproperty</code> operation for the HTTP and Modbus
+            protocols. Please note that these are examples and please always refer to the corresponding binding
+            specification to learn about the relevant vocabulary terms and their values.
           </p>
           <table>
             <tbody>
               <tr>
                 <td style="vertical-align: top; width: 50%">
-                  <pre class="example" title="Binding example of a readproperty operation to HTTP">
+                  <pre class="example" title="Binding instance of a readproperty operation to HTTP">
                                       {
                                           "href": "http://example.com/props/temperature",
                                           "op": "readproperty",
@@ -7245,12 +7179,11 @@
                   >
                 </td>
                 <td style="vertical-align: top; width: 50%">
-                  <pre class="example" title="Binding example of a readproperty operation to Modbus">
+                  <pre class="example" title="Binding instance of a readproperty operation to Modbus">
                                       {
-                                          "href": "modbus+tcp://127.0.0.1:60000/1",
+                                          "href": "modbus+tcp://127.0.0.1:60000/1/4",
                                           "op": "readproperty",
-                                          "modv:function": "readCoil",
-                                          "modv:address": 1
+                                          "modv:function": "readCoil"
                                       }
                                   </pre
                   >
@@ -7268,20 +7201,20 @@
             </li>
             <li>
               Right Example: To do a <code>readproperty</code> of the subject Property Affordance using the
-              <code>readCoil</code> function of Modbus at coil <code>1</code> of the device with the
-              <code>127.0.0.1</code> address at its port <code>60000</code>
+              <code>readCoil</code> function of Modbus at coil <code>4</code> of the device with the
+              <code>127.0.0.1</code> IP address and unitID <code>1</code> at its port <code>60000</code>
             </li>
           </ul>
           <p>
-            These bindings and their statements are possible for other operations and protocols as well. Below are
-            examples for <code>invokeaction</code> and <code>subscribeevent</code>:
+            These binding instances and their statements are possible for other operations and protocols as well. Below
+            are examples for <code>invokeaction</code> and <code>subscribeevent</code>:
           </p>
 
           <table>
             <tbody>
               <tr>
                 <td style="vertical-align: top; width: 50%">
-                  <pre class="example" title="Binding example of an invokeaction operation to HTTP">
+                  <pre class="example" title="Binding instance of an invokeaction operation to HTTP">
                                       {
                                           "op": "invokeaction",
                                           "href": "http://192.168.1.32:8081/example/levelaction",
@@ -7291,7 +7224,7 @@
                   >
                 </td>
                 <td style="vertical-align: top; width: 50%">
-                  <pre class="example" title="Binding example of a subscribeevent operation to MQTT">
+                  <pre class="example" title="Binding instance of a subscribeevent operation to MQTT">
                                       {
                                           "op": "subscribeevent",
                                           "href": "mqtt://iot.platform.com:8088",
@@ -7321,11 +7254,10 @@
 
           <p>
             In some cases, header options or other parameters of the protocols need to be included. Given that these are
-            highly protocol dependent, please refer to the bindings listed in [[[#protocol-bindings-table]]].
-            Additionally, protocols may have defined Subprotocols that can be used for some interaction types. For
-            example, to receive asynchronous notifications using HTTP, some servers may support long polling
-            (<code>longpoll</code>), WebSub [[WebSub]] (<code>websub</code>) and Server-Sent Events [[eventsource]]
-            (<code>sse</code>).
+            highly protocol dependent, please refer to the bindings listed in [[[WOT-BINDINGS-REGISTRY]]]. Additionally,
+            protocols may have defined Subprotocols that can be used for some interaction types. For example, to receive
+            asynchronous notifications using HTTP, some servers may support long polling (<code>longpoll</code>), WebSub
+            [[WebSub]] (<code>websub</code>) and Server-Sent Events [[eventsource]] (<code>sse</code>).
           </p>
 
           <section>
@@ -7362,173 +7294,14 @@
           </section>
 
           <section>
-            <h6>Terms Specified by Protocol Binding Templates</h6>
-            <p>
-              Overall, a protocol binding template specifies the values and structure of certain vocabulary terms in a
-              TD. The table below lists the vocabulary term, the class it belongs to and whether the subspecification is
-              required to specify the values the term can take. In addition to these, additional terms for describing
-              protocol options are typically added.
-            </p>
-
-            <table class="def numbered" id="table-protocol-terms">
-              <caption>
-                Terms specified by Protocol Binding Templates
-              </caption>
-              <thead>
-                <tr>
-                  <th>Vocabulary Term</th>
-                  <th>Class</th>
-                  <th>Specification Requirement</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>@context</td>
-                  <td>Thing</td>
-                  <td>mandatory</td>
-                </tr>
-                <tr>
-                  <td>href</td>
-                  <td>Form</td>
-                  <td>mandatory</td>
-                </tr>
-                <tr>
-                  <td>subprotocol</td>
-                  <td>Form</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentType</td>
-                  <td>Form</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentType</td>
-                  <td>ExpectedResponse</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentType</td>
-                  <td>AdditionalExpectedResponse</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentCoding</td>
-                  <td>Form</td>
-                  <td>optional</td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section id="protocol-bindings-table">
-            <h6>Existing Protocol Binding Templates</h6>
-            <p>
-              The table below summarizes the currently specified protocols in their respective
-              <a>Binding Template Subspecification</a>.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Existing Protocol Binding Templates
-              </caption>
-              <thead>
-                <tr>
-                  <th>Abbreviation</th>
-                  <th>Name</th>
-                  <th>Link to Binding Template</th>
-                  <th>Link to Ontology</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>HTTP</td>
-                  <td>Hypertext Transfer Protocol</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td><a href="https://www.w3.org/TR/HTTP-in-RDF10/">Ontology</a></td>
-                </tr>
-                <tr>
-                  <td>CoAP</td>
-                  <td>Constrained Application Protocol</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/ontology.html"
-                      >Ontology</a
-                    >
-                  </td>
-                </tr>
-                <tr>
-                  <td>MQTT</td>
-                  <td>Message Queuing Telemetry Transport</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/ontology.html"
-                      >Ontology</a
-                    >
-                  </td>
-                </tr>
-                <tr>
-                  <td>Modbus</td>
-                  <td>Modbus</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/ontology.html"
-                      >Ontology</a
-                    >
-                  </td>
-                </tr>
-                <tr>
-                  <td>BACnet</td>
-                  <td>Building Automation and Control Networks</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/bacnet/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/bacnet/bacnet-model.ttl"
-                      >Ontology</a
-                    >
-                  </td>
-                </tr>
-                <tr>
-                  <td>PROFINET</td>
-                  <td>Process Field Network</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/profinet/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td>Not available</td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section>
-            <h6>Using a Thing Description with a Protocol Binding Template Subspecification</h6>
+            <h6>Using a Thing Description with a Protocol Binding</h6>
 
             <p>
-              Protocol Binding Templates contain vocabularies that extend the vocabulary found in the
+              Protocol Binding Specifications contain vocabularies that extend the vocabulary found in the
               [[WOT-THING-DESCRIPTION]]. This means that the way a TD is consumed and how the interactions happen with
               the Thing are adapted to such vocabularies. The steps below explain how this process typically looks like.
-              <!-- this text should be extended after the PR 262 is merged -->
             </p>
+            <!-- TODO: Add assertions and sync with other binding assertions -->
             <ol>
               <li>
                 <b>Detect the protocol:</b> Upon the activation of a form to execute the operation, the
@@ -7541,8 +7314,8 @@
               </li>
               <li>
                 <b>Validate the forms part of the TD</b>: Using the JSON Schema instances provided in the respective
-                subspecification or through programmatically checking key value pairs, the <a>Consumer</a> MAY validate
-                the respective form terms in order to verify they are correctly specified in the TD instance.
+                binding specification or through programmatically checking key value pairs, the <a>Consumer</a> MAY
+                validate the respective form terms in order to verify they are correctly specified in the TD instance.
               </li>
               <li>
                 <b>Start communication:</b> The <a>Consumer</a> SHOULD send requests for the chosen operation as
@@ -7555,71 +7328,10 @@
               </li>
             </ol>
           </section>
-
-          <section>
-            <h6>Creating a new Protocol Binding Template Subspecification</h6>
-
-            <p>
-              When creating a new protocol binding template <a>subspecification</a>, e.g. based on a new communication
-              protocol, the proposed document should enable implementations of this binding in an interoperable way for
-              Consumer and Producer implementations. More specifically, each
-              <a>Binding Template Subspecification</a> MUST specify the following:
-            </p>
-            <ul>
-              <li>
-                <b>URI Scheme:</b> For identification of the used protocol, a standardized URI scheme [[RFC3986]] value
-                MUST be declared in the form of a string. This URI Scheme is used in TDs at top level
-                <code>base</code> or in the <code>href</code> term of the <code>forms</code>
-                container. These can be officially registered ones at IANA [[iana-uri-schemes]] (e.g.
-                <code>"https://"</code>, <code>"coap://"</code>) or they can be declared in the protocol
-                subspecification (e.g. <code>"mqtt://"</code>, <code>"modbus+tcp://"</code>). How the full URI can be
-                constructed for different affordances (or resources) MUST be specified as well.
-              </li>
-              <li>
-                <b><code>@context</code> Usage and Ontology:</b> A vocabulary that allows adding protocol options to a
-                Thing Description forms SHOULD be provided to allow semantic annotations of the operations with protocol
-                specific information. The prefix and IRI to be used in the <code>@context</code> in order to link to the
-                vocabulary of the protocol SHOULD be also provided. The prefix SHOULD use the <code>v</code> suffix
-                notation in order to avoid confusion with the URI scheme of the protocol (e.g. <code>htv</code> for HTTP
-                and <code>mqv</code> for MQTT). For instructions on how to create a vocabulary, please refer to our
-                <a href="./VOCABULARY-CREATION-GUIDE.md"> Vocabulary Creation Guide</a>.
-              </li>
-              <li>
-                <b>Mapping to WoT Operations:</b> Most protocols have a set of methods or verbs that adds a meaning to
-                the messages of the protocol. A protocol binding template MUST be able to map WoT operation types
-                (<code>readproperty</code>, <code>invokeaction</code>, etc.) to concrete protocol message types or
-                methods. When specifying the mapping, the mapping SHOULD be bidirectional, i.e. it should be clear how
-                to do a <code>readproperty</code> operation with the given protocol and how an existing implementation's
-                endpoints can be mapped to a WoT operation should be also clear.
-              </li>
-              <li>
-                <b>JSON Schema:</b> A JSON Schema to validate the forms of a TD using the Protocol Binding SHOULD be
-                provided. This allows validation of the URI scheme and the vocabulary terms. The JSON Schema instance
-                SHOULD follow the template provided in
-                <a href="https://github.com/w3c/wot-binding-templates/blob/main/bindings/protocols/template.schema.json"
-                  >the Binding Templates GitHub Repository.</a
-                >
-              </li>
-              <li>
-                <b>Specification:</b> The official specification document of the protocol SHOULD be provided. This
-                SHOULD be a static version, i.e. the exact document used during the writing of the binding that is
-                guaranteed to not change. If this is not possible, the specification should be marked with a date of
-                access. When the specification is not publicly available and cannot be linked with a static version, an
-                editor's note should be provided in the introduction, explaining how to get access to the specification.
-              </li>
-            </ul>
-
-            <p>
-              A template is also provided for new protocol binding template specifications at
-              <a href="https://github.com/w3c/wot-binding-templates/blob/main/bindings/index.template.html"
-                >the GitHub Repository.</a
-              >
-            </p>
-          </section>
         </section>
 
         <section id="payload-bindings">
-          <h5>Payload Binding Templates</h5>
+          <h5>Payload Bindings</h5>
           <p>
             [[WOT-THING-DESCRIPTION]] defines two mechanisms to describe how a payload of a message over any protocol
             can look like. Firstly, media types [[IANA-MEDIA-TYPES]] describe the serialization used for sending and
@@ -7632,9 +7344,7 @@
 
           <p>
             In the rest of this section at [[[#payload-bindings-contentType]]] and [[[#payload-bindings-dataschema]]],
-            you can find examples of how payload bindings can look like. At [[[#payload-bindings-table]]] you can find
-            the current payload binding templates and [[[#payload-bindings-creating]]] explains how new payload binding
-            templates can be created.
+            you can find examples of how payload bindings can look like.
           </p>
           <section id="payload-bindings-contentType">
             <h6>Content Types</h6>
@@ -7658,10 +7368,8 @@
               additional parameters. In this specific case, the forms describe that reading this property with
               <code>http</code> or <code>coap</code> result in different content types. For structured media types, a
               Data Schema is generally provided in the affordance level as explained in
-              [[[#payload-bindings-dataschema]]] and
-              <a data-cite="WOT-THING-DESCRIPTION#sec-data-schema-vocabulary-definition">
-                in the Data Schema section of the TD specification</a
-              >. However, for unstructured data such as images and videos, a Data Schema is typically not available.
+              [[[#payload-bindings-dataschema]]] and [[#sec-data-schema-vocabulary-definition"]]. However, for
+              unstructured data such as images and videos, a Data Schema is typically not available.
             </p>
 
             <pre class="example" title="JSON and CBOR media types in forms" id="example-payload-binding">
@@ -7719,16 +7427,17 @@
             <h6>Data Schemas</h6>
 
             <p>
-              Data Schema, as explained in [[WOT-THING-DESCRIPTION]], describes the structure of the messages, which are
-              used together with media types. Even though it is largely inspired by JSON Schema [[json-schema]], it can
-              be used for describing other payload types such as [[XML]], string-encoded images, bit representations of
-              integers, etc. Data Schema SHOULD be used in addition to the media types.
+              Data Schema, as explained in [[#sec-data-schema-vocabulary-definition"]], describes the structure of the
+              messages, which are used together with media types. Even though it is largely inspired by JSON Schema
+              [[json-schema]], it can be used for describing other payload types such as [[XML]], string-encoded images,
+              bit representations of integers, etc. Data Schema SHOULD be used in addition to the media types.
             </p>
             <p>
               Depending on the case, the structure of the messages can be anything from a simple number to arrays or
               objects with multiple levels of nesting. Existing IoT Platforms and Standards have certain payload formats
-              with variations on how the data is structured. As explained in [[WOT-THING-DESCRIPTION]], Data Schema can
-              be used in a TD in one of the following places:
+              with variations on how the data is structured. As explained in
+              [[#sec-data-schema-vocabulary-definition"]], Data Schema can be used in a TD in one of the following
+              places:
             </p>
             <ul>
               <li>
@@ -7792,122 +7501,9 @@
               </tbody>
             </table>
           </section>
-          <section>
-            <h6>Terms Specified by Payload Binding Templates</h6>
-            <p>
-              Overall, a payload binding template specifies the values and structure of certain vocabulary terms in a
-              TD. The table below lists the vocabulary term, the class it belongs to and whether the subspecification is
-              required to specify the values the term can take. In addition to these, additional vocabulary terms can be
-              added and restrictions to Data Schema terms can be placed.
-            </p>
-
-            <table class="def numbered" id="table-payload-terms">
-              <caption>
-                Terms specified by Payload Binding Templates
-              </caption>
-              <thead>
-                <tr>
-                  <th>Term</th>
-                  <th>Class</th>
-                  <th>Specification Requirement</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>contentType</td>
-                  <td>Form</td>
-                  <td>mandatory</td>
-                </tr>
-                <tr>
-                  <td>contentType</td>
-                  <td>ExpectedResponse</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentType</td>
-                  <td>AdditionalExpectedResponse</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentCoding</td>
-                  <td>Form</td>
-                  <td>optional</td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section id="payload-bindings-table">
-            <h6>Existing Payload Binding Templates</h6>
-            The table below summarizes the currently specified payload binding templates.
-
-            <table class="def numbered">
-              <caption>
-                Existing Platform Binding Templates
-              </caption>
-              <thead>
-                <tr>
-                  <th>Abbreviation</th>
-                  <th>Name</th>
-                  <th>Media Type</th>
-                  <th>Link</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>JSON</td>
-                  <td>JavaScript Object Notation</td>
-                  <td><code>application/json</code></td>
-                  <td>Planned</td>
-                </tr>
-                <tr>
-                  <td>XML</td>
-                  <td>eXtensible Markup Language</td>
-                  <td><code>application/xml</code></td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/payloads/xml/index.html">Link</a>
-                    (Work in Progress)
-                  </td>
-                </tr>
-                <tr>
-                  <td>text</td>
-                  <td>text</td>
-                  <td><code>text/plain</code></td>
-                  <td>Planned</td>
-                </tr>
-                <tr>
-                  <td>Unstructured Data</td>
-                  <td>Unstructured Data</td>
-                  <td>various</td>
-                  <td>Planned</td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section id="payload-bindings-creating">
-            <h6>Creating a new Payload Binding Template Subspecification</h6>
-
-            <p>
-              Each payload binding template <a>subspecification</a>, SHOULD contain the respective media type. Ideally
-              this media type has been registered at the IANA registry [[IANA-MEDIA-TYPES]] with a corresponding mime
-              type (e.g. <code>application/json</code>). If it is not registered, the binding document can propose a
-              mime type. Additionally, how that media type is represented in a Data Schema SHOULD be demonstrated with
-              examples. In all cases, the following information SHOULD be provided:
-            </p>
-
-            <ul>
-              <li>
-                <b>Specification:</b> The official specification document of the payload format SHOULD be provided. This
-                SHOULD be a static version, i.e. the exact document used during the writing of the binding that is
-                guaranteed to not change. If this is not possible, the specification should be marked with a date of
-                access. When the specification is not publicly available and cannot be linked with a static version, an
-                editor's note should be provided in the introduction, explaining how to get access to the specification.
-              </li>
-            </ul>
-          </section>
         </section>
 
+        <!-- TODO: Change to combining bindings -->
         <section id="platform-bindings">
           <h5>Platform Binding Templates</h5>
           <p>
@@ -7933,64 +7529,6 @@
             the usage of protocol or media type, corresponding protocol or payload binding templates MUST be created
             first.
           </p>
-
-          <section id="platform-bindings-table">
-            <h6>Existing Platform Binding Templates</h6>
-            <p>
-              The table below summarizes the currently specified platform binding template <a>subspecification</a>s.
-            </p>
-
-            <table class="def">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Link</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>Philips Hue</td>
-                  <td>Planned</td>
-                </tr>
-                <tr>
-                  <td>ECHONET</td>
-                  <td>Planned</td>
-                </tr>
-                <tr>
-                  <td>OPC-UA</td>
-                  <td>Planned</td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section>
-            <h6>Creating a new Platform Binding Template Subspecification</h6>
-
-            <p>
-              Depending on the platform and the variety of devices it proposes, each platform binding template
-              <a>subspecification</a> will be structured differently. When the platforms offer a <i>reasonable</i> set
-              of device types, a Thing Model for each device type SHOULD be provided. In other cases, possible devices
-              SHOULD be generalized by providing a set of example Thing Models or TDs. In all cases, the following
-              information SHOULD be provided:
-            </p>
-            <ul>
-              <li>
-                <b>Protocol:</b> The protocol used by the platform SHOULD be specified and linked to a protocol binding
-                template <a>subspecification</a> when a corresponding one exists.
-              </li>
-              <li>
-                <b>Media Type:</b> The media type used by the platform SHOULD be specified and linked to a payload
-                binding template <a>subspecification</a> when a corresponding one exists.
-              </li>
-              <li>
-                <b>API Documentation:</b> A static link pointing to the used API Documentation or Specification of the
-                platform SHOULD be provided. When the documentation is not publicly available and cannot be included in
-                a static version in the respective folder, an editor's note should be provided in the introduction,
-                explaining how to get access to the documentation.
-              </li>
-            </ul>
-          </section>
         </section>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -1130,363 +1130,862 @@
           <h2>Core Vocabulary Definitions</h2>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>Thing</code></h3><p>An abstraction of a physical or a virtual entity whose
-          metadata and interfaces are described by a WoT Thing
-          Description, whereas a virtual entity is the composition
-          of one or more Things.</p><table class="def numbered"><caption>Vocabulary Terms in Thing Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing"><td><code>@context</code></td><td>JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-id--Thing"><td><code>id</code></td><td>Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI, URI with local IP address, URN, etc.).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--Thing"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
-                a text for UI representation) based on a default
-                language.</td><td>mandatory</td><td>any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing"><td><code>titles</code></td><td>Provides multi-language human-readable titles
-                (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-description--Thing"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-version--Thing"><td><code>version</code></td><td>Provides version information.</td><td>optional</td><td><a href="#versioninfo"><code>VersionInfo</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-created--Thing"><td><code>created</code></td><td>Provides information when the TD instance was
-                created.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing"><td><code>modified</code></td><td>Provides information when the TD instance was
-                last modified.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-support--Thing"><td><code>support</code></td><td>Provides information about the TD maintainer as
-                URI scheme (e.g., <code>mailto</code> [[RFC6068]],
-                <code>tel</code> [[RFC3966]],
-                <code>https</code> [[RFC9112]]).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-base--Thing"><td><code>base</code></td><td>Define the base URI that is used for all
-                relative URI references throughout a TD document.
-                In TD instances, all relative URIs are resolved
-                relative to the base URI using the algorithm
-                defined in [<cite><a class="bibref" data-link-type=
-                "biblio" href='#bib-rfc3986' title=
-                "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>].<br>
-                <br>
-                <code>base</code> does not affect the URIs used in
-                <code>@context</code> and the IRIs used within
-                Linked Data [<cite><a class="bibref"
-                data-link-type="biblio" href='#bib-linked-data'
-                title=
-                "Linked Data Design Issues">LINKED-DATA</a></cite>]
-                graphs that are relevant when semantic processing
-                is applied to TD instances.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing"><td><code>properties</code></td><td>All Property-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#propertyaffordance"><code>PropertyAffordance</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing"><td><code>actions</code></td><td>All Action-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#actionaffordance"><code>ActionAffordance</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-events--Thing"><td><code>events</code></td><td>All Event-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#eventaffordance"><code>EventAffordance</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-links--Thing"><td><code>links</code></td><td>Provides Web links to arbitrary resources that
-                relate to the specified Thing Description.</td><td>optional</td><td><a>Array</a> of <a href="#link"><code>Link</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing"><td><code>forms</code></td><td>Set of form hypermedia controls that describe how 
-                  an operation can be performed. Forms are
-                  serializations of Protocol Bindings. <a>Thing level</a> forms are used to describe endpoints for a group of interaction affordances.</td><td>optional</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-security--Thing"><td><code>security</code></td><td>Set of security definition names, chosen from
-                those defined in <code>securityDefinitions</code>.
-                These must all be satisfied for access to resources.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing"><td><code>securityDefinitions</code></td><td>Set of named security configurations
-                (definitions only). Not actually applied unless
-                names are used in a <code>security</code>
-                name-value pair.</td><td>mandatory</td><td><a>Map</a> of <a href="#securityscheme"><code>SecurityScheme</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-profile--Thing"><td><code>profile</code></td><td>Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing implementation.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-schemaDefinitions--Thing"><td><code>schemaDefinitions</code></td><td>Set of named data schemas.
-                To be used in a <code>schema</code>
-                name-value pair inside an 
-                <code>AdditionalExpectedResponse</code> object.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
-                based on DataSchema declarations. The <a>Thing level</a> <code>uriVariables</code> can be used in <a>Thing level</a> 
-                <code>forms</code> or in Interaction Affordances.
-                The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
-                to be serialized to a string inside the <code>href</code> upon the execution of the operation.
-                If the same variable is both declared in <a>Thing level</a> <code>uriVariables</code> and in Interaction Affordance level,
-                 the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>
-              For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:
-              </p>
-        <ul>
-            <li>
-    <span class="rfc2119-assertion" id=
-          "td-context-ns-thing-mandatory">
+          <section>
+            <h3><code>Thing</code></h3>
+            <p>
+              An abstraction of a physical or a virtual entity whose metadata and interfaces are described by a WoT
+              Thing Description, whereas a virtual entity is the composition of one or more Things.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in Thing Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing">
+                  <td><code>@context</code></td>
+                  <td>
+                    JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or
+                    <a>Array</a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-id--Thing">
+                  <td><code>id</code></td>
+                  <td>
+                    Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI,
+                    URI with local IP address, URN, etc.).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-title--Thing">
+                  <td><code>title</code></td>
+                  <td>
+                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
+                    language.
+                  </td>
+                  <td>mandatory</td>
+                  <td>any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing">
+                  <td><code>titles</code></td>
+                  <td>
+                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
+                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--Thing">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-version--Thing">
+                  <td><code>version</code></td>
+                  <td>Provides version information.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#versioninfo"><code>VersionInfo</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-created--Thing">
+                  <td><code>created</code></td>
+                  <td>Provides information when the TD instance was created.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing">
+                  <td><code>modified</code></td>
+                  <td>Provides information when the TD instance was last modified.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-support--Thing">
+                  <td><code>support</code></td>
+                  <td>
+                    Provides information about the TD maintainer as URI scheme (e.g., <code>mailto</code> [[RFC6068]],
+                    <code>tel</code> [[RFC3966]], <code>https</code> [[RFC9112]]).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-base--Thing">
+                  <td><code>base</code></td>
+                  <td>
+                    Define the base URI that is used for all relative URI references throughout a TD document. In TD
+                    instances, all relative URIs are resolved relative to the base URI using the algorithm defined in
+                    [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc3986"
+                        title="Uniform Resource Identifier (URI): Generic Syntax"
+                        >RFC3986</a
+                      ></cite
+                    >].<br />
+                    <br />
+                    <code>base</code> does not affect the URIs used in <code>@context</code> and the IRIs used within
+                    Linked Data [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-linked-data"
+                        title="Linked Data Design Issues"
+                        >LINKED-DATA</a
+                      ></cite
+                    >] graphs that are relevant when semantic processing is applied to TD instances.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing">
+                  <td><code>properties</code></td>
+                  <td>
+                    All Property-based
+                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
+                      >Interaction Affordances</a
+                    >
+                    of the Thing.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#propertyaffordance"><code>PropertyAffordance</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing">
+                  <td><code>actions</code></td>
+                  <td>
+                    All Action-based
+                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
+                      >Interaction Affordances</a
+                    >
+                    of the Thing.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#actionaffordance"><code>ActionAffordance</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-events--Thing">
+                  <td><code>events</code></td>
+                  <td>
+                    All Event-based
+                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
+                      >Interaction Affordances</a
+                    >
+                    of the Thing.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#eventaffordance"><code>EventAffordance</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-links--Thing">
+                  <td><code>links</code></td>
+                  <td>Provides Web links to arbitrary resources that relate to the specified Thing Description.</td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#link"><code>Link</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing">
+                  <td><code>forms</code></td>
+                  <td>
+                    Set of form hypermedia controls that describe how an operation can be performed. Forms are
+                    serializations of Protocol Bindings. <a>Thing level</a> forms are used to describe endpoints for a
+                    group of interaction affordances.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#form"><code>Form</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-security--Thing">
+                  <td><code>security</code></td>
+                  <td>
+                    Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.
+                    These must all be satisfied for access to resources.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing">
+                  <td><code>securityDefinitions</code></td>
+                  <td>
+                    Set of named security configurations (definitions only). Not actually applied unless names are used
+                    in a <code>security</code> name-value pair.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Map</a> of <a href="#securityscheme"><code>SecurityScheme</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-profile--Thing">
+                  <td><code>profile</code></td>
+                  <td>
+                    Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing
+                    implementation.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-schemaDefinitions--Thing">
+                  <td><code>schemaDefinitions</code></td>
+                  <td>
+                    Set of named data schemas. To be used in a <code>schema</code>
+                    name-value pair inside an
+                    <code>AdditionalExpectedResponse</code> object.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing">
+                  <td><code>uriVariables</code></td>
+                  <td>
+                    Define URI template variables according to [[RFC6570]] as collection based on DataSchema
+                    declarations. The <a>Thing level</a> <code>uriVariables</code> can be used in <a>Thing level</a>
+                    <code>forms</code> or in Interaction Affordances. The individual variables DataSchema cannot be an
+                    ObjectSchema or an ArraySchema since each variable needs to be serialized to a string inside the
+                    <code>href</code> upon the execution of the operation. If the same variable is both declared in
+                    <a>Thing level</a> <code>uriVariables</code> and in Interaction Affordance level, the Interaction
+                    Affordance level variable takes precedence.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:</p>
+            <ul>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-thing-mandatory">
+                  The <code>@context</code>
+                  name-value pair MUST contain the anyURI
+                  <code>https://www.w3.org/2022/wot/td/v1.1</code>
+                  in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly
+                  introduced terms.
+                </span>
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-td10-namespace">
+                  When there are possibly TD 1.0 consumers the anyURI
+                  <code>https://www.w3.org/2019/wot/td/v1</code>
+                  MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second
+                  entry.</span
+                >
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-td10-namespacev10">
+                  TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0
+                  [[wot-thing-description10]] specification.
+                </span>
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-thing-optional"
+                  >When <code>@context</code> is an
+                  <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>, the anyURI
+                  <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class="rfc2119" title="MAY">MAY</em> be followed
+                  by elements of type <code>anyURI</code> or type
+                  <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> in any order, while it is
+                  RECOMMENDED to include only one
+                  <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> with all the name-value pairs in
+                  the <code>@context</code>
+                  <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span
+                >
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-ns-thing-map-of-namespaces"
+                  ><a href="#dfn-map" class="internalDFN" data-link-type="dfn">Maps</a> contained in an
+                  <code>@context</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> MAY
+                  contain name-value pairs, where the value is a namespace identifier of type <code>anyURI</code> and
+                  the name a <a href="#dfn-term" class="internalDFN" data-link-type="dfn">Term</a> or prefix denoting
+                  that namespace.</span
+                >
+              </li>
+              <li>
+                <span class="rfc2119-assertion" id="td-context-default-language"
+                  >One <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> contained in an
+                  <code>@context</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> SHOULD
+                  contain a name-value pair that defines the default language for the Thing Description, where the name
+                  is the <a href="#dfn-term" class="internalDFN" data-link-type="dfn">Term</a>
+                  <code>@language</code> and the value is a well-formed language tag as defined by [<cite
+                    ><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages"
+                      >BCP47</a
+                    ></cite
+                  >] (e.g., <code>en</code>, <code>de-AT</code>, <code>gsw-CH</code>, <code>zh-Hans</code>,
+                  <code>zh-Hant-HK</code>, <code>sl-nedis</code>).</span
+                >
+              </li>
+            </ul>
 
-          The <code>@context</code>
-          name-value pair MUST contain the anyURI
-          <code>https://www.w3.org/2022/wot/td/v1.1</code>
-          in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly introduced terms.
-          </span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-td10-namespace"> 
-          When there are possibly TD 1.0 consumers the anyURI
-          <code>https://www.w3.org/2019/wot/td/v1</code>
-          MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second entry.</span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-td10-namespacev10"> 
-            TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0 [[wot-thing-description10]] specification. 
-            </span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-thing-optional">When <code>@context</code>
-          is an <a href="#dfn-array" class="internalDFN"
-          data-link-type="dfn">Array</a>, the anyURI
-          <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class=
-          "rfc2119" title="MAY">MAY</em> be followed by elements of
-          type <code>anyURI</code> or type <a href="#dfn-map"
-          class="internalDFN" data-link-type="dfn">Map</a> in any
-          order, while it is RECOMMENDED to include only one
-          <a href="#dfn-map" class="internalDFN" data-link-type=
-          "dfn">Map</a> with all the name-value pairs in the
-          <code>@context</code> <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a>.</span>
-          </li>
-        <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-ns-thing-map-of-namespaces"><a href=
-          "#dfn-map" class="internalDFN" data-link-type=
-          "dfn">Maps</a> contained in an <code>@context</code>
-          <a href="#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> MAY
-          contain name-value pairs, where the value is a namespace
-          identifier of type <code>anyURI</code> and the name a
-          <a href="#dfn-term" class="internalDFN" data-link-type=
-          "dfn">Term</a> or prefix denoting that namespace.</span>
-          </li>
-          <li>
-          <span class="rfc2119-assertion" id=
-          "td-context-default-language">One <a href="#dfn-map"
-          class="internalDFN" data-link-type="dfn">Map</a>
-          contained in an <code>@context</code> <a href=
-          "#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> SHOULD contain a name-value pair that
-          defines the default language for the Thing Description,
-          where the name is the <a href="#dfn-term" class=
-          "internalDFN" data-link-type="dfn">Term</a>
-          <code>@language</code> and the value is a well-formed
-          language tag as defined by [<cite><a class="bibref"
-          data-link-type="biblio" href="#bib-bcp47" title=
-          "Tags for Identifying Languages">BCP47</a></cite>] (e.g.,
-          <code>en</code>, <code>de-AT</code>, <code>gsw-CH</code>,
-          <code>zh-Hans</code>, <code>zh-Hant-HK</code>,
-          <code>sl-nedis</code>).</span>
-          </li>
-          </ul>
+            <p>
+              To determine the base direction of all human-readable text in <a>Thing Description</a> and
+              <a>Thing Model</a> instances this specification recommends to follow the [[STRING-META]] guideline about
+              <a href="https://www.w3.org/TR/string-meta/#string_specific_direction"
+                >string-specific directional information</a
+              >
+              when no built-in mechanism for associating base direction metadata is available.
+            </p>
 
-          
-          <p>To determine the base direction of all
-          human-readable text in <a>Thing Description</a> 
-          and <a>Thing Model</a> instances this specification 
-           recommends to follow the [[STRING-META]] guideline about 
-           <a href="https://www.w3.org/TR/string-meta/#string_specific_direction">string-specific directional information</a>
-           when no built-in mechanism for associating base direction metadata
-           is available.
-           </p>
-
-          <p><a href="#dfn-td-processor" class="internalDFN"
-          data-link-type="dfn">TD Processors</a> should be aware of
-          certain special cases when processing bidirectional text.
-          <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
-          <a href="#dfn-td-processor" class="internalDFN"
-          data-link-type="dfn">TD Processors</a> SHOULD take care to use bidi isolation when
-          presenting strings to users, particularly when embedding
-          in surrounding text (e.g., for Web user interface)</span>. 
-          Mixed direction text can occur in any language, even when the
-          language is properly identified.</p>
-          <p><span class="rfc2119-assertion" id="td-producer-mixed-direction">
-          TD <a>producers</a> SHOULD attempt to provide mixed direction
-          strings in a way that can be displayed successfully by a
-          naive user agent. </span>
-          For example, if an RTL string begins
-          with an LTR run (such as a number or a brand or trade
-          name in Latin script), including an RLM character at the
-          start of the string or wrapping opposite direction runs
-          in bidi controls can assist in proper display.</p>
-          <p><em>Strings on the Web: Language and Direction
-          Metadata</em> [<cite><a class="bibref" data-link-type=
-          "biblio" href="#bib-string-meta" title=
-          "Strings on the Web: Language and Direction Metadata">string-meta</a></cite>]
-          provides some guidance and illustrates a number of
-          pitfalls when using bidirectional text.</p>
-          <p id="meta-interactions-of-thing">In addition to the
-          explicitly provided <a href="#dfn-interaction-affordance"
-          class="internalDFN" data-link-type="dfn">Interaction
-          Affordances</a> in the <code>properties</code>,
-          <code>actions</code>, and <code>events</code> <a href=
-          "#dfn-map" class="internalDFN" data-link-type=
-          "dfn">Maps</a>, a <a href="#dfn-thing" class=
-          "internalDFN" data-link-type="dfn">Thing</a> can also
-          provide meta-interactions, which are indicated by
-          <code>Form</code> instances in its optional
-          <code>forms</code> <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a>.
-          <span class="rfc2119-assertion" id="td-op-for-thing">When
-          the <code>forms</code> <a href="#dfn-array" class=
-          "internalDFN" data-link-type="dfn">Array</a> of a
-          <a href="#dfn-thing" class="internalDFN" data-link-type=
-          "dfn">Thing</a> instance contains <code>Form</code>
-          instances, it MUST contain <code>op</code> member with the string values assigned 
-          to the name <code>op</code>, either directly or within an <a href=
-          "#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a>, MUST be one of the following <em>operation
-          types</em>: <code>readallproperties</code>,
-          <code>writeallproperties</code>,
-          <code>readmultipleproperties</code>,
-          <code>writemultipleproperties</code>, <code>observeallproperties</code>,
-          <code>unobserveallproperties</code>, <code>queryallactions</code>, 
-          <code>subscribeallevents</code>, or
-          <code>unsubscribeallevents</code>.</span> (See
-          <a href="#td-forms-readall-example">an example</a> for an
-          usage of <code>form</code> in a Thing instance.)</p>
-          <p>The data schema for each of the property meta-interactions is
-          constructed by combining the data schemas of each
-          <code>PropertyAffordance</code> instance in a single
-          <code>ObjectSchema</code> instance, where the
-          <code>properties</code> <a href="#dfn-map" class=
-          "internalDFN" data-link-type="dfn">Map</a> of the
-          <code>ObjectSchema</code> instance contains each data
-          schema of the <code>PropertyAffordances</code> identified
-          by the name of the corresponding
-          <code>PropertyAffordances</code> instance.</p>
-          <p>If not specified otherwise (e.g., through a <a href=
-          "#dfn-context-ext" class="internalDFN" data-link-type=
-          "dfn">TD Context Extension</a>), the request data of the
-          <code>readmultipleproperties</code> operation is an
-          <a href="#dfn-array" class="internalDFN" data-link-type=
-          "dfn">Array</a> that contains the intended
-          <code>PropertyAffordances</code> instance names, which is
-          serialized to the content type specified by the
-          <code>Form</code> instance.</p></section>
-<section><h3><code>InteractionAffordance</code></h3><p>Metadata of a Thing that shows the possible choices to
-          <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a>, thereby suggesting
-          how <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> may interact with the
-          Thing. There are many types of potential affordances, but
-          <abbr title="World Wide Web Consortium">W3C</abbr> WoT
-          defines three types of Interaction Affordances:
-          Properties, Actions, and Events.</p><table class="def numbered"><caption>Vocabulary Terms in InteractionAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
-                a text for UI representation) based on a default
-                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance"><td><code>titles</code></td><td>Provides multi-language human-readable titles
-                (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance"><td><code>forms</code></td><td>Set of form hypermedia controls that describe
-                how an operation can be performed. Forms are
-                serializations of Protocol Bindings. The array cannot be empty.</td><td>mandatory</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
-                based on DataSchema declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
-                to be serialized to a string inside the <code>href</code> upon the execution of the operation. 
-                If the same variable is both declared in <a>Thing level</a> <code>uriVariables</code>and in Interaction Affordance level, 
-                the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>The class <code>InteractionAffordance</code> has the following subclasses:</p><ul><li><a href="#propertyaffordance"><code>PropertyAffordance</code></a></li>
-<li><a href="#actionaffordance"><code>ActionAffordance</code></a></li>
-<li><a href="#eventaffordance"><code>EventAffordance</code></a></li></ul></section>
-<section><h3><code>PropertyAffordance</code></h3><p>An Interaction Affordance that exposes state of the
-          Thing. This state can then be retrieved (read) and/or updated (write).
-           Things can also choose to
-          make Properties observable by pushing the new state after
-          a change.</p><table class="def numbered"><caption>Vocabulary Terms in PropertyAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance"><td><code>observable</code></td><td>A hint that indicates whether Servients hosting
-                the Thing and Intermediaries should provide a
-                Protocol Binding that supports the <code>observeproperty</code> and <code>unobserveproperty</code> operations 
-                for this Property.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table><p class="note">Property instances are also instances of
-            the class <a href="#dataschema" class="sec-ref">DataSchema</a>. Therefore, it can contain the
-            <code>type</code>, <code>unit</code>,
-            <code>readOnly</code> and <code>writeOnly</code>
-            members, among others.</p><p><code>PropertyAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> and
-          the <code>DataSchema</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-          <span class="rfc2119-assertion" id="td-op-for-property">When a Form instance is within a
-          <code>PropertyAffordance</code> instance, the value
-          assigned to <code>op</code> MUST be one of <code>readproperty</code>,
-          <code>writeproperty</code>, <code>observeproperty</code>,
-          <code>unobserveproperty</code> or an <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
-          containing a combination of these terms.</span></p><p class="note">
-		  It is considered to be good practice that each <code>observeproperty</code> has a corresponding
-		  <code>unobserveproperty</code> unless the protocol supports implicit unsubscription mechanisms
-		  (e.g., heartbeat to detect connection loss).</p><p class="note">
-		  The observation mechanism depends on the underlying protocol or sub-protocol. Having said that, it is not 
-          guaranteed that the current <a>Property</a> value will be provided once the subscription is initiated. Hence, it may be 
-          necessary to read the current <a>Property</a> value before/after the subscription to get a first value. 
-          </p></section>
-<section><h3><code>ActionAffordance</code></h3><p>An Interaction Affordance that allows to invoke a
-          function of the Thing, which manipulates state (e.g.,
-          toggling a lamp on or off) or triggers a process on the
-          Thing (e.g., dim a lamp over time).</p><table class="def numbered"><caption>Vocabulary Terms in ActionAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance"><td><code>input</code></td><td>Used to define the input data schema of the
-                Action.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance"><td><code>output</code></td><td>Used to define the output data schema of the
-                Action.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance"><td><code>safe</code></td><td>Signals if the Action is safe (=true) or not.
-                Used to signal if there is no internal state (cf.
-                resource state) is changed when invoking an Action.
-                In that case responses can be cached as
-                example.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance"><td><code>idempotent</code></td><td>Indicates whether the Action is idempotent
-                (=true) or not. Informs whether the Action can be
-                called repeatedly with the same result, if present,
-                based on the same input.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-synchronous--ActionAffordance"><td><code>synchronous</code></td><td>Indicates whether the action is synchronous (=true) or not. 
-                A synchronous action means that the response of action contains all the information 
-                about the result of the action and no further querying about the status of the action 
-                is needed. Lack of this keyword means that no claim on the synchronicity of the 
-                action can be made.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table><p><code>ActionAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-          <span class="rfc2119-assertion" id="td-op-for-action">When a Form instance is within an
-          <code>ActionAffordance</code> instance, the value
-          assigned to op MUST
-          either be <code>invokeaction</code>, <code>queryaction</code>, 
-          <code>cancelaction</code> or an 
-          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
-          containing a combination of these terms.
-          </span></p></section>
-<section><h3><code>EventAffordance</code></h3><p>An Interaction Affordance that describes an event
-          source, which asynchronously pushes event data to
-          <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating
-          alerts).</p><table class="def numbered"><caption>Vocabulary Terms in EventAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance"><td><code>subscription</code></td><td>Defines data that needs to be passed upon
-                subscription, e.g., filters or message format for
-                setting up Webhooks.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance"><td><code>data</code></td><td>Defines the data schema of the Event instance
-                messages pushed by the Thing.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-dataResponse--EventAffordance"><td><code>dataResponse</code></td><td>Defines the data schema of the Event response messages sent by the consumer in a response to a data message.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance"><td><code>cancellation</code></td><td>Defines any data that needs to be passed to
-                cancel a subscription, e.g., a specific message to
-                remove a Webhook.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p><code>EventAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-          <span class="rfc2119-assertion" id="td-op-for-event">When
-          a Form instance is within an <code>EventAffordance</code>
-          instance, the value assigned to <code>op</code>
-          MUST be either
-          <code>subscribeevent</code>,
-          <code>unsubscribeevent</code>, or both terms within an
-          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span></p><p class="note">
-		  It is considered to be good practice that each <code>subscribeevent</code> has a corresponding <code>unsubscribeevent</code> unless the protocol
-		  supports implicit unsubscription mechanisms (e.g., heartbeat to detect connection loss).</p>
-          <p>
-            EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs interested Consumers about state changes.
-            However, a main difference of EventAffordances is that not every change of the associated resource needs to trigger an event message to be emitted, e.g. a critical threshold for a numeric value.
-        Furthermore, EventAffordances allow for more complex subscribing and unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and <code>cancellation</code> DataSchema definitions.
-            Not all protocols might support these more advanced mechanisms, however, which is why in some scenarios, events may be very similar to observable PropertyAffordances.
-            In these cases, the choice between a Property and a Event for modelling the Affordance should be made based on the semantics of the underlying resource; for example, if the state of the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the appropriate choice.
-          </p>
+            <p>
+              <a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TD Processors</a> should be aware of
+              certain special cases when processing bidirectional text.
+              <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
+                <a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TD Processors</a> SHOULD take care
+                to use bidi isolation when presenting strings to users, particularly when embedding in surrounding text
+                (e.g., for Web user interface)</span
+              >. Mixed direction text can occur in any language, even when the language is properly identified.
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-producer-mixed-direction">
+                TD <a>producers</a> SHOULD attempt to provide mixed direction strings in a way that can be displayed
+                successfully by a naive user agent.
+              </span>
+              For example, if an RTL string begins with an LTR run (such as a number or a brand or trade name in Latin
+              script), including an RLM character at the start of the string or wrapping opposite direction runs in bidi
+              controls can assist in proper display.
+            </p>
+            <p>
+              <em>Strings on the Web: Language and Direction Metadata</em> [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-string-meta"
+                  title="Strings on the Web: Language and Direction Metadata"
+                  >string-meta</a
+                ></cite
+              >] provides some guidance and illustrates a number of pitfalls when using bidirectional text.
+            </p>
+            <p id="meta-interactions-of-thing">
+              In addition to the explicitly provided
+              <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
+              in the <code>properties</code>, <code>actions</code>, and <code>events</code>
+              <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Maps</a>, a
+              <a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a> can also provide
+              meta-interactions, which are indicated by <code>Form</code> instances in its optional <code>forms</code>
+              <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.
+              <span class="rfc2119-assertion" id="td-op-for-thing"
+                >When the <code>forms</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> of
+                a <a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a> instance contains
+                <code>Form</code> instances, it MUST contain <code>op</code> member with the string values assigned to
+                the name <code>op</code>, either directly or within an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>, MUST be one of the following
+                <em>operation types</em>: <code>readallproperties</code>, <code>writeallproperties</code>,
+                <code>readmultipleproperties</code>, <code>writemultipleproperties</code>,
+                <code>observeallproperties</code>, <code>unobserveallproperties</code>, <code>queryallactions</code>,
+                <code>subscribeallevents</code>, or <code>unsubscribeallevents</code>.</span
+              >
+              (See <a href="#td-forms-readall-example">an example</a> for an usage of <code>form</code> in a Thing
+              instance.)
+            </p>
+            <p>
+              The data schema for each of the property meta-interactions is constructed by combining the data schemas of
+              each <code>PropertyAffordance</code> instance in a single <code>ObjectSchema</code> instance, where the
+              <code>properties</code> <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> of the
+              <code>ObjectSchema</code> instance contains each data schema of the
+              <code>PropertyAffordances</code> identified by the name of the corresponding
+              <code>PropertyAffordances</code> instance.
+            </p>
+            <p>
+              If not specified otherwise (e.g., through a
+              <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>), the request
+              data of the <code>readmultipleproperties</code> operation is an
+              <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> that contains the intended
+              <code>PropertyAffordances</code> instance names, which is serialized to the content type specified by the
+              <code>Form</code> instance.
+            </p>
           </section>
-<section><h3><code>VersionInfo</code></h3><p>Metadata of a Thing that provides version information
-          about the TD document. If required, additional version
-          information such as firmware and hardware version (term
-          definitions outside of the TD namespace) can be extended
-          via the <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>
-          mechanism.</p><table class="def numbered"><caption>Vocabulary Terms in VersionInfo Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo"><td><code>instance</code></td><td>Provides a version indicator of this TD.
-                </td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-model--VersionInfo"><td><code>model</code></td><td>Provides a version indicator of the underlying TM.
-                </td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><p>It is recommended that the values within <code>instances</code> and <code>model</code> of
-          the <code>VersionInfo</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> follow the
-          semantic versioning pattern, where a sequence of three
-          numbers separated by a dot indicates the major version,
-          minor version, and patch version, respectively. See
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0">SEMVER</a></cite>] for
-          details.</p></section>
-<section><h3><code>MultiLanguage</code></h3><p><p>A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
-            <p><span class="rfc2119-assertion" id="td-multilanguage-language-tag">Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in [[!BCP47]].</span>
-            <span class="rfc2119-assertion" id="td-multilanguage-value"> Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>. </span> 
-            </p></section>
+          <section>
+            <h3><code>InteractionAffordance</code></h3>
+            <p>
+              Metadata of a Thing that shows the possible choices to
+              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a>, thereby suggesting how
+              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> may interact with the
+              Thing. There are many types of potential affordances, but
+              <abbr title="World Wide Web Consortium">W3C</abbr> WoT defines three types of Interaction Affordances:
+              Properties, Actions, and Events.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in InteractionAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance">
+                  <td><code>title</code></td>
+                  <td>
+                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
+                    language.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance">
+                  <td><code>titles</code></td>
+                  <td>
+                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
+                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance">
+                  <td><code>forms</code></td>
+                  <td>
+                    Set of form hypermedia controls that describe how an operation can be performed. Forms are
+                    serializations of Protocol Bindings. The array cannot be empty.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Array</a> of <a href="#form"><code>Form</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance">
+                  <td><code>uriVariables</code></td>
+                  <td>
+                    Define URI template variables according to [[RFC6570]] as collection based on DataSchema
+                    declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since
+                    each variable needs to be serialized to a string inside the <code>href</code> upon the execution of
+                    the operation. If the same variable is both declared in <a>Thing level</a>
+                    <code>uriVariables</code>and in Interaction Affordance level, the Interaction Affordance level
+                    variable takes precedence.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>The class <code>InteractionAffordance</code> has the following subclasses:</p>
+            <ul>
+              <li>
+                <a href="#propertyaffordance"><code>PropertyAffordance</code></a>
+              </li>
+              <li>
+                <a href="#actionaffordance"><code>ActionAffordance</code></a>
+              </li>
+              <li>
+                <a href="#eventaffordance"><code>EventAffordance</code></a>
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3><code>PropertyAffordance</code></h3>
+            <p>
+              An Interaction Affordance that exposes state of the Thing. This state can then be retrieved (read) and/or
+              updated (write). Things can also choose to make Properties observable by pushing the new state after a
+              change.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in PropertyAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance">
+                  <td><code>observable</code></td>
+                  <td>
+                    A hint that indicates whether Servients hosting the Thing and Intermediaries should provide a
+                    Protocol Binding that supports the <code>observeproperty</code> and
+                    <code>unobserveproperty</code> operations for this Property.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="note">
+              Property instances are also instances of the class <a href="#dataschema" class="sec-ref">DataSchema</a>.
+              Therefore, it can contain the <code>type</code>, <code>unit</code>, <code>readOnly</code> and
+              <code>writeOnly</code> members, among others.
+            </p>
+            <p>
+              <code>PropertyAffordance</code> is a
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+              <code>InteractionAffordance</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> and the <code>DataSchema</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+              <span class="rfc2119-assertion" id="td-op-for-property"
+                >When a Form instance is within a <code>PropertyAffordance</code> instance, the value assigned to
+                <code>op</code> MUST be one of <code>readproperty</code>, <code>writeproperty</code>,
+                <code>observeproperty</code>, <code>unobserveproperty</code> or an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> containing a combination of
+                these terms.</span
+              >
+            </p>
+            <p class="note">
+              It is considered to be good practice that each <code>observeproperty</code> has a corresponding
+              <code>unobserveproperty</code> unless the protocol supports implicit unsubscription mechanisms (e.g.,
+              heartbeat to detect connection loss).
+            </p>
+            <p class="note">
+              The observation mechanism depends on the underlying protocol or sub-protocol. Having said that, it is not
+              guaranteed that the current <a>Property</a> value will be provided once the subscription is initiated.
+              Hence, it may be necessary to read the current <a>Property</a> value before/after the subscription to get
+              a first value.
+            </p>
+          </section>
+          <section>
+            <h3><code>ActionAffordance</code></h3>
+            <p>
+              An Interaction Affordance that allows to invoke a function of the Thing, which manipulates state (e.g.,
+              toggling a lamp on or off) or triggers a process on the Thing (e.g., dim a lamp over time).
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ActionAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance">
+                  <td><code>input</code></td>
+                  <td>Used to define the input data schema of the Action.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance">
+                  <td><code>output</code></td>
+                  <td>Used to define the output data schema of the Action.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance">
+                  <td><code>safe</code></td>
+                  <td>
+                    Signals if the Action is safe (=true) or not. Used to signal if there is no internal state (cf.
+                    resource state) is changed when invoking an Action. In that case responses can be cached as example.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance">
+                  <td><code>idempotent</code></td>
+                  <td>
+                    Indicates whether the Action is idempotent (=true) or not. Informs whether the Action can be called
+                    repeatedly with the same result, if present, based on the same input.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-synchronous--ActionAffordance">
+                  <td><code>synchronous</code></td>
+                  <td>
+                    Indicates whether the action is synchronous (=true) or not. A synchronous action means that the
+                    response of action contains all the information about the result of the action and no further
+                    querying about the status of the action is needed. Lack of this keyword means that no claim on the
+                    synchronicity of the action can be made.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              <code>ActionAffordance</code> is a
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+              <code>InteractionAffordance</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+              <span class="rfc2119-assertion" id="td-op-for-action"
+                >When a Form instance is within an <code>ActionAffordance</code> instance, the value assigned to op MUST
+                either be <code>invokeaction</code>, <code>queryaction</code>, <code>cancelaction</code> or an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
+                containing a combination of these terms.
+              </span>
+            </p>
+          </section>
+          <section>
+            <h3><code>EventAffordance</code></h3>
+            <p>
+              An Interaction Affordance that describes an event source, which asynchronously pushes event data to
+              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating alerts).
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in EventAffordance Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance">
+                  <td><code>subscription</code></td>
+                  <td>
+                    Defines data that needs to be passed upon subscription, e.g., filters or message format for setting
+                    up Webhooks.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance">
+                  <td><code>data</code></td>
+                  <td>Defines the data schema of the Event instance messages pushed by the Thing.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-dataResponse--EventAffordance">
+                  <td><code>dataResponse</code></td>
+                  <td>
+                    Defines the data schema of the Event response messages sent by the consumer in a response to a data
+                    message.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance">
+                  <td><code>cancellation</code></td>
+                  <td>
+                    Defines any data that needs to be passed to cancel a subscription, e.g., a specific message to
+                    remove a Webhook.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              <code>EventAffordance</code> is a
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+              <code>InteractionAffordance</code>
+              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+              <span class="rfc2119-assertion" id="td-op-for-event"
+                >When a Form instance is within an <code>EventAffordance</code> instance, the value assigned to
+                <code>op</code>
+                MUST be either
+                <code>subscribeevent</code>, <code>unsubscribeevent</code>, or both terms within an
+                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span
+              >
+            </p>
+            <p class="note">
+              It is considered to be good practice that each <code>subscribeevent</code> has a corresponding
+              <code>unsubscribeevent</code> unless the protocol supports implicit unsubscription mechanisms (e.g.,
+              heartbeat to detect connection loss).
+            </p>
+            <p>
+              EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs
+              interested Consumers about state changes. However, a main difference of EventAffordances is that not every
+              change of the associated resource needs to trigger an event message to be emitted, e.g. a critical
+              threshold for a numeric value. Furthermore, EventAffordances allow for more complex subscribing and
+              unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and
+              <code>cancellation</code> DataSchema definitions. Not all protocols might support these more advanced
+              mechanisms, however, which is why in some scenarios, events may be very similar to observable
+              PropertyAffordances. In these cases, the choice between a Property and a Event for modelling the
+              Affordance should be made based on the semantics of the underlying resource; for example, if the state of
+              the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the
+              appropriate choice.
+            </p>
+          </section>
+          <section>
+            <h3><code>VersionInfo</code></h3>
+            <p>
+              Metadata of a Thing that provides version information about the TD document. If required, additional
+              version information such as firmware and hardware version (term definitions outside of the TD namespace)
+              can be extended via the
+              <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a> mechanism.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in VersionInfo Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo">
+                  <td><code>instance</code></td>
+                  <td>Provides a version indicator of this TD.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-model--VersionInfo">
+                  <td><code>model</code></td>
+                  <td>Provides a version indicator of the underlying TM.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              It is recommended that the values within <code>instances</code> and <code>model</code> of the
+              <code>VersionInfo</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> follow
+              the semantic versioning pattern, where a sequence of three numbers separated by a dot indicates the major
+              version, minor version, and patch version, respectively. See [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0"
+                  >SEMVER</a
+                ></cite
+              >] for details.
+            </p>
+          </section>
+          <section>
+            <h3><code>MultiLanguage</code></h3>
+            <p></p>
+            <p>
+              A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags
+              described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of
+              this container in a Thing Description instance.
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-multilanguage-language-tag"
+                >Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in
+                [[!BCP47]].</span
+              >
+              <span class="rfc2119-assertion" id="td-multilanguage-value">
+                Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>.
+              </span>
+            </p>
+          </section>
         </section>
 
         <section id="sec-data-schema-vocabulary-definition">
@@ -1552,122 +2051,579 @@
           </table>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>DataSchema</code></h3><p>Metadata that describes the data format used. It can
-          be used for validation.</p><table class="def numbered"><caption>Vocabulary Terms in DataSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
-                a text for UI representation) based on a default
-                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema"><td><code>titles</code></td><td>Provides multi-language human-readable titles
-                (e.g., display a text for UI representation in
-                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema"><td><code>const</code></td><td>Provides a constant value.</td><td>optional</td><td>any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema"><td><code>default</code></td><td>Supply a default value. The value SHOULD validate against the data schema in which it resides.</td><td>optional</td><td>any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema"><td><code>unit</code></td><td>Provides unit information that is used, e.g.,
-                in international science, engineering, and
-                business. To preserve uniqueness, it is recommended that 
-                the value of the unit points to a semantic definition (also see Section <a href="#semantic-annotations-example-version-units"
-          class="internalDFN" data-link-type="dfn">Semantic Annotations</a>).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema"><td><code>oneOf</code></td><td>Used to ensure that the data is valid against
-                one of the specified schemas in the array.  This can be used to describe multiple input or output schemas.</td><td>optional</td><td><a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema"><td><code>enum</code></td><td>Restricted set of values provided as an
-                array.</td><td>optional</td><td><a>Array</a> of any type</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema"><td><code>readOnly</code></td><td>Boolean value that is a hint to indicate
-                whether a property interaction / value is read only
-                (=true) or not (=false).</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema"><td><code>writeOnly</code></td><td>Boolean value that is a hint to indicate
-                whether a property interaction / value is write
-                only (=true) or not (=false).</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema"><td><code>format</code></td><td>Allows validation based on a format pattern
-                such as "date-time", "email", "uri", etc. (Also see
-                below.)</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-type--DataSchema"><td><code>type</code></td><td>Assignment of JSON-based data types compatible
-                with JSON Schema (one of boolean, integer, number,
-                string, object, array, or null).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> (one of <code>object</code>, <code>array</code>, <code>string</code>, <code>number</code>, <code>integer</code>, <code>boolean</code>, or <code>null</code>)</td></tr></tbody></table><p>The class <code>DataSchema</code> has the following subclasses:</p><ul><li><a href="#arrayschema"><code>ArraySchema</code></a></li>
-<li><a href="#booleanschema"><code>BooleanSchema</code></a></li>
-<li><a href="#numberschema"><code>NumberSchema</code></a></li>
-<li><a href="#integerschema"><code>IntegerSchema</code></a></li>
-<li><a href="#objectschema"><code>ObjectSchema</code></a></li>
-<li><a href="#stringschema"><code>StringSchema</code></a></li>
-<li><a href="#nullschema"><code>NullSchema</code></a></li></ul><p>The <code>format</code> string values are known from a
-          fixed set of values and their corresponding format rules
-          defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]
-          (Section 7.3 Defined Formats in particular). <span class="rfc2119-assertion" id="td-format-validation-known-values">Servients MAY use the
-          <code>format</code> value to perform additional
-          validation accordingly.</span> <span class="rfc2119-assertion" id="td-format-validation-other-values">When a value that is
-          not found in the known set of values is assigned to
-          <code>format</code>, such a validation SHOULD succeed.</span></p>
-          Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>, <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string, object, array, or null).
-          <p class="note">The <code>format</code> term is not widely implemented by JSON Schema tools. 
-          In addition, the term <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by another mechanism or removed in a future JSON Schema version.</p></section>
-<section><h3><code>ArraySchema</code></h3><p>Metadata describing data of type <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>. This
-          <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>array</code> assigned to <code>type</code> in
-          <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in ArraySchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema"><td><code>items</code></td><td>Used to define the characteristics of an
-                array.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a> or <a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema"><td><code>minItems</code></td><td>Defines the minimum number of items that have
-                to be in the array.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema"><td><code>maxItems</code></td><td>Defines the maximum number of items that have
-                to be in the array.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr></tbody></table></section>
-<section><h3><code>BooleanSchema</code></h3><p>Metadata describing data of type <code>boolean</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>boolean</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p></section>
-<section><h3><code>NumberSchema</code></h3><p>Metadata describing data of type <code>number</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>number</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in NumberSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema"><td><code>minimum</code></td><td>Specifies a minimum numeric value, representing an inclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--NumberSchema"><td><code>exclusiveMinimum</code></td><td>Specifies a minimum numeric value, representing an exclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema"><td><code>maximum</code></td><td>Specifies a maximum numeric value, representing an inclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--NumberSchema"><td><code>exclusiveMaximum</code></td><td>Specifies a maximum numeric value, representing an exclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--NumberSchema"><td><code>multipleOf</code></td><td>Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr></tbody></table></section>
-<section><h3><code>IntegerSchema</code></h3><p>Metadata describing data of type <code>integer</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>integer</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in IntegerSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema"><td><code>minimum</code></td><td>Specifies a minimum numeric value, representing an inclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--IntegerSchema"><td><code>exclusiveMinimum</code></td><td>Specifies a minimum numeric value, representing an exclusive lower limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema"><td><code>maximum</code></td><td>Specifies a maximum numeric value, representing an inclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--IntegerSchema"><td><code>exclusiveMaximum</code></td><td>Specifies a maximum numeric value, representing an exclusive upper limit. Only
-                applicable for associated number or integer
-                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--IntegerSchema"><td><code>multipleOf</code></td><td>Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr></tbody></table></section>
-<section><h3><code>ObjectSchema</code></h3><p>Metadata describing data of type <a href="#dfn-object" class="internalDFN" data-link-type="dfn">Object</a>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>object</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in ObjectSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema"><td><code>properties</code></td><td>Data schema nested definitions.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema"><td><code>required</code></td><td>Defines which members of the object type are mandatory, i.e. which members are mandatory in the payload that is to be sent (e.g. input of <code>invokeaction</code>, <code>writeproperty</code>) and what members will be definitely delivered in the payload that is being received (e.g. output of <code>invokeaction</code>, <code>readproperty</code>)</td><td>optional</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>StringSchema</code></h3><p>Metadata describing data of type <code>string</code>.
-          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-          value <code>string</code> assigned to <code>type</code>
-          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in StringSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minLength--StringSchema"><td><code>minLength</code></td><td>Specifies the minimum length of a string. Only applicable for associated string types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-maxLength--StringSchema"><td><code>maxLength</code></td><td>Specifies the maximum length of a string. Only applicable for associated string types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-pattern--StringSchema"><td><code>pattern</code></td><td>Provides a regular expression to express constraints of the string value. The regular expression must follow the [[ECMA-262]] dialect.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentEncoding--StringSchema"><td><code>contentEncoding</code></td><td>Specifies the encoding used to store the contents, as specified in [[RFC2045]] (Section 6.1) and [[RFC4648]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>7bit</code>, <code>8bit</code>, <code>binary</code>, <code>quoted-printable</code>, <code>base16</code>, <code>base32</code>, or <code>base64</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentMediaType--StringSchema"><td><code>contentMediaType</code></td><td>Specifies the MIME type of the contents of a string value, as described in [[RFC2046]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>image/png</code>, or <code>audio/mpeg</code>)</td></tr></tbody></table><p class="note">The length of a string (i.e., <code>minLength</code> and
-        <code>maxLength</code>) is defined as the number
-        of Unicode code points, as defined by [[RFC8259]].
-		Note that some <a href="https://www.w3.org/TR/i18n-glossary/#dfn-grapheme" target="_blank">user-perceived characters</a> are composed of more than one Unicode code point. Arbitrary index values might not fall on these grapheme boundaries, so truncation according to <code>maxLength</code> might alter the appearance or meaning of the string.
-		</p></section>
-<section><h3><code>NullSchema</code></h3><p>Metadata describing data of type <code>null</code>. This subclass is indicated by the value <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. 
-    This Subclass describes only one acceptable value, namely <code>null</code>. 
-    It is important to note that <code>null</code> does not mean the absence of a value. It is analogous to <code>null</code> in JavaScript, <code>None</code> in Python, <code>null</code> in Java and <code>nil</code> in Ruby programming languages. 
-    It can be used as part of a <code>oneOf</code> declaration, where it is used to indicate, that the data can also be <code>null</code>.</p></section>
+          <section>
+            <h3><code>DataSchema</code></h3>
+            <p>Metadata that describes the data format used. It can be used for validation.</p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in DataSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema">
+                  <td><code>title</code></td>
+                  <td>
+                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
+                    language.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema">
+                  <td><code>titles</code></td>
+                  <td>
+                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
+                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema">
+                  <td><code>const</code></td>
+                  <td>Provides a constant value.</td>
+                  <td>optional</td>
+                  <td>any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema">
+                  <td><code>default</code></td>
+                  <td>
+                    Supply a default value. The value SHOULD validate against the data schema in which it resides.
+                  </td>
+                  <td>optional</td>
+                  <td>any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema">
+                  <td><code>unit</code></td>
+                  <td>
+                    Provides unit information that is used, e.g., in international science, engineering, and business.
+                    To preserve uniqueness, it is recommended that the value of the unit points to a semantic definition
+                    (also see Section
+                    <a href="#semantic-annotations-example-version-units" class="internalDFN" data-link-type="dfn"
+                      >Semantic Annotations</a
+                    >).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema">
+                  <td><code>oneOf</code></td>
+                  <td>
+                    Used to ensure that the data is valid against one of the specified schemas in the array. This can be
+                    used to describe multiple input or output schemas.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema">
+                  <td><code>enum</code></td>
+                  <td>Restricted set of values provided as an array.</td>
+                  <td>optional</td>
+                  <td><a>Array</a> of any type</td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema">
+                  <td><code>readOnly</code></td>
+                  <td>
+                    Boolean value that is a hint to indicate whether a property interaction / value is read only (=true)
+                    or not (=false).
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema">
+                  <td><code>writeOnly</code></td>
+                  <td>
+                    Boolean value that is a hint to indicate whether a property interaction / value is write only
+                    (=true) or not (=false).
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema">
+                  <td><code>format</code></td>
+                  <td>
+                    Allows validation based on a format pattern such as "date-time", "email", "uri", etc. (Also see
+                    below.)
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-type--DataSchema">
+                  <td><code>type</code></td>
+                  <td>
+                    Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number,
+                    string, object, array, or null).
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> (one
+                    of <code>object</code>, <code>array</code>, <code>string</code>, <code>number</code>,
+                    <code>integer</code>, <code>boolean</code>, or <code>null</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>The class <code>DataSchema</code> has the following subclasses:</p>
+            <ul>
+              <li>
+                <a href="#arrayschema"><code>ArraySchema</code></a>
+              </li>
+              <li>
+                <a href="#booleanschema"><code>BooleanSchema</code></a>
+              </li>
+              <li>
+                <a href="#numberschema"><code>NumberSchema</code></a>
+              </li>
+              <li>
+                <a href="#integerschema"><code>IntegerSchema</code></a>
+              </li>
+              <li>
+                <a href="#objectschema"><code>ObjectSchema</code></a>
+              </li>
+              <li>
+                <a href="#stringschema"><code>StringSchema</code></a>
+              </li>
+              <li>
+                <a href="#nullschema"><code>NullSchema</code></a>
+              </li>
+            </ul>
+            <p>
+              The <code>format</code> string values are known from a fixed set of values and their corresponding format
+              rules defined in [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-json-schema"
+                  title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
+                  >JSON-SCHEMA</a
+                ></cite
+              >] (Section 7.3 Defined Formats in particular).
+              <span class="rfc2119-assertion" id="td-format-validation-known-values"
+                >Servients MAY use the <code>format</code> value to perform additional validation accordingly.</span
+              >
+              <span class="rfc2119-assertion" id="td-format-validation-other-values"
+                >When a value that is not found in the known set of values is assigned to <code>format</code>, such a
+                validation SHOULD succeed.</span
+              >
+            </p>
+            Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>,
+            <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string,
+            object, array, or null).
+            <p class="note">
+              The <code>format</code> term is not widely implemented by JSON Schema tools. In addition, the term
+              <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by
+              another mechanism or removed in a future JSON Schema version.
+            </p>
+          </section>
+          <section>
+            <h3><code>ArraySchema</code></h3>
+            <p>
+              Metadata describing data of type <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.
+              This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+              value <code>array</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ArraySchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema">
+                  <td><code>items</code></td>
+                  <td>Used to define the characteristics of an array.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#dataschema"><code>DataSchema</code></a> or <a>Array</a> of
+                    <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema">
+                  <td><code>minItems</code></td>
+                  <td>Defines the minimum number of items that have to be in the array.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema">
+                  <td><code>maxItems</code></td>
+                  <td>Defines the maximum number of items that have to be in the array.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>BooleanSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>boolean</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>boolean</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+          </section>
+          <section>
+            <h3><code>NumberSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>number</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>number</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in NumberSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema">
+                  <td><code>minimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--NumberSchema">
+                  <td><code>exclusiveMinimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema">
+                  <td><code>maximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--NumberSchema">
+                  <td><code>exclusiveMaximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--NumberSchema">
+                  <td><code>multipleOf</code></td>
+                  <td>
+                    Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>IntegerSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>integer</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>integer</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in IntegerSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema">
+                  <td><code>minimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--IntegerSchema">
+                  <td><code>exclusiveMinimum</code></td>
+                  <td>
+                    Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema">
+                  <td><code>maximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--IntegerSchema">
+                  <td><code>exclusiveMaximum</code></td>
+                  <td>
+                    Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--IntegerSchema">
+                  <td><code>multipleOf</code></td>
+                  <td>
+                    Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for
+                    associated number or integer types.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>ObjectSchema</code></h3>
+            <p>
+              Metadata describing data of type
+              <a href="#dfn-object" class="internalDFN" data-link-type="dfn">Object</a>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>object</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ObjectSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema">
+                  <td><code>properties</code></td>
+                  <td>Data schema nested definitions.</td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema">
+                  <td><code>required</code></td>
+                  <td>
+                    Defines which members of the object type are mandatory, i.e. which members are mandatory in the
+                    payload that is to be sent (e.g. input of <code>invokeaction</code>, <code>writeproperty</code>) and
+                    what members will be definitely delivered in the payload that is being received (e.g. output of
+                    <code>invokeaction</code>, <code>readproperty</code>)
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>StringSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>string</code>. This
+              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
+              <code>string</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in StringSchema Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-minLength--StringSchema">
+                  <td><code>minLength</code></td>
+                  <td>Specifies the minimum length of a string. Only applicable for associated string types.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-maxLength--StringSchema">
+                  <td><code>maxLength</code></td>
+                  <td>Specifies the maximum length of a string. Only applicable for associated string types.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
+                      ><code>unsignedInt</code></a
+                    >
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-pattern--StringSchema">
+                  <td><code>pattern</code></td>
+                  <td>
+                    Provides a regular expression to express constraints of the string value. The regular expression
+                    must follow the [[ECMA-262]] dialect.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentEncoding--StringSchema">
+                  <td><code>contentEncoding</code></td>
+                  <td>
+                    Specifies the encoding used to store the contents, as specified in [[RFC2045]] (Section 6.1) and
+                    [[RFC4648]].
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>7bit</code>, <code>8bit</code>, <code>binary</code>, <code>quoted-printable</code>,
+                    <code>base16</code>, <code>base32</code>, or <code>base64</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentMediaType--StringSchema">
+                  <td><code>contentMediaType</code></td>
+                  <td>Specifies the MIME type of the contents of a string value, as described in [[RFC2046]].</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>image/png</code>, or <code>audio/mpeg</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="note">
+              The length of a string (i.e., <code>minLength</code> and <code>maxLength</code>) is defined as the number
+              of Unicode code points, as defined by [[RFC8259]]. Note that some
+              <a href="https://www.w3.org/TR/i18n-glossary/#dfn-grapheme" target="_blank">user-perceived characters</a>
+              are composed of more than one Unicode code point. Arbitrary index values might not fall on these grapheme
+              boundaries, so truncation according to <code>maxLength</code> might alter the appearance or meaning of the
+              string.
+            </p>
+          </section>
+          <section>
+            <h3><code>NullSchema</code></h3>
+            <p>
+              Metadata describing data of type <code>null</code>. This subclass is indicated by the value
+              <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. This Subclass
+              describes only one acceptable value, namely <code>null</code>. It is important to note that
+              <code>null</code> does not mean the absence of a value. It is analogous to <code>null</code> in
+              JavaScript, <code>None</code> in Python, <code>null</code> in Java and <code>nil</code> in Ruby
+              programming languages. It can be used as part of a <code>oneOf</code> declaration, where it is used to
+              indicate, that the data can also be <code>null</code>.
+            </p>
+          </section>
         </section>
 
         <section id="sec-security-vocabulary-definition">
@@ -1691,229 +2647,713 @@
           </p>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>SecurityScheme</code></h3><p><p>Metadata describing the configuration of a security
-          mechanism. <span class="rfc2119-assertion" id="td-security-scheme-name">The value assigned to the name
-          <code>scheme</code> MUST be defined within a 
-          <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
-          included in the <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>,
-          either in the standard <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined
-          in <a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD
-          Information Model</a> or in a <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context
-          Extension</a>.</span>
-          </p><p>
-          <span class="rfc2119-assertion" id="td-security-no-secrets">For all security schemes,
-          any keys, passwords, or other sensitive information directly providing access 
-          MUST NOT be stored in the TD and should instead
-          be shared and stored out-of-band via other mechanisms.</span> 
-          The purpose of a TD is to describe how to access a Thing if and only if a Consumer 
-          already has authorization, and is not meant be used to grant that authorization.
-          </p><p>Each security scheme object used in a TD defines a set of requirements to be met before access can be granted.
-          We say a security scheme is <em>satisfied</em> when all its requirements are met.
-          In some cases requirements from multiple security schemes will have to be met before access can be granted.
-          </p><p>
-          Security schemes generally may require additional authentication
-          parameters, such as a password or key.
-          The location of this information is indicated by the
-          value associated with the name <code>in</code>, often in combination with the value associated with <code>name</code>.
-          The value associated with <code>in</code> can take one of the following values:
-          </p>
-          <dl>
-          <dt><code>header</code>:</dt>
-          <dd>The parameter will be given
-            in a header provided by the protocol, with the name of the header
-            provided by the value of <code>name</code>.</dd>
-          <dt><code>query</code>:</dt>
-          <dd>The parameter will be appended to the URI as a query parameter, with the name of the 
-            query parameter provided by <code>name</code>.</dd>
-          <dt><code>body</code>:</dt>
-          <dd>The parameter will be provided in the body of the request payload, with the data schema element  
-            used provided by <code>name</code>.
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer">When used in the context of a 
-            <code>body</code> security information location, the value of <code>name</code> 
-            MUST be in the form of a JSON pointer [[!RFC6901]] relative to 
-            the root of the input <code>DataSchema</code> for each interaction it is used with.</span> 
-            Since this value is not a fragment identifier, and is not relative to the root of the TD but
-            to whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
-            it is a "pure" JSON pointer.
-            Since this value is not a fragment identifier, it also does not
-            need to URL-encode special characters.
-            The targeted element may or may not already exist at the specified location in the referenced object or array schema (consequently the mechanism is not applicable to simple types).
-            If it does not, it will be inserted. This avoids having to duplicate definitions in the data schemas of
-            every interaction.
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-creatable">When an element
-            of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
-            does not already exist in the indicated schema, it MUST
-            be possible to insert the indicated element
-            at the location indicated by the pointer.</span>
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-array">The JSON pointer
-            used in the <code>body</code> locator MAY
-            use the "<code>-</code>" character to indicate a non-existent array element when 
-            it is necessary to insert an element after the last element of an existing array.
-            </span>
-            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-type">The element referenced
-            (or created) by a 
-            <code>body</code> security information location
-            MUST be required and of type "<code>string</code>".</span> 
-            If <code>name</code> is not given, it is assumed the entire body
-            is to be used as the security parameter.
-          </dd>
-          <dt><code>cookie</code>:</dt>
-          <dd>The parameter is stored in a cookie identified by the value of   
-            <code>name</code>.
-          </dd>
-          <dt><code>uri</code>:</dt>
-          <dd>The parameter is embedded in the URI itself, which is encoded in the
-          relevant interaction using a URI template variable defined by the value of <code>name</code>.
-          This is more general than the <code>query</code> mechanism but more complex. 
-          <span class="rfc2119-assertion" id="td-security-in-query-over-uri">The value <code>uri</code> 
-          SHOULD be specified 
-          for the name <code>in</code> in a security scheme only if
-          <code>query</code> is not applicable.</span>  
-          <span class="rfc2119-assertion" id="td-security-in-uri-variable">The URIs provided
-          in interactions where a security scheme using <code>uri</code> as the value for <code>in</code>
-          MUST be a URI template including the defined variable.
-          </span>  
-          </dd>
-          <dt><code>auto</code>:</dt>
-          <dd>The location is determined as part of the protocol, or negotiated. 
-          <span class="rfc2119-assertion" id="td-security-security-vocab-auto-in-no-name">If a value of <code>auto</code> 
-          is set for the <code>in</code> field of a <code>SecurityScheme</code>, 
-          then the <code>name</code> field SHOULD NOT be set.</span> 
-          In this case, the application of the <code>SecurityScheme</code> is subject to 
-          the respective specification for the given protocol (e.g. [[!RFC8288]] when using the 
-          <code>BasicSecurityScheme</code> with HTTP).
-          </dd>
-          </dl>
-          <p>
-          If multiple parameters are needed for a security scheme, repeat the security scheme definition for
-          each parameter and combine them using a <code>combo</code> security scheme and <code>allOf</code>.
-          In some cases parameters may not actually be secret but a user may wish to leave them
-          out of the TD to help protect privacy.  As an example of this, some security mechanisms
-          require both a client identifier and a secret key.  In theory, the client identifier is 
-          public however it may be hard to update and pose a tracking risk.  In such a case it can
-          be provided as an additional security parameter so it does not appear in the TD.
-          </p><p>
-          <span class="rfc2119-assertion" id="td-security-uri-variables-distinct">The names of URI variables 
-          declared in a <code>SecurityScheme</code> 
-          MUST be distinct from all other URI variables 
-          declared in the TD.</span></p><table class="def numbered"><caption>Vocabulary Terms in SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable)
-                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
-                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme"><td><code>proxy</code></td><td>URI of the proxy server this security
-                configuration provides access to. If not given, the
-                corresponding security configuration is for the
-                endpoint.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme"><td><code>scheme</code></td><td>Identification of the security mechanism being
-                configured.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>nosec</code>, <code>combo</code>, <code>basic</code>, <code>digest</code>, <code>bearer</code>, <code>psk</code>, <code>oauth2</code>, <code>apikey</code>, or <code>auto</code>)</td></tr></tbody></table><p>The class <code>SecurityScheme</code> has the following subclasses:</p><ul><li><a href="#nosecurityscheme"><code>NoSecurityScheme</code></a></li>
-<li><a href="#autosecurityscheme"><code>AutoSecurityScheme</code></a></li>
-<li><a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a></li>
-<li><a href="#basicsecurityscheme"><code>BasicSecurityScheme</code></a></li>
-<li><a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a></li>
-<li><a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a></li>
-<li><a href="#bearersecurityscheme"><code>BearerSecurityScheme</code></a></li>
-<li><a href="#psksecurityscheme"><code>PSKSecurityScheme</code></a></li>
-<li><a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a></li></ul></section>
-<section><h3><code>NoSecurityScheme</code></h3><p>A security configuration corresponding to identified
-          by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-          <code>nosec</code> (i.e., <code>"scheme":
-          "nosec"</code>), indicating there is no authentication or
-          other mechanism required to access the resource.</p></section>
-<section><h3><code>AutoSecurityScheme</code></h3><p>An automatic authentication security configuration identified by the term <code>auto</code> (i.e., <code>"scheme": "auto"</code>). This scheme indicates that the security parameters are going to be negotiated by the underlying protocols at runtime, subject to the respective specifications for the protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).</p></section>
-<section><h3><code>ComboSecurityScheme</code></h3><p>A combination of other security schemes identified by the <a>Vocabulary Term</a> <code>combo</code> (i.e., <code>"scheme": "combo"</code>).  Elements of this scheme define various ways in which other named schemes defined in <code>securityDefinitions</code>, including other <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> definitions, are to be combined to create a new scheme definition.  <span class="rfc2119-assertion" id="td-security-combo-exclusive-oneof-or-allof">Exactly one of either <code>oneOf</code> or <code>allOf</code> <i>vocabulary terms</i> MUST be included.</span> <!-- Redundant, table states "two or more" already <scan class="rfc2119-assertion">The array given as a value associated with either <code>oneOf</code> or <code>allOf</code> MUST have at least two elements.</scan> --> Only security scheme definitions which can be used together can be combined with <code>allOf</code>.  For example, it is not possible in general to combine different OAuth 2.0 flows together using <code>allOf</code> unless one applies to a proxy and one to the endpoint.  Note that when multiple named security scheme definitions are listed in a <code>security</code> field the same semantics apply as in an <code>allOf</code> combination (and the same limitations on allowable combinations).  The <code>oneOf</code> combination is equivalent to using different security schemes on forms that are otherwise identical.  In this sense a <code>oneOf</code> scheme is not an essential feature but it does avoid redundancy in such cases.</p><table class="def numbered"><caption>Vocabulary Terms in ComboSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-oneOf--ComboSecurityScheme"><td><code>oneOf</code></td><td>Array of two or more strings identifying other named security scheme definitions, any one of which, when satisfied, will allow access.  Only one may be chosen for use.</td><td>mandatory</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-allOf--ComboSecurityScheme"><td><code>allOf</code></td><td>Array of two or more strings identifying other named security scheme definitions, all of which must be satisfied for access.</td><td>mandatory</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><!-- <p class="ednote" title="Recursive Use">The 
-<a href="#combosecurityscheme">ComboSecurityScheme</a> may be applied recursively to generate Boolean expressions for combinations of security schemes. One use case for this is when multiple security schemes are needed for a proxy in combination with multiple security schemes for an endpoint.  Suppose for example a proxy accepts either schemes A or B, and then the endpoint accepts either C or D.  Then the possible combinations are AC, AD, BC, and BD.  These could be expressed directly at the <code>Form</code> level but would require four-fold redundancy.  Instead, three <code>combo</code> nodes can be used to combine the four leaf schemes in the correct way into a single scheme.  It is not clear however if other use cases exist for deeper expression trees and if not, we may consider limiting the recursion depth to two.</p>--></section>
-<section><h3><code>BasicSecurityScheme</code></h3><p>Basic Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7617" title="The 'Basic' HTTP Authentication Scheme">RFC7617</a></cite>]
-          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>basic</code> (i.e.,
-          <code>"scheme": "basic"</code>), using an unencrypted
-          username and password.</p><table class="def numbered"><caption>Vocabulary Terms in BasicSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr></tbody></table></section>
-<section><h3><code>DigestSecurityScheme</code></h3><p>Digest Access Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication">RFC7616</a></cite>]
-          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>digest</code> (i.e.,
-          <code>"scheme": "digest"</code>). This scheme is similar
-          to basic authentication but with added features to avoid
-          man-in-the-middle attacks.</p><table class="def numbered"><caption>Vocabulary Terms in DigestSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme"><td><code>qop</code></td><td>Quality of protection.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>auth</code>, or <code>auth-int</code>)</td></tr></tbody></table></section>
-<section><h3><code>APIKeySecurityScheme</code></h3><p>API key authentication security configuration
-          identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-          <code>apikey</code> (i.e., <code>"scheme":
-          "apikey"</code>). 
-          This scheme is to be used when the access token is opaque,
-          for example when a key in an unknown or proprietary format is provided by a cloud service provider.
-          In this case the key may not be using a standard token format.
-          This scheme indicates that the key provided by the service provider 
-          needs to be supplied as part 
-          of service requests using the mechanism indicated by the <code>"in"</code> field.</p><table class="def numbered"><caption>Vocabulary Terms in APIKeySecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, <code>uri</code>, or <code>auto</code>)</td></tr></tbody></table></section>
-<section><h3><code>BearerSecurityScheme</code></h3><p>Bearer Token [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6750" title="The OAuth 2.0 Authorization Framework: Bearer Token Usage">RFC6750</a></cite>]
-          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>bearer</code> (i.e.,
-          <code>"scheme": "bearer"</code>) for situations where
-          bearer tokens are used independently of OAuth2. If the
-          <code>oauth2</code> scheme is specified it is not
-          generally necessary to specify this scheme as well as it
-          is implied. For <code>format</code>, the value
-          <code>jwt</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>],
-          <code>jws</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7797" title="JSON Web Signature (JWS) Unencoded Payload Option">RFC7797</a></cite>],
-          <code>cwt</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)">RFC8392</a></cite>], and
-          <code>jwe</code> indicates conformance with
-          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>], with
-          values for <code>alg</code> interpreted consistently with
-          those standards. <span class="rfc2119-assertion" id="td-security-bearer-format-extensions">Other formats and
-          algorithms for bearer tokens MAY be specified in vocabulary
-          extensions</span>.</p><table class="def numbered"><caption>Vocabulary Terms in BearerSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
-               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
-            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme"><td><code>alg</code></td><td>Encoding, encryption, or digest algorithm.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>ES256</code>, or <code>ES512-256</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme"><td><code>format</code></td><td>Specifies format of security authentication
-                 information.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)</td></tr></tbody></table></section>
-<section><h3><code>PSKSecurityScheme</code></h3><p>Pre-shared key authentication security configuration
-          identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-          <code>psk</code> (i.e., <code>"scheme":
-          "psk"</code>).
-          This is meant to identify that a standard is used for pre-shared keys such as TLS-PSK [[RFC4279]], 
-          and that the ciphersuite used for keys will be established during protocol negotiation.</p><table class="def numbered"><caption>Vocabulary Terms in PSKSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-identity--PSKSecurityScheme"><td><code>identity</code></td><td>Identifier providing information which can be
-                   used for selection or confirmation.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>OAuth2SecurityScheme</code></h3><p>OAuth 2.0 authentication security configuration
-            for systems conformant with [[!RFC6749]] and [[!RFC8252]], <!-- and
-            (for the <code>device</code> flow) [[!RFC8628]],--> identified
-            by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e.,
-            <code>"scheme": "oauth2"</code>).</p><table class="def numbered"><caption>Vocabulary Terms in OAuth2SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.<!-- In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]. --></td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme"><td><code>token</code></td><td>URI of the token server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme"><td><code>refresh</code></td><td>URI of the refresh server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided
-                as an array. These are provided in tokens returned
-                by an authorization server and associated with
-                forms in order to identify what resources a client
-                may access and how. The values associated with a
-                form SHOULD be chosen from those defined in an
-                <code>OAuth2SecurityScheme</code> active on that
-                form.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme"><td><code>flow</code></td><td>Authorization flow.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>code</code>, or <code>client</code>)</td></tr></tbody></table><p><span class="rfc2119-assertion" id="td-security-oauth2-code-flow">For
-            the <code>code</code> flow both <code>authorization</code> and <code>token</code> <a>vocabulary terms</a>
-            MUST be included.</span> <span class="rfc2119-assertion" id="td-security-oauth2-client-flow">For
-            the <code>client</code> flow <code>token</code> <a>vocabulary term</a> MUST be included.</span>
-            <span class="rfc2119-assertion" id="td-security-oauth2-client-flow-no-auth">For the
-            <code>client</code> flow <code>authorization</code> <a>vocabulary term</a> MUST NOT be included.</span>
-            <!-- <span class="rfc2119-assertion" id="td-security-oauth2-device-flow">For the
+          <section>
+            <h3><code>SecurityScheme</code></h3>
+            <p></p>
+            <p>
+              Metadata describing the configuration of a security mechanism.
+              <span class="rfc2119-assertion" id="td-security-scheme-name"
+                >The value assigned to the name <code>scheme</code> MUST be defined within a
+                <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
+                included in the
+                <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>, either
+                in the standard
+                <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined in
+                <a href="#sec-vocabulary-definition" class="sec-ref"
+                  >§&nbsp;<bdi class="secno">5.</bdi> TD Information Model</a
+                >
+                or in a
+                <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>.</span
+              >
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-security-no-secrets"
+                >For all security schemes, any keys, passwords, or other sensitive information directly providing access
+                MUST NOT be stored in the TD and should instead be shared and stored out-of-band via other
+                mechanisms.</span
+              >
+              The purpose of a TD is to describe how to access a Thing if and only if a Consumer already has
+              authorization, and is not meant be used to grant that authorization.
+            </p>
+            <p>
+              Each security scheme object used in a TD defines a set of requirements to be met before access can be
+              granted. We say a security scheme is <em>satisfied</em> when all its requirements are met. In some cases
+              requirements from multiple security schemes will have to be met before access can be granted.
+            </p>
+            <p>
+              Security schemes generally may require additional authentication parameters, such as a password or key.
+              The location of this information is indicated by the value associated with the name <code>in</code>, often
+              in combination with the value associated with <code>name</code>. The value associated with
+              <code>in</code> can take one of the following values:
+            </p>
+            <dl>
+              <dt><code>header</code>:</dt>
+              <dd>
+                The parameter will be given in a header provided by the protocol, with the name of the header provided
+                by the value of <code>name</code>.
+              </dd>
+              <dt><code>query</code>:</dt>
+              <dd>
+                The parameter will be appended to the URI as a query parameter, with the name of the query parameter
+                provided by <code>name</code>.
+              </dd>
+              <dt><code>body</code>:</dt>
+              <dd>
+                The parameter will be provided in the body of the request payload, with the data schema element used
+                provided by <code>name</code>.
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer"
+                  >When used in the context of a <code>body</code> security information location, the value of
+                  <code>name</code> MUST be in the form of a JSON pointer [[!RFC6901]] relative to the root of the input
+                  <code>DataSchema</code> for each interaction it is used with.</span
+                >
+                Since this value is not a fragment identifier, and is not relative to the root of the TD but to
+                whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
+                it is a "pure" JSON pointer. Since this value is not a fragment identifier, it also does not need to
+                URL-encode special characters. The targeted element may or may not already exist at the specified
+                location in the referenced object or array schema (consequently the mechanism is not applicable to
+                simple types). If it does not, it will be inserted. This avoids having to duplicate definitions in the
+                data schemas of every interaction.
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-creatable"
+                  >When an element of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
+                  does not already exist in the indicated schema, it MUST be possible to insert the indicated element at
+                  the location indicated by the pointer.</span
+                >
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-array"
+                  >The JSON pointer used in the <code>body</code> locator MAY use the "<code>-</code>" character to
+                  indicate a non-existent array element when it is necessary to insert an element after the last element
+                  of an existing array.
+                </span>
+                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-type"
+                  >The element referenced (or created) by a <code>body</code> security information location MUST be
+                  required and of type "<code>string</code>".</span
+                >
+                If <code>name</code> is not given, it is assumed the entire body is to be used as the security
+                parameter.
+              </dd>
+              <dt><code>cookie</code>:</dt>
+              <dd>The parameter is stored in a cookie identified by the value of <code>name</code>.</dd>
+              <dt><code>uri</code>:</dt>
+              <dd>
+                The parameter is embedded in the URI itself, which is encoded in the relevant interaction using a URI
+                template variable defined by the value of <code>name</code>. This is more general than the
+                <code>query</code> mechanism but more complex.
+                <span class="rfc2119-assertion" id="td-security-in-query-over-uri"
+                  >The value <code>uri</code> SHOULD be specified for the name <code>in</code> in a security scheme only
+                  if <code>query</code> is not applicable.</span
+                >
+                <span class="rfc2119-assertion" id="td-security-in-uri-variable"
+                  >The URIs provided in interactions where a security scheme using <code>uri</code> as the value for
+                  <code>in</code>
+                  MUST be a URI template including the defined variable.
+                </span>
+              </dd>
+              <dt><code>auto</code>:</dt>
+              <dd>
+                The location is determined as part of the protocol, or negotiated.
+                <span class="rfc2119-assertion" id="td-security-security-vocab-auto-in-no-name"
+                  >If a value of <code>auto</code> is set for the <code>in</code> field of a
+                  <code>SecurityScheme</code>, then the <code>name</code> field SHOULD NOT be set.</span
+                >
+                In this case, the application of the <code>SecurityScheme</code> is subject to the respective
+                specification for the given protocol (e.g. [[!RFC8288]] when using the
+                <code>BasicSecurityScheme</code> with HTTP).
+              </dd>
+            </dl>
+            <p>
+              If multiple parameters are needed for a security scheme, repeat the security scheme definition for each
+              parameter and combine them using a <code>combo</code> security scheme and <code>allOf</code>. In some
+              cases parameters may not actually be secret but a user may wish to leave them out of the TD to help
+              protect privacy. As an example of this, some security mechanisms require both a client identifier and a
+              secret key. In theory, the client identifier is public however it may be hard to update and pose a
+              tracking risk. In such a case it can be provided as an additional security parameter so it does not appear
+              in the TD.
+            </p>
+            <p>
+              <span class="rfc2119-assertion" id="td-security-uri-variables-distinct"
+                >The names of URI variables declared in a <code>SecurityScheme</code> MUST be distinct from all other
+                URI variables declared in the TD.</span
+              >
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in SecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme">
+                  <td><code>@type</code></td>
+                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme">
+                  <td><code>description</code></td>
+                  <td>Provides additional (human-readable) information based on a default language.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme">
+                  <td><code>descriptions</code></td>
+                  <td>
+                    Can be used to support (human-readable) information in different languages. Also see
+                    <cite><a href="#multilanguage">MultiLanguage</a></cite
+                    >.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme">
+                  <td><code>proxy</code></td>
+                  <td>
+                    URI of the proxy server this security configuration provides access to. If not given, the
+                    corresponding security configuration is for the endpoint.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme">
+                  <td><code>scheme</code></td>
+                  <td>Identification of the security mechanism being configured.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>nosec</code>, <code>combo</code>, <code>basic</code>, <code>digest</code>,
+                    <code>bearer</code>, <code>psk</code>, <code>oauth2</code>, <code>apikey</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>The class <code>SecurityScheme</code> has the following subclasses:</p>
+            <ul>
+              <li>
+                <a href="#nosecurityscheme"><code>NoSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#autosecurityscheme"><code>AutoSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#basicsecurityscheme"><code>BasicSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#bearersecurityscheme"><code>BearerSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#psksecurityscheme"><code>PSKSecurityScheme</code></a>
+              </li>
+              <li>
+                <a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a>
+              </li>
+            </ul>
+          </section>
+          <section>
+            <h3><code>NoSecurityScheme</code></h3>
+            <p>
+              A security configuration corresponding to identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>nosec</code> (i.e., <code>"scheme": "nosec"</code>), indicating there is no authentication or other
+              mechanism required to access the resource.
+            </p>
+          </section>
+          <section>
+            <h3><code>AutoSecurityScheme</code></h3>
+            <p>
+              An automatic authentication security configuration identified by the term <code>auto</code> (i.e.,
+              <code>"scheme": "auto"</code>). This scheme indicates that the security parameters are going to be
+              negotiated by the underlying protocols at runtime, subject to the respective specifications for the
+              protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).
+            </p>
+          </section>
+          <section>
+            <h3><code>ComboSecurityScheme</code></h3>
+            <p>
+              A combination of other security schemes identified by the <a>Vocabulary Term</a> <code>combo</code> (i.e.,
+              <code>"scheme": "combo"</code>). Elements of this scheme define various ways in which other named schemes
+              defined in <code>securityDefinitions</code>, including other
+              <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> definitions, are to be combined to
+              create a new scheme definition.
+              <span class="rfc2119-assertion" id="td-security-combo-exclusive-oneof-or-allof"
+                >Exactly one of either <code>oneOf</code> or <code>allOf</code> <i>vocabulary terms</i> MUST be
+                included.</span
+              >
+              <!-- Redundant, table states "two or more" already <scan class="rfc2119-assertion">The array given as a value associated with either <code>oneOf</code> or <code>allOf</code> MUST have at least two elements.</scan> -->
+              Only security scheme definitions which can be used together can be combined with <code>allOf</code>. For
+              example, it is not possible in general to combine different OAuth 2.0 flows together using
+              <code>allOf</code> unless one applies to a proxy and one to the endpoint. Note that when multiple named
+              security scheme definitions are listed in a <code>security</code> field the same semantics apply as in an
+              <code>allOf</code> combination (and the same limitations on allowable combinations). The
+              <code>oneOf</code> combination is equivalent to using different security schemes on forms that are
+              otherwise identical. In this sense a <code>oneOf</code> scheme is not an essential feature but it does
+              avoid redundancy in such cases.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ComboSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--ComboSecurityScheme">
+                  <td><code>oneOf</code></td>
+                  <td>
+                    Array of two or more strings identifying other named security scheme definitions, any one of which,
+                    when satisfied, will allow access. Only one may be chosen for use.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-allOf--ComboSecurityScheme">
+                  <td><code>allOf</code></td>
+                  <td>
+                    Array of two or more strings identifying other named security scheme definitions, all of which must
+                    be satisfied for access.
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <!-- <p class="ednote" title="Recursive Use">The 
+<a href="#combosecurityscheme">ComboSecurityScheme</a> may be applied recursively to generate Boolean expressions for combinations of security schemes. One use case for this is when multiple security schemes are needed for a proxy in combination with multiple security schemes for an endpoint.  Suppose for example a proxy accepts either schemes A or B, and then the endpoint accepts either C or D.  Then the possible combinations are AC, AD, BC, and BD.  These could be expressed directly at the <code>Form</code> level but would require four-fold redundancy.  Instead, three <code>combo</code> nodes can be used to combine the four leaf schemes in the correct way into a single scheme.  It is not clear however if other use cases exist for deeper expression trees and if not, we may consider limiting the recursion depth to two.</p>-->
+          </section>
+          <section>
+            <h3><code>BasicSecurityScheme</code></h3>
+            <p>
+              Basic Authentication [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-rfc7617"
+                  title="The 'Basic' HTTP Authentication Scheme"
+                  >RFC7617</a
+                ></cite
+              >] security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>basic</code> (i.e., <code>"scheme": "basic"</code>), using an unencrypted username and password.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in BasicSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>DigestSecurityScheme</code></h3>
+            <p>
+              Digest Access Authentication [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication"
+                  >RFC7616</a
+                ></cite
+              >] security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>digest</code> (i.e., <code>"scheme": "digest"</code>). This scheme is similar to basic
+              authentication but with added features to avoid man-in-the-middle attacks.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in DigestSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme">
+                  <td><code>qop</code></td>
+                  <td>Quality of protection.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>auth</code>, or <code>auth-int</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>APIKeySecurityScheme</code></h3>
+            <p>
+              API key authentication security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>apikey</code> (i.e., <code>"scheme": "apikey"</code>). This scheme is to be used when the access
+              token is opaque, for example when a key in an unknown or proprietary format is provided by a cloud service
+              provider. In this case the key may not be using a standard token format. This scheme indicates that the
+              key provided by the service provider needs to be supplied as part of service requests using the mechanism
+              indicated by the <code>"in"</code> field.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in APIKeySecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>,
+                    <code>uri</code>, or <code>auto</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>BearerSecurityScheme</code></h3>
+            <p>
+              Bearer Token [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-rfc6750"
+                  title="The OAuth 2.0 Authorization Framework: Bearer Token Usage"
+                  >RFC6750</a
+                ></cite
+              >] security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>bearer</code> (i.e., <code>"scheme": "bearer"</code>) for situations where bearer tokens are used
+              independently of OAuth2. If the <code>oauth2</code> scheme is specified it is not generally necessary to
+              specify this scheme as well as it is implied. For <code>format</code>, the value
+              <code>jwt</code> indicates conformance with [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)"
+                  >RFC7519</a
+                ></cite
+              >], <code>jws</code> indicates conformance with [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-rfc7797"
+                  title="JSON Web Signature (JWS) Unencoded Payload Option"
+                  >RFC7797</a
+                ></cite
+              >], <code>cwt</code> indicates conformance with [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)"
+                  >RFC8392</a
+                ></cite
+              >], and <code>jwe</code> indicates conformance with [<cite
+                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)"
+                  >RFC7516</a
+                ></cite
+              >], with values for <code>alg</code> interpreted consistently with those standards.
+              <span class="rfc2119-assertion" id="td-security-bearer-format-extensions"
+                >Other formats and algorithms for bearer tokens MAY be specified in vocabulary extensions</span
+              >.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in BearerSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme">
+                  <td><code>authorization</code></td>
+                  <td>URI of the authorization server.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme">
+                  <td><code>name</code></td>
+                  <td>Name for query, header, cookie, or uri parameters.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme">
+                  <td><code>in</code></td>
+                  <td>Specifies the location of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
+                    <code>auto</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme">
+                  <td><code>alg</code></td>
+                  <td>Encoding, encryption, or digest algorithm.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>ES256</code>, or <code>ES512-256</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme">
+                  <td><code>format</code></td>
+                  <td>Specifies format of security authentication information.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>PSKSecurityScheme</code></h3>
+            <p>
+              Pre-shared key authentication security configuration identified by the
+              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+              <code>psk</code> (i.e., <code>"scheme": "psk"</code>). This is meant to identify that a standard is used
+              for pre-shared keys such as TLS-PSK [[RFC4279]], and that the ciphersuite used for keys will be
+              established during protocol negotiation.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in PSKSecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-identity--PSKSecurityScheme">
+                  <td><code>identity</code></td>
+                  <td>Identifier providing information which can be used for selection or confirmation.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>OAuth2SecurityScheme</code></h3>
+            <p>
+              OAuth 2.0 authentication security configuration for systems conformant with [[!RFC6749]] and [[!RFC8252]],
+              <!-- and
+            (for the <code>device</code> flow) [[!RFC8628]],-->
+              identified by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e., <code>"scheme": "oauth2"</code>).
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in OAuth2SecurityScheme Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme">
+                  <td><code>authorization</code></td>
+                  <td>
+                    URI of the authorization server.<!-- In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]. -->
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme">
+                  <td><code>token</code></td>
+                  <td>URI of the token server.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme">
+                  <td><code>refresh</code></td>
+                  <td>URI of the refresh server.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme">
+                  <td><code>scopes</code></td>
+                  <td>
+                    Set of authorization scope identifiers provided as an array. These are provided in tokens returned
+                    by an authorization server and associated with forms in order to identify what resources a client
+                    may access and how. The values associated with a form SHOULD be chosen from those defined in an
+                    <code>OAuth2SecurityScheme</code> active on that form.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme">
+                  <td><code>flow</code></td>
+                  <td>Authorization flow.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>code</code>, or <code>client</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              <span class="rfc2119-assertion" id="td-security-oauth2-code-flow"
+                >For the <code>code</code> flow both <code>authorization</code> and <code>token</code>
+                <a>vocabulary terms</a> MUST be included.</span
+              >
+              <span class="rfc2119-assertion" id="td-security-oauth2-client-flow"
+                >For the <code>client</code> flow <code>token</code> <a>vocabulary term</a> MUST be included.</span
+              >
+              <span class="rfc2119-assertion" id="td-security-oauth2-client-flow-no-auth"
+                >For the <code>client</code> flow <code>authorization</code> <a>vocabulary term</a> MUST NOT be
+                included.</span
+              >
+              <!-- <span class="rfc2119-assertion" id="td-security-oauth2-device-flow">For the
             <code>device</code> flow both <code>authorization</code> and <code>token</code> <a>vocabulary terms</a>
             MUST be included.</span> In the case of the <code>device</code> flow the value
             provided for <code>authorization</code> <a>vocabulary terms</a> refers to the device authorization endpoint
-            defined in [[!RFC8628]]. --> The mandatory elements for each flow are summarized in the
-            following table:
+            defined in [[!RFC8628]]. -->
+              The mandatory elements for each flow are summarized in the following table:
             </p>
-            <table class="def numbered"> <tr><th>Element</th><th><code>code</code></th><th><code>client</code></th></tr> <tr><td><code>authorization</code></td><td>mandatory</td><td>omit</td><!-- <td>mandatory; refers to device authorization endpoint</td> --></tr> <tr><td><code>token</code></td><td>mandatory</td><td>mandatory</td><!-- <td>mandatory</td> --></tr> <tr><td><code>refresh</code></td><td>optional</td><td>optional</td><!-- <td>optional</td> --></tr> </table>
+            <table class="def numbered">
+              <tr>
+                <th>Element</th>
+                <th><code>code</code></th>
+                <th><code>client</code></th>
+              </tr>
+              <tr>
+                <td><code>authorization</code></td>
+                <td>mandatory</td>
+                <td>omit</td>
+                <!-- <td>mandatory; refers to device authorization endpoint</td> -->
+              </tr>
+              <tr>
+                <td><code>token</code></td>
+                <td>mandatory</td>
+                <td>mandatory</td>
+                <!-- <td>mandatory</td> -->
+              </tr>
+              <tr>
+                <td><code>refresh</code></td>
+                <td>optional</td>
+                <td>optional</td>
+                <!-- <td>optional</td> -->
+              </tr>
+            </table>
             <!-- 
 	    <p class="ednote"> Note that the <code>OAuth2SecurityScheme</code> class definition lists these elements as "optional". 
             In fact whether they are mandatory or not depends on the flow.  The <code>token</code>
@@ -1938,7 +3378,8 @@
             however an alternative design where there is a separate element,
             <code>device_authorization</code>, which MUST be included for the <code>device</code>
             flow (and then the regular authorization endpoint then MUST NOT be used).</p>
-	    --></section>
+	    -->
+          </section>
         </section>
 
         <section id="sec-hypermedia-vocabulary-definition">
@@ -1954,587 +3395,843 @@
           </p>
 
           <!-- rendered from RDF definitions -->
-          <section><h3><code>Link</code></h3><p>A link can be viewed as a statement of the form
-          "<b><em>link context</em></b> has a <b><em>relation
-          type</em></b> resource at <b><em>link target</em></b>",
-          where the optional <b><em>target attributes</em></b> may
-          further describe the resource.</p><table class="def numbered"><caption>Vocabulary Terms in Link Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Link"><td><code>href</code></td><td>Target IRI of a link or submission target of a
-                form.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-type--Link"><td><code>type</code></td><td>Target attribute providing a hint indicating
-                what the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]
-                of the result of dereferencing the link should
-                be.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-rel--Link"><td><code>rel</code></td><td>A link relation type identifies the semantics
-                of a link.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link"><td><code>anchor</code></td><td>Overrides the link context (by default the
-                Thing itself identified by its <code>id</code>)
-                with the given URI or IRI.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link"><td><code>sizes</code></td><td>Target attribute that specifies one or more sizes for the referenced icon. 
-                    Only applicable for relation type "icon". The value pattern follows 
-                    {Height}x{Width} (e.g., "16x16", "16x16 32x32").</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-hreflang--Link"><td><code>hreflang</code></td><td>The hreflang attribute specifies the language of a linked document. The value of this must be a valid language tag [[BCP47]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><p class="note" title="hreflang type">
-        The <code>hreflang</code> attribute is allowed to be a <code>string</code> or <code>array</code> in this version of the spec. Depending on the result of [[LINKSET-MEDIA-TYPES]] the values of <code>hrefLang</code> can be restricted to <code>array</code> only.
-	</p>
-     <p>Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description
-    is an instance of a specific Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended to reuse existing and established 
-    <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
-    </p>
-        <p>In the following a best practice relation type table is introduced that is recommended to use within WoT <a>Thing Description</a>
-    or <a>Thing Model</a> instances.      
-    </p>
-    <table class="def numbered">
-        <caption>Best practice relation type table</caption>
-        <thead>
-            <tr>
-                <th>Value</th>                
-                <th>Occurrence</th>
-                <th>Explanation</th>
-                <th>Source of value origin</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr >
-                <td>
+          <section>
+            <h3><code>Link</code></h3>
+            <p>
+              A link can be viewed as a statement of the form "<b><em>link context</em></b> has a
+              <b><em>relation type</em></b> resource at <b><em>link target</em></b
+              >", where the optional <b><em>target attributes</em></b> may further describe the resource.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in Link Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-href--Link">
+                  <td><code>href</code></td>
+                  <td>Target IRI of a link or submission target of a form.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-type--Link">
+                  <td><code>type</code></td>
+                  <td>
+                    Target attribute providing a hint indicating what the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >] of the result of dereferencing the link should be.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-rel--Link">
+                  <td><code>rel</code></td>
+                  <td>A link relation type identifies the semantics of a link.</td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link">
+                  <td><code>anchor</code></td>
+                  <td>
+                    Overrides the link context (by default the Thing itself identified by its <code>id</code>) with the
+                    given URI or IRI.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link">
+                  <td><code>sizes</code></td>
+                  <td>
+                    Target attribute that specifies one or more sizes for the referenced icon. Only applicable for
+                    relation type "icon". The value pattern follows {Height}x{Width} (e.g., "16x16", "16x16 32x32").
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-hreflang--Link">
+                  <td><code>hreflang</code></td>
+                  <td>
+                    The hreflang attribute specifies the language of a linked document. The value of this must be a
+                    valid language tag [[BCP47]].
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="note" title="hreflang type">
+              The <code>hreflang</code> attribute is allowed to be a <code>string</code> or <code>array</code> in this
+              version of the spec. Depending on the result of [[LINKSET-MEDIA-TYPES]] the values of
+              <code>hrefLang</code> can be restricted to <code>array</code> only.
+            </p>
+            <p>
+              Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a
+              Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description is an instance of a specific
+              Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended
+              to reuse existing and established
+              <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
+            </p>
+            <p>
+              In the following a best practice relation type table is introduced that is recommended to use within WoT
+              <a>Thing Description</a> or <a>Thing Model</a> instances.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Best practice relation type table
+              </caption>
+              <thead>
+                <tr>
+                  <th>Value</th>
+                  <th>Occurrence</th>
+                  <th>Explanation</th>
+                  <th>Source of value origin</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
                     <code>icon</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Imports an icon associated to the <a>Thing</a> (e.g., for UI purposes).</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>Imports an icon associated to the <a>Thing</a> (e.g., for UI purposes).</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>service-doc</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Relation to a resource that provide (human-readable) documentation or descriptions.</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>Relation to a resource that provide (human-readable) documentation or descriptions.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>alternate</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Point to alternative representation of the <a>Thing</a> (i.e. RDF-Turtle, human-readable HTML document, ...).</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Point to alternative representation of the <a>Thing</a> (i.e. RDF-Turtle, human-readable HTML
+                    document, ...).
+                  </td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>type</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Indicate that the <a>Thing</a> is an instance of the target resource such as to a <a>Thing Model</a>.</td>
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>
+                    Indicate that the <a>Thing</a> is an instance of the target resource such as to a
+                    <a>Thing Model</a>.
+                  </td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>tm:extends</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Extends an existing definition of the target resource such as a <a>Thing Model</a>. Only applicable for Thing Model definitions.</td>
-                <td>
-                    W3C WoT Thing Model
-                </td>
-            </tr>
-            <tr >
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>
+                    Extends an existing definition of the target resource such as a <a>Thing Model</a>. Only applicable
+                    for Thing Model definitions.
+                  </td>
+                  <td>W3C WoT Thing Model</td>
+                </tr>
+                <tr>
+                  <td>
                     <code>tm:submodel</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Used to compose one or multiple <a>Thing Models</a>. Only applicable for Thing Model definitions.</td>
-                <td>
-                    W3C WoT Thing Model
-                </td>
-            </tr>                         
-            <tr >
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Used to compose one or multiple <a>Thing Models</a>. Only applicable for Thing Model definitions.
+                  </td>
+                  <td>W3C WoT Thing Model</td>
+                </tr>
+                <tr>
+                  <td>
                     <code>manifest</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Point to the web app manifest of a web application which provides, e.g., a user interface with which a user can interact with the Thing (also see [[APPMANIFEST]]).</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Point to the web app manifest of a web application which provides, e.g., a user interface with which
+                    a user can interact with the Thing (also see [[APPMANIFEST]]).
+                  </td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>proxy-to</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Target resource provide the address of a proxy. Additional security metadata can be provided using the <code>proxy</code> field in a <a href="#securityscheme">SecurityScheme</a>.</td>
-                <td>
-                    W3C WoT Security and WoT Binding Template
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>
+                    Target resource provide the address of a proxy. Additional security metadata can be provided using
+                    the <code>proxy</code> field in a <a href="#securityscheme">SecurityScheme</a>.
+                  </td>
+                  <td>W3C WoT Security and WoT Binding Template</td>
+                </tr>
+                <tr>
+                  <td>
                     <code>collection</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Points to a collections of <a>Things</a>.</td>
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>Points to a collections of <a>Things</a>.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>item</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Points to a <a>Thing</a> that is member of the current <a>Thing</a> collections.</td>
-                <td>
+                  </td>
+                  <td>0..*</td>
+                  <td>Points to a <a>Thing</a> that is member of the current <a>Thing</a> collections.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>predecessor-version</code>
-                </td>
-                <td>
-                    0..1
-                </td>
-                <td>Points to a previous <a>Thing Description</a> or <a>Thing Model</a> version.</td>
-                <td>
+                  </td>
+                  <td>0..1</td>
+                  <td>Points to a previous <a>Thing Description</a> or <a>Thing Model</a> version.</td>
+                  <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                </td>
-            </tr>
-            <tr>
-                <td>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <code>controlledBy</code>
-                </td>
-                <td>
-                    0..*
-                </td>
-                <td>Refers to a <a>Thing</a> that controls the context <a>Thing</a>.</td>
-                <td>
-                    W3C Thing Description
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    </section>
-<section><h3><code>Form</code></h3><p>A form can be viewed as a statement of "To perform an
-          <b><em>operation type</em></b> operation on <b><em>form
-          context</em></b>, make a <b><em>request method</em></b>
-          request to <b><em>submission target</em></b>" where the
-          optional <b><em>form fields</em></b> may further describe
-          the required request. In Thing Descriptions, the
-          <b><em>form context</em></b> is the surrounding Object,
-          such as Properties, Actions, and Events or the Thing
-          itself for meta-interactions.</p><table class="def numbered"><caption>Vocabulary Terms in Form Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Form"><td><code>href</code></td><td>Target IRI of a link or submission target of a
-                form.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form"><td><code>contentType</code></td><td>Assign a content type based on a media type
-                (e.g., <code>text/plain</code>) and potential
-                parameters (e.g., <code>charset=utf-8</code>) for
-                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form"><td><code>contentCoding</code></td><td>Content coding values indicate an encoding
-                transformation that has been or can be applied to a
-                representation. Content codings are primarily used
-                to allow a representation to be compressed or
-                otherwise usefully transformed without losing the
-                identity of its underlying media type and without
-                loss of information. Examples of content coding
-                include "gzip", "deflate", etc. .</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-security--Form"><td><code>security</code></td><td>Set of security definition names, chosen from
-                those defined in <code>securityDefinitions</code>.
-                These must all be satisfied for access to resources.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided
-                as an array. These are provided in tokens returned
-                by an authorization server and associated with
-                forms in order to identify what resources a client
-                may access and how. The values associated with a
-                form SHOULD be chosen from those defined in an
-                <code>OAuth2SecurityScheme</code> active on that
-                form.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-response--Form"><td><code>response</code></td><td>This optional term can be used if, e.g., the
-                output communication metadata differ from input
-                metadata (e.g., output contentType differ from the
-                input contentType). The response name contains
-                metadata that is only valid for the primary response
-                messages.</td><td>optional</td><td><a href="#expectedresponse"><code>ExpectedResponse</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-additionalResponses--Form"><td><code>additionalResponses</code></td><td>This optional term can be used if additional expected responses
-                are possible, e.g. for error reporting.  Each additional response needs to be 
-                distinguished from others in some way (for example, by specifying
-                a protocol-specific error code), and may also have its own data schema.</td><td>optional</td><td><a>Array</a> of <a href="#additionalexpectedresponse"><code>AdditionalExpectedResponse</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form"><td><code>subprotocol</code></td><td>Indicates the exact mechanism by which an
-                interaction will be accomplished for a given
-                protocol when there are multiple options. For
-                example, for HTTP and Events, it indicates which of
-                several available mechanisms should be used for
-                asynchronous notifications such as long polling
-                (<code>longpoll</code>), WebSub [<cite><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite>]
-                (<code>websub</code>), Server-Sent Events
-                (<code>sse</code>) [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite>] (also known as
-                EventSource). Please note that there is no
-                restriction on the subprotocol selection and other
-                mechanisms can also be announced by this
-                subprotocol term.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)</td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-op--Form"><td><code>op</code></td><td>Indicates the semantic intention of performing
-                the operation(s) described by the form. For
-                example, the Property interaction allows get and
-                set operations. The protocol binding may contain a
-                form for the get operation and a different form for
-                the set operation. The op attribute indicates which
-                form is for which and allows the client to select
-                the correct form for the operation required. op can
-                be assigned one or more interaction verb(s) each
-                representing a semantic intention of an
-                operation.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>, <code>unobserveproperty</code>, <code>invokeaction</code>, <code>queryaction</code>, <code>cancelaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>, <code>readallproperties</code>, <code>writeallproperties</code>, <code>readmultipleproperties</code>, <code>writemultipleproperties</code>, <code>observeallproperties</code>, <code>unobserveallproperties</code>, <code>subscribeallevents</code>, <code>unsubscribeallevents</code>, or <code>queryallactions</code>)</td></tr></tbody></table><p>Possible values for the <code>contentCoding</code>
-          property can be found, e.g., in the <a href=
-          "https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
-          IANA HTTP content coding registry</a>.</p>
-          <p>The list of possible operation types of a form is
-          fixed. As of this version of the specification, it only
-          includes the well-known types necessary to implement the
-          WoT interaction model described in [<cite><a class=
-          "bibref" data-link-type="biblio" href=
-          "#bib-wot-architecture11" title=
-          "Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>].
-          Future versions of the standard may extend this list but
-          <span class="rfc2119-assertion" id=
-          "well-known-operation-types-only">operations types
-          MUST be restricted to the values in the
-          table below.</span></p>
-
-        <div id="table-operation-types">
-          <table class="def numbered">
-            <caption>Well-known operation types</caption>
-            <thead>
-              <tr>
-                <th>Operation Type</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>readproperty</td>
-                <td>Identifies the read operation on
-                  Property Affordances to retrieve the
-                  corresponding data.</td>
-              </tr>
-              <tr>
-                <td>writeproperty</td>
-                <td>Identifies the write operation on
-                  Property Affordances to update the
-                  corresponding data.</td>
-              </tr>
-              <tr>
-                <td>observeproperty</td>
-                <td>Identifies the observe operation on
-                  Property Affordances to be notified with
-                  the new data when the Property is
-                  updated.</td>
-              </tr>
-              <tr>
-                <td>unobserveproperty</td>
-                <td>Identifies the unobserve
-                  operation on Property Affordances to stop
-                  the corresponding notifications.</td>
-              </tr>
-              <tr>
-                <td>invokeaction</td>
-                <td>Identifies the invoke operation on
-                  Action Affordances to perform the
-                  corresponding action.</td>
-              </tr>
-              <tr>
-                <td>queryaction</td>
-                <td>Identifies the querying operation on
-                  Action Affordances to get the status of the
-                  corresponding action.</td>
-              </tr>
-              <tr>
-                <td>cancelaction</td>
-                <td>Identifies the cancel operation on
-                  Action Affordances to cancel the ongoing
-                  corresponding action.</td>
-              </tr>
-              <tr>
-                <td>subscribeevent</td>
-                <td>Identifies the subscribe operation
-                  on Event Affordances to be notified by
-                  the Thing when the event occurs.</td>
-              </tr>
-              <tr>
-                <td>unsubscribeevent</td>
-                <td>Identifies the unsubscribe
-                  operation on Event Affordances to stop
-                  the corresponding notifications.</td>
-              </tr>
-              <tr>
-                <td>readallproperties</td>
-                <td>Identifies the readallproperties
-                  operation on a Thing to retrieve the
-                  data of all Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>writeallproperties</td>
-                <td>Identifies the writeallproperties
-                  operation on a Thing to update the
-                  data of all writable Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>readmultipleproperties</td>
-                <td>Identifies the readmultipleproperties
-                  operation on a Thing to retrieve the
-                  data of selected Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>writemultipleproperties</td>
-                <td>Identifies the writemultipleproperties
-                  operation on a Thing to update the
-                  data of selected writable Properties in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>observeallproperties</td>
-                <td>Identifies the observeallproperties operation on
-                  Properties to be notified with new data when any Property is
-                  updated.</td>
-              </tr>
-              <tr>
-                <td>unobserveallproperties</td>
-                <td>Identifies the unobserveallproperties operation on
-                  Properties to stop notifications from all Properties in a 
-                  single interaction.</td>
-              </tr>
-              <tr>
-                <td>queryallactions</td>
-                <td>Identifies the queryallactions operation on a Thing to get the status of
-                 all Actions in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>subscribeallevents</td>
-                <td>Identifies the subscribeallevents operation on Events to subscribe
-                  to notifications from all Events in a single interaction.</td>
-              </tr>
-              <tr>
-                <td>unsubscribeallevents</td>
-                <td>Identifies the unsubscribeallevents operation on Events to unsubscribe
-                  from notifications from all Events in a single interaction.</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <p>
-          A <a>Thing Description</a> of a WoT <a>producer</a> may have multiple forms entries with, e.g., different 
-          protocol and/or content types declarations that a <a>Consumer</a> could possibly support. In that case 
-          the Consumer may choose any form entry that works (e.g., the protocol and content type is supported) for them. 
-          When one form is chosen, it is expected that the <a>Consumer</a> will continue to use it as long as possible 
-          for every new interaction with the WoT <a>producer</a>.
-        </p>
-
-        <section id="sec-op-data-schema-mapping" class="informative">
-        <h4>Mapping op Values to Data Schemas</h4>
-
-        <p>
-            Protocols that can be used with TDs follow request-response or eventing mechanisms. 
-            The Data Schema of an affordance generally correlates with the <code>op</code> keywords used in <code>forms</code>.
-            The table below informatively summarizes the available data schema related terms with the <code>op</code> keywords.
-        </p>
-        <ul>
-            <li>Consumer to Thing applies for messages sent by the Consumer to the Thing, such as the value for writing a property.</li>
-            <li>Thing to Consumer applies for messages sent by the Thing to the Consumer, such as the value of a property value as the result of reading a property.</li>
-            <li>In case that there is no correlation with the data schema and the operation, it implies that no payload is required for executing the operation or no 
-            payload is expected as a result of the operation.</li>
-        </ul>
-
-        <table class="def numbered">
-        <caption>Mapping op Values to Data Schemas</caption>
-        <thead>
-            <tr>
-            <th>Operation Type</th>
-            <th>Consumer to Thing DataSchema Correlation</th>
-            <th>Thing to Consumer DataSchema Correlation</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-            <td>readproperty</td>
-            <td>No correlation.</td>
-            <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
-            </tr>
-            <tr>
-            <td>writeproperty</td>
-            <td>All fields in the Property Affordance without <code>"readOnly":true</code>.</td>
-            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-            </tr>
-            <tr>
-            <td>observeproperty</td>
-            <td>No correlation.</td>
-            <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
-            </tr>
-            <tr>
-            <td>unobserveproperty</td>
-            <td>No correlation.</td>
-            <td>No correlation.</td>
-            </tr>
-            <tr>
-            <td>invokeaction</td>
-            <td>Value of the <code>input</code> key.</td>
-            <td>Value of the <code>output</code> key.</td>
-            </tr>
-            <tr>
-            <td>queryaction</td>
-            <td>No correlation.</td>
-            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-            </tr>
-            <tr>
-            <td>cancelaction</td>
-            <td>No correlation.</td>
-            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-            </tr>
-            <tr>
-            <td>subscribeevent</td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code></td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code></td>
-            </tr>
-            <tr>
-            <td>unsubscribeevent</td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code></td>
-            <td>Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code></td>
-            </tr>
-        </tbody>
-        </table>
-        <p class="note" title="writeproperty and observeproperty relationship">
-            Writing to a property does not necessarily mean that a new value will be sent to the Consumer observing the property. 
-            It depends on the protocol and implementation.
-        </p>
-        <p class="note" title="Further Data Schemas mappings">
-            Further specification of how to map operations to data schemas, as well as mapping meta operations such as <code>readallproperties</code> 
-            can be found in the respective protocol specification of the [[WOT-BINDING-TEMPLATES]].
-        </p>
-        </section>
-
-        <section id="sec-response-usage">
-        <h4>Response-related Terms Usage</h4>
-
-          <p>The optional <code>response</code> name-value pair can
-          be used to provide metadata for the expected response
-          message. 
-          With the core vocabulary, it only includes
-          content type information, but TD Context Extensions could
-          be applied. <span class="rfc2119-assertion" id=
-          "td-expectedResponse-default-contentType">If no
-          <code>response</code> name-value pair is provided, it
-          MUST be assumed
-          that the content type of the response is equal to the
-          content type assigned to the Form instance.</span> Note
-          that <code>contentType</code> within an
-          <code>ExpectedResponse</code> 
-          <a href="#dfn-class" class=
-          "internalDFN" data-link-type="dfn">Class</a> does not
-          have a <a href="#dfn-default-value" class="internalDFN"
-          data-link-type="dfn">Default Value</a>. For instance, if
-          the value of the content type of the form is
-          <code>application/xml</code> the assumed value of the
-          content type of the response will be also
-          <code>application/xml</code>.</p>
-          <p>
-          In some cases additional responses might be possible.
-          One example of this is error responses but in some cases
-          there might also be additional successful responses.
-          In this case, the <code>response</code> name-value pair
-          is still used for the primary response but 
-          <code>additionalResponses</code> may also be provided,
-          whose value is an array of <code>AdditionalExpectedResponse</code>
-          objects.
-          Each additional response must be distinguished in some way from the primary
-          response, either by <code>contentType</code> or by
-          protocol-specific settings such as error code header values.
-          Each additional response may also have a data schema
-          which can differ from the normal output data schema for the
-          interaction.  
-          </p>
-          <p>In some use cases, input and output data might be
-          represented in a different form, for instance an Action
-          that accepts JSON, but returns an image. In such a case,
-          the optional <code>response</code> name-value pair can
-          describe the content type of the expected response.
-          <span class="rfc2119-assertion" id=
-          "td-expectedResponse-contentType">If the content type of
-          the expected response differs from the content type of
-          the form, the <code>Form</code> instance <em class=
-          "rfc2119" title="MUST">MUST</em> include a name-value
-          pair with the name <code>response</code>.</span> 
-          For instance, an <code>ActionAffordance</code> could only
-          accept <code>application/json</code> for its input data,
-          while it will respond with an <code>image/jpeg</code>
-          content type for its output data. In that case the
-          content types differ and the <code>response</code>
-          name-value pair has to be used to provide response
-          content type (<code>image/jpeg</code>) information to the
-          <a href="#dfn-consumer" class="internalDFN"
-          data-link-type="dfn">Consumer</a>.</p>
-          <p>
-          Similar considerations apply to additional responses,
-          although in this case the <code>contentType</code> is optional
-          if it is the same as the input content Type (e.g. JSON).
-          <span class="rfc2119-assertion" id=
-          "td-additionalExpectedResponse-contentType">If the content type of
-          an additional expected response differs from the content type of
-          the form, the <code>Form</code> instance <em class=
-          "rfc2119" title="MUST">MUST</em> include an entry in the array
-          associated with the name <code>additionalResponses</code>
-          that includes a value for the name <code>contentType</code>.</span> 
-          <span class="rfc2119-assertion" id=
-          "td-additionalExpectedResponse-schema">If the data schema of
-          an additional expected response differs from the output data schema of
-          the interaction, the <code>Form</code> instance <em class=
-          "rfc2119" title="MUST">MUST</em> include an entry in the array
-          associated with the name <code>additionalResponses</code> that
-          includes a value for the name <code>schema</code>.</span> 
-          </p>
-          <p>
-            The different cases on the variation of request and response are explained above.
-            The tables at <a href="#contentType-usage"></a> summarize these cases in a concise manner.
-          </p>
+                  </td>
+                  <td>0..*</td>
+                  <td>Refers to a <a>Thing</a> that controls the context <a>Thing</a>.</td>
+                  <td>W3C Thing Description</td>
+                </tr>
+              </tbody>
+            </table>
           </section>
+          <section>
+            <h3><code>Form</code></h3>
+            <p>
+              A form can be viewed as a statement of "To perform an <b><em>operation type</em></b> operation on
+              <b><em>form context</em></b
+              >, make a <b><em>request method</em></b> request to <b><em>submission target</em></b
+              >" where the optional <b><em>form fields</em></b> may further describe the required request. In Thing
+              Descriptions, the <b><em>form context</em></b> is the surrounding Object, such as Properties, Actions, and
+              Events or the Thing itself for meta-interactions.
+            </p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in Form Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-href--Form">
+                  <td><code>href</code></td>
+                  <td>Target IRI of a link or submission target of a form.</td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form">
+                  <td><code>contentType</code></td>
+                  <td>
+                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
+                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >].
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form">
+                  <td><code>contentCoding</code></td>
+                  <td>
+                    Content coding values indicate an encoding transformation that has been or can be applied to a
+                    representation. Content codings are primarily used to allow a representation to be compressed or
+                    otherwise usefully transformed without losing the identity of its underlying media type and without
+                    loss of information. Examples of content coding include "gzip", "deflate", etc. .
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-security--Form">
+                  <td><code>security</code></td>
+                  <td>
+                    Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.
+                    These must all be satisfied for access to resources.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form">
+                  <td><code>scopes</code></td>
+                  <td>
+                    Set of authorization scope identifiers provided as an array. These are provided in tokens returned
+                    by an authorization server and associated with forms in order to identify what resources a client
+                    may access and how. The values associated with a form SHOULD be chosen from those defined in an
+                    <code>OAuth2SecurityScheme</code> active on that form.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-response--Form">
+                  <td><code>response</code></td>
+                  <td>
+                    This optional term can be used if, e.g., the output communication metadata differ from input
+                    metadata (e.g., output contentType differ from the input contentType). The response name contains
+                    metadata that is only valid for the primary response messages.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="#expectedresponse"><code>ExpectedResponse</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-additionalResponses--Form">
+                  <td><code>additionalResponses</code></td>
+                  <td>
+                    This optional term can be used if additional expected responses are possible, e.g. for error
+                    reporting. Each additional response needs to be distinguished from others in some way (for example,
+                    by specifying a protocol-specific error code), and may also have its own data schema.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a>Array</a> of <a href="#additionalexpectedresponse"><code>AdditionalExpectedResponse</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form">
+                  <td><code>subprotocol</code></td>
+                  <td>
+                    Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when
+                    there are multiple options. For example, for HTTP and Events, it indicates which of several
+                    available mechanisms should be used for asynchronous notifications such as long polling
+                    (<code>longpoll</code>), WebSub [<cite
+                      ><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite
+                    >] (<code>websub</code>), Server-Sent Events (<code>sse</code>) [<cite
+                      ><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite
+                    >] (also known as EventSource). Please note that there is no restriction on the subprotocol
+                    selection and other mechanisms can also be announced by this subprotocol term.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                    (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-op--Form">
+                  <td><code>op</code></td>
+                  <td>
+                    Indicates the semantic intention of performing the operation(s) described by the form. For example,
+                    the Property interaction allows get and set operations. The protocol binding may contain a form for
+                    the get operation and a different form for the set operation. The op attribute indicates which form
+                    is for which and allows the client to select the correct form for the operation required. op can be
+                    assigned one or more interaction verb(s) each representing a semantic intention of an operation.
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
+                    <a>Array</a> of
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
+                    of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>,
+                    <code>unobserveproperty</code>, <code>invokeaction</code>, <code>queryaction</code>,
+                    <code>cancelaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>,
+                    <code>readallproperties</code>, <code>writeallproperties</code>,
+                    <code>readmultipleproperties</code>, <code>writemultipleproperties</code>,
+                    <code>observeallproperties</code>, <code>unobserveallproperties</code>,
+                    <code>subscribeallevents</code>, <code>unsubscribeallevents</code>, or <code>queryallactions</code>)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p>
+              Possible values for the <code>contentCoding</code> property can be found, e.g., in the
+              <a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
+                IANA HTTP content coding registry</a
+              >.
+            </p>
+            <p>
+              The list of possible operation types of a form is fixed. As of this version of the specification, it only
+              includes the well-known types necessary to implement the WoT interaction model described in [<cite
+                ><a
+                  class="bibref"
+                  data-link-type="biblio"
+                  href="#bib-wot-architecture11"
+                  title="Web of Things (WoT) Architecture 1.1"
+                  >wot-architecture11</a
+                ></cite
+              >]. Future versions of the standard may extend this list but
+              <span class="rfc2119-assertion" id="well-known-operation-types-only"
+                >operations types MUST be restricted to the values in the table below.</span
+              >
+            </p>
+
+            <div id="table-operation-types">
+              <table class="def numbered">
+                <caption>
+                  Well-known operation types
+                </caption>
+                <thead>
+                  <tr>
+                    <th>Operation Type</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>readproperty</td>
+                    <td>Identifies the read operation on Property Affordances to retrieve the corresponding data.</td>
+                  </tr>
+                  <tr>
+                    <td>writeproperty</td>
+                    <td>Identifies the write operation on Property Affordances to update the corresponding data.</td>
+                  </tr>
+                  <tr>
+                    <td>observeproperty</td>
+                    <td>
+                      Identifies the observe operation on Property Affordances to be notified with the new data when the
+                      Property is updated.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unobserveproperty</td>
+                    <td>
+                      Identifies the unobserve operation on Property Affordances to stop the corresponding
+                      notifications.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>invokeaction</td>
+                    <td>Identifies the invoke operation on Action Affordances to perform the corresponding action.</td>
+                  </tr>
+                  <tr>
+                    <td>queryaction</td>
+                    <td>
+                      Identifies the querying operation on Action Affordances to get the status of the corresponding
+                      action.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>cancelaction</td>
+                    <td>
+                      Identifies the cancel operation on Action Affordances to cancel the ongoing corresponding action.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>subscribeevent</td>
+                    <td>
+                      Identifies the subscribe operation on Event Affordances to be notified by the Thing when the event
+                      occurs.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unsubscribeevent</td>
+                    <td>
+                      Identifies the unsubscribe operation on Event Affordances to stop the corresponding notifications.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>readallproperties</td>
+                    <td>
+                      Identifies the readallproperties operation on a Thing to retrieve the data of all Properties in a
+                      single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>writeallproperties</td>
+                    <td>
+                      Identifies the writeallproperties operation on a Thing to update the data of all writable
+                      Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>readmultipleproperties</td>
+                    <td>
+                      Identifies the readmultipleproperties operation on a Thing to retrieve the data of selected
+                      Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>writemultipleproperties</td>
+                    <td>
+                      Identifies the writemultipleproperties operation on a Thing to update the data of selected
+                      writable Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>observeallproperties</td>
+                    <td>
+                      Identifies the observeallproperties operation on Properties to be notified with new data when any
+                      Property is updated.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unobserveallproperties</td>
+                    <td>
+                      Identifies the unobserveallproperties operation on Properties to stop notifications from all
+                      Properties in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>queryallactions</td>
+                    <td>
+                      Identifies the queryallactions operation on a Thing to get the status of all Actions in a single
+                      interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>subscribeallevents</td>
+                    <td>
+                      Identifies the subscribeallevents operation on Events to subscribe to notifications from all
+                      Events in a single interaction.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unsubscribeallevents</td>
+                    <td>
+                      Identifies the unsubscribeallevents operation on Events to unsubscribe from notifications from all
+                      Events in a single interaction.
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <p>
+              A <a>Thing Description</a> of a WoT <a>producer</a> may have multiple forms entries with, e.g., different
+              protocol and/or content types declarations that a <a>Consumer</a> could possibly support. In that case the
+              Consumer may choose any form entry that works (e.g., the protocol and content type is supported) for them.
+              When one form is chosen, it is expected that the <a>Consumer</a> will continue to use it as long as
+              possible for every new interaction with the WoT <a>producer</a>.
+            </p>
+
+            <section id="sec-op-data-schema-mapping" class="informative">
+              <h4>Mapping op Values to Data Schemas</h4>
+
+              <p>
+                Protocols that can be used with TDs follow request-response or eventing mechanisms. The Data Schema of
+                an affordance generally correlates with the <code>op</code> keywords used in <code>forms</code>. The
+                table below informatively summarizes the available data schema related terms with the
+                <code>op</code> keywords.
+              </p>
+              <ul>
+                <li>
+                  Consumer to Thing applies for messages sent by the Consumer to the Thing, such as the value for
+                  writing a property.
+                </li>
+                <li>
+                  Thing to Consumer applies for messages sent by the Thing to the Consumer, such as the value of a
+                  property value as the result of reading a property.
+                </li>
+                <li>
+                  In case that there is no correlation with the data schema and the operation, it implies that no
+                  payload is required for executing the operation or no payload is expected as a result of the
+                  operation.
+                </li>
+              </ul>
+
+              <table class="def numbered">
+                <caption>
+                  Mapping op Values to Data Schemas
+                </caption>
+                <thead>
+                  <tr>
+                    <th>Operation Type</th>
+                    <th>Consumer to Thing DataSchema Correlation</th>
+                    <th>Thing to Consumer DataSchema Correlation</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>readproperty</td>
+                    <td>No correlation.</td>
+                    <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
+                  </tr>
+                  <tr>
+                    <td>writeproperty</td>
+                    <td>All fields in the Property Affordance without <code>"readOnly":true</code>.</td>
+                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+                  </tr>
+                  <tr>
+                    <td>observeproperty</td>
+                    <td>No correlation.</td>
+                    <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
+                  </tr>
+                  <tr>
+                    <td>unobserveproperty</td>
+                    <td>No correlation.</td>
+                    <td>No correlation.</td>
+                  </tr>
+                  <tr>
+                    <td>invokeaction</td>
+                    <td>Value of the <code>input</code> key.</td>
+                    <td>Value of the <code>output</code> key.</td>
+                  </tr>
+                  <tr>
+                    <td>queryaction</td>
+                    <td>No correlation.</td>
+                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+                  </tr>
+                  <tr>
+                    <td>cancelaction</td>
+                    <td>No correlation.</td>
+                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+                  </tr>
+                  <tr>
+                    <td>subscribeevent</td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code>
+                    </td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>unsubscribeevent</td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code>
+                    </td>
+                    <td>
+                      Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <p class="note" title="writeproperty and observeproperty relationship">
+                Writing to a property does not necessarily mean that a new value will be sent to the Consumer observing
+                the property. It depends on the protocol and implementation.
+              </p>
+              <p class="note" title="Further Data Schemas mappings">
+                Further specification of how to map operations to data schemas, as well as mapping meta operations such
+                as <code>readallproperties</code>
+                can be found in the respective protocol specification of the [[WOT-BINDING-TEMPLATES]].
+              </p>
+            </section>
+
+            <section id="sec-response-usage">
+              <h4>Response-related Terms Usage</h4>
+
+              <p>
+                The optional <code>response</code> name-value pair can be used to provide metadata for the expected
+                response message. With the core vocabulary, it only includes content type information, but TD Context
+                Extensions could be applied.
+                <span class="rfc2119-assertion" id="td-expectedResponse-default-contentType"
+                  >If no <code>response</code> name-value pair is provided, it MUST be assumed that the content type of
+                  the response is equal to the content type assigned to the Form instance.</span
+                >
+                Note that <code>contentType</code> within an
+                <code>ExpectedResponse</code>
+                <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> does not have a
+                <a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">Default Value</a>. For instance,
+                if the value of the content type of the form is <code>application/xml</code> the assumed value of the
+                content type of the response will be also <code>application/xml</code>.
+              </p>
+              <p>
+                In some cases additional responses might be possible. One example of this is error responses but in some
+                cases there might also be additional successful responses. In this case, the
+                <code>response</code> name-value pair is still used for the primary response but
+                <code>additionalResponses</code> may also be provided, whose value is an array of
+                <code>AdditionalExpectedResponse</code> objects. Each additional response must be distinguished in some
+                way from the primary response, either by <code>contentType</code> or by protocol-specific settings such
+                as error code header values. Each additional response may also have a data schema which can differ from
+                the normal output data schema for the interaction.
+              </p>
+              <p>
+                In some use cases, input and output data might be represented in a different form, for instance an
+                Action that accepts JSON, but returns an image. In such a case, the optional
+                <code>response</code> name-value pair can describe the content type of the expected response.
+                <span class="rfc2119-assertion" id="td-expectedResponse-contentType"
+                  >If the content type of the expected response differs from the content type of the form, the
+                  <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include a name-value pair with
+                  the name <code>response</code>.</span
+                >
+                For instance, an <code>ActionAffordance</code> could only accept <code>application/json</code> for its
+                input data, while it will respond with an <code>image/jpeg</code> content type for its output data. In
+                that case the content types differ and the <code>response</code>
+                name-value pair has to be used to provide response content type (<code>image/jpeg</code>) information to
+                the
+                <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumer</a>.
+              </p>
+              <p>
+                Similar considerations apply to additional responses, although in this case the
+                <code>contentType</code> is optional if it is the same as the input content Type (e.g. JSON).
+                <span class="rfc2119-assertion" id="td-additionalExpectedResponse-contentType"
+                  >If the content type of an additional expected response differs from the content type of the form, the
+                  <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include an entry in the array
+                  associated with the name <code>additionalResponses</code> that includes a value for the name
+                  <code>contentType</code>.</span
+                >
+                <span class="rfc2119-assertion" id="td-additionalExpectedResponse-schema"
+                  >If the data schema of an additional expected response differs from the output data schema of the
+                  interaction, the <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include an
+                  entry in the array associated with the name <code>additionalResponses</code> that includes a value for
+                  the name <code>schema</code>.</span
+                >
+              </p>
+              <p>
+                The different cases on the variation of request and response are explained above. The tables at
+                <a href="#contentType-usage"></a> summarize these cases in a concise manner.
+              </p>
+            </section>
           </section>
-<section><h3><code>ExpectedResponse</code></h3><p>Communication metadata describing the expected
-          response message for the primary response.</p><table class="def numbered"><caption>Vocabulary Terms in ExpectedResponse Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type
-                (e.g., <code>text/plain</code>) and potential
-                parameters (e.g., <code>charset=utf-8</code>) for
-                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
-<section><h3><code>AdditionalExpectedResponse</code></h3><p>Communication metadata describing the expected
-          response message for additional responses.</p><table class="def numbered"><caption>Vocabulary Terms in AdditionalExpectedResponse Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-success--AdditionalExpectedResponse"><td><code>success</code></td><td>Signals if an additional response should not be considered an error.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-contentType--AdditionalExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type
-                (e.g., <code>text/plain</code>) and potential
-                parameters (e.g., <code>charset=utf-8</code>) for
-                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
-<tr class="rfc2119-table-assertion" id="td-vocab-schema--AdditionalExpectedResponse"><td><code>schema</code></td><td>Used to define the output data schema 
-                for an additional response if it differs from the default
-                output data schema. 
-                Rather than a <code>DataSchema</code> object, the
-                name of a previous definition given in a 
-                <code>schemaDefinitions</code> map must be used.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+          <section>
+            <h3><code>ExpectedResponse</code></h3>
+            <p>Communication metadata describing the expected response message for the primary response.</p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in ExpectedResponse Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse">
+                  <td><code>contentType</code></td>
+                  <td>
+                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
+                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >].
+                  </td>
+                  <td>mandatory</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h3><code>AdditionalExpectedResponse</code></h3>
+            <p>Communication metadata describing the expected response message for additional responses.</p>
+            <table class="def numbered">
+              <caption>
+                Vocabulary Terms in AdditionalExpectedResponse Level
+              </caption>
+              <thead>
+                <tr>
+                  <th><a>Vocabulary term</a></th>
+                  <th>Description</th>
+                  <th>Assignment</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="rfc2119-table-assertion" id="td-vocab-success--AdditionalExpectedResponse">
+                  <td><code>success</code></td>
+                  <td>Signals if an additional response should not be considered an error.</td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--AdditionalExpectedResponse">
+                  <td><code>contentType</code></td>
+                  <td>
+                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
+                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
+                      ><a
+                        class="bibref"
+                        data-link-type="biblio"
+                        href="#bib-rfc2046"
+                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
+                        >RFC2046</a
+                      ></cite
+                    >].
+                  </td>
+                  <td><a href="#sec-default-values">with default</a></td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+                <tr class="rfc2119-table-assertion" id="td-vocab-schema--AdditionalExpectedResponse">
+                  <td><code>schema</code></td>
+                  <td>
+                    Used to define the output data schema for an additional response if it differs from the default
+                    output data schema. Rather than a <code>DataSchema</code> object, the name of a previous definition
+                    given in a <code>schemaDefinitions</code> map must be used.
+                  </td>
+                  <td>optional</td>
+                  <td>
+                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
         </section>
       </section>
       <section id="sec-default-values">

--- a/index.html
+++ b/index.html
@@ -150,6 +150,14 @@
             publisher: "W3C",
             date: "July 2021"
           },
+          "WOT-BINDINGS-REGISTRY": {
+            title: "Web of Things (WoT) Bindings Registry",
+            //, href: "https://www.w3.org/TR/wot-bindings-registry/"
+            href: "https://w3c.github.io/wot-bindings-registry/",
+            authors: ["TODO"], //TODO: sync authors
+            publisher: "W3C",
+            date: "TODO" //TODO: Add publication date
+          },
           "MQTT": {
             title: "MQTT Version 3.1.1",
             href: "http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html",
@@ -778,11 +786,10 @@
           <code>href</code> is defined within the Forms level. Even if not defined, other levels can be used such as
           Links level.
         </dd>
-        <dt><dfn id="dfn-subspecification">Binding Template Subspecification</dfn>, <dfn>subspecification</dfn></dt>
+        <dt><dfn id="dfn-binding-specification">Binding Specification</dfn></dt>
         <dd>
-          A binding template document that is published separately from this document that specifies a binding template
-          for a protocol, payload format or platform. All binding template subspecifications respect the rules set in
-          the <a href="binding-templates">Binding Templates</a> section.
+          A binding specification is a document that specifies a binding
+          for a protocol or payload format or both. All bindings follow the rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
         </dd>
       </dl>
 
@@ -1123,862 +1130,363 @@
           <h2>Core Vocabulary Definitions</h2>
 
           <!-- rendered from RDF definitions -->
-          <section>
-            <h3><code>Thing</code></h3>
-            <p>
-              An abstraction of a physical or a virtual entity whose metadata and interfaces are described by a WoT
-              Thing Description, whereas a virtual entity is the composition of one or more Things.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in Thing Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing">
-                  <td><code>@context</code></td>
-                  <td>
-                    JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or
-                    <a>Array</a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing">
-                  <td><code>@type</code></td>
-                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-id--Thing">
-                  <td><code>id</code></td>
-                  <td>
-                    Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI,
-                    URI with local IP address, URN, etc.).
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-title--Thing">
-                  <td><code>title</code></td>
-                  <td>
-                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
-                    language.
-                  </td>
-                  <td>mandatory</td>
-                  <td>any type</td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing">
-                  <td><code>titles</code></td>
-                  <td>
-                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
-                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-description--Thing">
-                  <td><code>description</code></td>
-                  <td>Provides additional (human-readable) information based on a default language.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing">
-                  <td><code>descriptions</code></td>
-                  <td>
-                    Can be used to support (human-readable) information in different languages. Also see
-                    <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-version--Thing">
-                  <td><code>version</code></td>
-                  <td>Provides version information.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#versioninfo"><code>VersionInfo</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-created--Thing">
-                  <td><code>created</code></td>
-                  <td>Provides information when the TD instance was created.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing">
-                  <td><code>modified</code></td>
-                  <td>Provides information when the TD instance was last modified.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-support--Thing">
-                  <td><code>support</code></td>
-                  <td>
-                    Provides information about the TD maintainer as URI scheme (e.g., <code>mailto</code> [[RFC6068]],
-                    <code>tel</code> [[RFC3966]], <code>https</code> [[RFC9112]]).
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-base--Thing">
-                  <td><code>base</code></td>
-                  <td>
-                    Define the base URI that is used for all relative URI references throughout a TD document. In TD
-                    instances, all relative URIs are resolved relative to the base URI using the algorithm defined in
-                    [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-rfc3986"
-                        title="Uniform Resource Identifier (URI): Generic Syntax"
-                        >RFC3986</a
-                      ></cite
-                    >].<br />
-                    <br />
-                    <code>base</code> does not affect the URIs used in <code>@context</code> and the IRIs used within
-                    Linked Data [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-linked-data"
-                        title="Linked Data Design Issues"
-                        >LINKED-DATA</a
-                      ></cite
-                    >] graphs that are relevant when semantic processing is applied to TD instances.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing">
-                  <td><code>properties</code></td>
-                  <td>
-                    All Property-based
-                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
-                      >Interaction Affordances</a
-                    >
-                    of the Thing.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#propertyaffordance"><code>PropertyAffordance</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing">
-                  <td><code>actions</code></td>
-                  <td>
-                    All Action-based
-                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
-                      >Interaction Affordances</a
-                    >
-                    of the Thing.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#actionaffordance"><code>ActionAffordance</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-events--Thing">
-                  <td><code>events</code></td>
-                  <td>
-                    All Event-based
-                    <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"
-                      >Interaction Affordances</a
-                    >
-                    of the Thing.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#eventaffordance"><code>EventAffordance</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-links--Thing">
-                  <td><code>links</code></td>
-                  <td>Provides Web links to arbitrary resources that relate to the specified Thing Description.</td>
-                  <td>optional</td>
-                  <td>
-                    <a>Array</a> of <a href="#link"><code>Link</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing">
-                  <td><code>forms</code></td>
-                  <td>
-                    Set of form hypermedia controls that describe how an operation can be performed. Forms are
-                    serializations of Protocol Bindings. <a>Thing level</a> forms are used to describe endpoints for a
-                    group of interaction affordances.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Array</a> of <a href="#form"><code>Form</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-security--Thing">
-                  <td><code>security</code></td>
-                  <td>
-                    Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.
-                    These must all be satisfied for access to resources.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing">
-                  <td><code>securityDefinitions</code></td>
-                  <td>
-                    Set of named security configurations (definitions only). Not actually applied unless names are used
-                    in a <code>security</code> name-value pair.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a>Map</a> of <a href="#securityscheme"><code>SecurityScheme</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-profile--Thing">
-                  <td><code>profile</code></td>
-                  <td>
-                    Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing
-                    implementation.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-schemaDefinitions--Thing">
-                  <td><code>schemaDefinitions</code></td>
-                  <td>
-                    Set of named data schemas. To be used in a <code>schema</code>
-                    name-value pair inside an
-                    <code>AdditionalExpectedResponse</code> object.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing">
-                  <td><code>uriVariables</code></td>
-                  <td>
-                    Define URI template variables according to [[RFC6570]] as collection based on DataSchema
-                    declarations. The <a>Thing level</a> <code>uriVariables</code> can be used in <a>Thing level</a>
-                    <code>forms</code> or in Interaction Affordances. The individual variables DataSchema cannot be an
-                    ObjectSchema or an ArraySchema since each variable needs to be serialized to a string inside the
-                    <code>href</code> upon the execution of the operation. If the same variable is both declared in
-                    <a>Thing level</a> <code>uriVariables</code> and in Interaction Affordance level, the Interaction
-                    Affordance level variable takes precedence.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:</p>
-            <ul>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-ns-thing-mandatory">
-                  The <code>@context</code>
-                  name-value pair MUST contain the anyURI
-                  <code>https://www.w3.org/2022/wot/td/v1.1</code>
-                  in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly
-                  introduced terms.
-                </span>
-              </li>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-ns-td10-namespace">
-                  When there are possibly TD 1.0 consumers the anyURI
-                  <code>https://www.w3.org/2019/wot/td/v1</code>
-                  MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second
-                  entry.</span
-                >
-              </li>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-ns-td10-namespacev10">
-                  TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0
-                  [[wot-thing-description10]] specification.
-                </span>
-              </li>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-ns-thing-optional"
-                  >When <code>@context</code> is an
-                  <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>, the anyURI
-                  <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class="rfc2119" title="MAY">MAY</em> be followed
-                  by elements of type <code>anyURI</code> or type
-                  <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> in any order, while it is
-                  RECOMMENDED to include only one
-                  <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> with all the name-value pairs in
-                  the <code>@context</code>
-                  <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span
-                >
-              </li>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-ns-thing-map-of-namespaces"
-                  ><a href="#dfn-map" class="internalDFN" data-link-type="dfn">Maps</a> contained in an
-                  <code>@context</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> MAY
-                  contain name-value pairs, where the value is a namespace identifier of type <code>anyURI</code> and
-                  the name a <a href="#dfn-term" class="internalDFN" data-link-type="dfn">Term</a> or prefix denoting
-                  that namespace.</span
-                >
-              </li>
-              <li>
-                <span class="rfc2119-assertion" id="td-context-default-language"
-                  >One <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> contained in an
-                  <code>@context</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> SHOULD
-                  contain a name-value pair that defines the default language for the Thing Description, where the name
-                  is the <a href="#dfn-term" class="internalDFN" data-link-type="dfn">Term</a>
-                  <code>@language</code> and the value is a well-formed language tag as defined by [<cite
-                    ><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages"
-                      >BCP47</a
-                    ></cite
-                  >] (e.g., <code>en</code>, <code>de-AT</code>, <code>gsw-CH</code>, <code>zh-Hans</code>,
-                  <code>zh-Hant-HK</code>, <code>sl-nedis</code>).</span
-                >
-              </li>
-            </ul>
+          <section><h3><code>Thing</code></h3><p>An abstraction of a physical or a virtual entity whose
+          metadata and interfaces are described by a WoT Thing
+          Description, whereas a virtual entity is the composition
+          of one or more Things.</p><table class="def numbered"><caption>Vocabulary Terms in Thing Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-context--Thing"><td><code>@context</code></td><td>JSON-LD keyword to define short-hand names called terms that are used throughout a TD document.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-id--Thing"><td><code>id</code></td><td>Identifier of the Thing in form of a URI [[RFC3986]] (e.g., stable URI, temporary and mutable URI, URI with local IP address, URN, etc.).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--Thing"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
+                a text for UI representation) based on a default
+                language.</td><td>mandatory</td><td>any type</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing"><td><code>titles</code></td><td>Provides multi-language human-readable titles
+                (e.g., display a text for UI representation in
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-description--Thing"><td><code>description</code></td><td>Provides additional (human-readable)
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-version--Thing"><td><code>version</code></td><td>Provides version information.</td><td>optional</td><td><a href="#versioninfo"><code>VersionInfo</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-created--Thing"><td><code>created</code></td><td>Provides information when the TD instance was
+                created.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing"><td><code>modified</code></td><td>Provides information when the TD instance was
+                last modified.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-support--Thing"><td><code>support</code></td><td>Provides information about the TD maintainer as
+                URI scheme (e.g., <code>mailto</code> [[RFC6068]],
+                <code>tel</code> [[RFC3966]],
+                <code>https</code> [[RFC9112]]).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-base--Thing"><td><code>base</code></td><td>Define the base URI that is used for all
+                relative URI references throughout a TD document.
+                In TD instances, all relative URIs are resolved
+                relative to the base URI using the algorithm
+                defined in [<cite><a class="bibref" data-link-type=
+                "biblio" href='#bib-rfc3986' title=
+                "Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>].<br>
+                <br>
+                <code>base</code> does not affect the URIs used in
+                <code>@context</code> and the IRIs used within
+                Linked Data [<cite><a class="bibref"
+                data-link-type="biblio" href='#bib-linked-data'
+                title=
+                "Linked Data Design Issues">LINKED-DATA</a></cite>]
+                graphs that are relevant when semantic processing
+                is applied to TD instances.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing"><td><code>properties</code></td><td>All Property-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
+                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#propertyaffordance"><code>PropertyAffordance</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing"><td><code>actions</code></td><td>All Action-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
+                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#actionaffordance"><code>ActionAffordance</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-events--Thing"><td><code>events</code></td><td>All Event-based <a href='#dfn-interaction-affordance' class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
+                  of the Thing.</td><td>optional</td><td><a>Map</a> of <a href="#eventaffordance"><code>EventAffordance</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-links--Thing"><td><code>links</code></td><td>Provides Web links to arbitrary resources that
+                relate to the specified Thing Description.</td><td>optional</td><td><a>Array</a> of <a href="#link"><code>Link</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing"><td><code>forms</code></td><td>Set of form hypermedia controls that describe how 
+                  an operation can be performed. Forms are
+                  serializations of Protocol Bindings. <a>Thing level</a> forms are used to describe endpoints for a group of interaction affordances.</td><td>optional</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-security--Thing"><td><code>security</code></td><td>Set of security definition names, chosen from
+                those defined in <code>securityDefinitions</code>.
+                These must all be satisfied for access to resources.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing"><td><code>securityDefinitions</code></td><td>Set of named security configurations
+                (definitions only). Not actually applied unless
+                names are used in a <code>security</code>
+                name-value pair.</td><td>mandatory</td><td><a>Map</a> of <a href="#securityscheme"><code>SecurityScheme</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-profile--Thing"><td><code>profile</code></td><td>Indicates the WoT Profile mechanisms followed by this Thing Description and the corresponding Thing implementation.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-schemaDefinitions--Thing"><td><code>schemaDefinitions</code></td><td>Set of named data schemas.
+                To be used in a <code>schema</code>
+                name-value pair inside an 
+                <code>AdditionalExpectedResponse</code> object.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--Thing"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
+                based on DataSchema declarations. The <a>Thing level</a> <code>uriVariables</code> can be used in <a>Thing level</a> 
+                <code>forms</code> or in Interaction Affordances.
+                The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
+                to be serialized to a string inside the <code>href</code> upon the execution of the operation.
+                If the same variable is both declared in <a>Thing level</a> <code>uriVariables</code> and in Interaction Affordance level,
+                 the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>
+              For <code>@context</code> the following rules are defined for <a>Thing Description</a> instances:
+              </p>
+        <ul>
+            <li>
+    <span class="rfc2119-assertion" id=
+          "td-context-ns-thing-mandatory">
 
-            <p>
-              To determine the base direction of all human-readable text in <a>Thing Description</a> and
-              <a>Thing Model</a> instances this specification recommends to follow the [[STRING-META]] guideline about
-              <a href="https://www.w3.org/TR/string-meta/#string_specific_direction"
-                >string-specific directional information</a
-              >
-              when no built-in mechanism for associating base direction metadata is available.
-            </p>
+          The <code>@context</code>
+          name-value pair MUST contain the anyURI
+          <code>https://www.w3.org/2022/wot/td/v1.1</code>
+          in order to identify the document as a TD 1.1 which would allow <a>Consumers</a> to use the newly introduced terms.
+          </span>
+          </li>
+          <li>
+          <span class="rfc2119-assertion" id=
+          "td-context-ns-td10-namespace"> 
+          When there are possibly TD 1.0 consumers the anyURI
+          <code>https://www.w3.org/2019/wot/td/v1</code>
+          MUST be the first entry and the <code>https://www.w3.org/2022/wot/td/v1.1</code> MUST be the second entry.</span>
+          </li>
+          <li>
+          <span class="rfc2119-assertion" id=
+          "td-context-ns-td10-namespacev10"> 
+            TD 1.1 consumers MUST accept TDs satisfying the W3C WoT Thing Description 1.0 [[wot-thing-description10]] specification. 
+            </span>
+          </li>
+          <li>
+          <span class="rfc2119-assertion" id=
+          "td-context-ns-thing-optional">When <code>@context</code>
+          is an <a href="#dfn-array" class="internalDFN"
+          data-link-type="dfn">Array</a>, the anyURI
+          <code>https://www.w3.org/2022/wot/td/v1.1</code> <em class=
+          "rfc2119" title="MAY">MAY</em> be followed by elements of
+          type <code>anyURI</code> or type <a href="#dfn-map"
+          class="internalDFN" data-link-type="dfn">Map</a> in any
+          order, while it is RECOMMENDED to include only one
+          <a href="#dfn-map" class="internalDFN" data-link-type=
+          "dfn">Map</a> with all the name-value pairs in the
+          <code>@context</code> <a href="#dfn-array" class=
+          "internalDFN" data-link-type="dfn">Array</a>.</span>
+          </li>
+        <li>
+          <span class="rfc2119-assertion" id=
+          "td-context-ns-thing-map-of-namespaces"><a href=
+          "#dfn-map" class="internalDFN" data-link-type=
+          "dfn">Maps</a> contained in an <code>@context</code>
+          <a href="#dfn-array" class="internalDFN" data-link-type=
+          "dfn">Array</a> MAY
+          contain name-value pairs, where the value is a namespace
+          identifier of type <code>anyURI</code> and the name a
+          <a href="#dfn-term" class="internalDFN" data-link-type=
+          "dfn">Term</a> or prefix denoting that namespace.</span>
+          </li>
+          <li>
+          <span class="rfc2119-assertion" id=
+          "td-context-default-language">One <a href="#dfn-map"
+          class="internalDFN" data-link-type="dfn">Map</a>
+          contained in an <code>@context</code> <a href=
+          "#dfn-array" class="internalDFN" data-link-type=
+          "dfn">Array</a> SHOULD contain a name-value pair that
+          defines the default language for the Thing Description,
+          where the name is the <a href="#dfn-term" class=
+          "internalDFN" data-link-type="dfn">Term</a>
+          <code>@language</code> and the value is a well-formed
+          language tag as defined by [<cite><a class="bibref"
+          data-link-type="biblio" href="#bib-bcp47" title=
+          "Tags for Identifying Languages">BCP47</a></cite>] (e.g.,
+          <code>en</code>, <code>de-AT</code>, <code>gsw-CH</code>,
+          <code>zh-Hans</code>, <code>zh-Hant-HK</code>,
+          <code>sl-nedis</code>).</span>
+          </li>
+          </ul>
 
-            <p>
-              <a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TD Processors</a> should be aware of
-              certain special cases when processing bidirectional text.
-              <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
-                <a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TD Processors</a> SHOULD take care
-                to use bidi isolation when presenting strings to users, particularly when embedding in surrounding text
-                (e.g., for Web user interface)</span
-              >. Mixed direction text can occur in any language, even when the language is properly identified.
-            </p>
-            <p>
-              <span class="rfc2119-assertion" id="td-producer-mixed-direction">
-                TD <a>producers</a> SHOULD attempt to provide mixed direction strings in a way that can be displayed
-                successfully by a naive user agent.
-              </span>
-              For example, if an RTL string begins with an LTR run (such as a number or a brand or trade name in Latin
-              script), including an RLM character at the start of the string or wrapping opposite direction runs in bidi
-              controls can assist in proper display.
-            </p>
-            <p>
-              <em>Strings on the Web: Language and Direction Metadata</em> [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-string-meta"
-                  title="Strings on the Web: Language and Direction Metadata"
-                  >string-meta</a
-                ></cite
-              >] provides some guidance and illustrates a number of pitfalls when using bidirectional text.
-            </p>
-            <p id="meta-interactions-of-thing">
-              In addition to the explicitly provided
-              <a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">Interaction Affordances</a>
-              in the <code>properties</code>, <code>actions</code>, and <code>events</code>
-              <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Maps</a>, a
-              <a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a> can also provide
-              meta-interactions, which are indicated by <code>Form</code> instances in its optional <code>forms</code>
-              <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.
-              <span class="rfc2119-assertion" id="td-op-for-thing"
-                >When the <code>forms</code> <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> of
-                a <a href="#dfn-thing" class="internalDFN" data-link-type="dfn">Thing</a> instance contains
-                <code>Form</code> instances, it MUST contain <code>op</code> member with the string values assigned to
-                the name <code>op</code>, either directly or within an
-                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>, MUST be one of the following
-                <em>operation types</em>: <code>readallproperties</code>, <code>writeallproperties</code>,
-                <code>readmultipleproperties</code>, <code>writemultipleproperties</code>,
-                <code>observeallproperties</code>, <code>unobserveallproperties</code>, <code>queryallactions</code>,
-                <code>subscribeallevents</code>, or <code>unsubscribeallevents</code>.</span
-              >
-              (See <a href="#td-forms-readall-example">an example</a> for an usage of <code>form</code> in a Thing
-              instance.)
-            </p>
-            <p>
-              The data schema for each of the property meta-interactions is constructed by combining the data schemas of
-              each <code>PropertyAffordance</code> instance in a single <code>ObjectSchema</code> instance, where the
-              <code>properties</code> <a href="#dfn-map" class="internalDFN" data-link-type="dfn">Map</a> of the
-              <code>ObjectSchema</code> instance contains each data schema of the
-              <code>PropertyAffordances</code> identified by the name of the corresponding
-              <code>PropertyAffordances</code> instance.
-            </p>
-            <p>
-              If not specified otherwise (e.g., through a
-              <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>), the request
-              data of the <code>readmultipleproperties</code> operation is an
-              <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> that contains the intended
-              <code>PropertyAffordances</code> instance names, which is serialized to the content type specified by the
-              <code>Form</code> instance.
-            </p>
+          
+          <p>To determine the base direction of all
+          human-readable text in <a>Thing Description</a> 
+          and <a>Thing Model</a> instances this specification 
+           recommends to follow the [[STRING-META]] guideline about 
+           <a href="https://www.w3.org/TR/string-meta/#string_specific_direction">string-specific directional information</a>
+           when no built-in mechanism for associating base direction metadata
+           is available.
+           </p>
+
+          <p><a href="#dfn-td-processor" class="internalDFN"
+          data-link-type="dfn">TD Processors</a> should be aware of
+          certain special cases when processing bidirectional text.
+          <span class="rfc2119-assertion" id="td-processor-bidi-isolation">
+          <a href="#dfn-td-processor" class="internalDFN"
+          data-link-type="dfn">TD Processors</a> SHOULD take care to use bidi isolation when
+          presenting strings to users, particularly when embedding
+          in surrounding text (e.g., for Web user interface)</span>. 
+          Mixed direction text can occur in any language, even when the
+          language is properly identified.</p>
+          <p><span class="rfc2119-assertion" id="td-producer-mixed-direction">
+          TD <a>producers</a> SHOULD attempt to provide mixed direction
+          strings in a way that can be displayed successfully by a
+          naive user agent. </span>
+          For example, if an RTL string begins
+          with an LTR run (such as a number or a brand or trade
+          name in Latin script), including an RLM character at the
+          start of the string or wrapping opposite direction runs
+          in bidi controls can assist in proper display.</p>
+          <p><em>Strings on the Web: Language and Direction
+          Metadata</em> [<cite><a class="bibref" data-link-type=
+          "biblio" href="#bib-string-meta" title=
+          "Strings on the Web: Language and Direction Metadata">string-meta</a></cite>]
+          provides some guidance and illustrates a number of
+          pitfalls when using bidirectional text.</p>
+          <p id="meta-interactions-of-thing">In addition to the
+          explicitly provided <a href="#dfn-interaction-affordance"
+          class="internalDFN" data-link-type="dfn">Interaction
+          Affordances</a> in the <code>properties</code>,
+          <code>actions</code>, and <code>events</code> <a href=
+          "#dfn-map" class="internalDFN" data-link-type=
+          "dfn">Maps</a>, a <a href="#dfn-thing" class=
+          "internalDFN" data-link-type="dfn">Thing</a> can also
+          provide meta-interactions, which are indicated by
+          <code>Form</code> instances in its optional
+          <code>forms</code> <a href="#dfn-array" class=
+          "internalDFN" data-link-type="dfn">Array</a>.
+          <span class="rfc2119-assertion" id="td-op-for-thing">When
+          the <code>forms</code> <a href="#dfn-array" class=
+          "internalDFN" data-link-type="dfn">Array</a> of a
+          <a href="#dfn-thing" class="internalDFN" data-link-type=
+          "dfn">Thing</a> instance contains <code>Form</code>
+          instances, it MUST contain <code>op</code> member with the string values assigned 
+          to the name <code>op</code>, either directly or within an <a href=
+          "#dfn-array" class="internalDFN" data-link-type=
+          "dfn">Array</a>, MUST be one of the following <em>operation
+          types</em>: <code>readallproperties</code>,
+          <code>writeallproperties</code>,
+          <code>readmultipleproperties</code>,
+          <code>writemultipleproperties</code>, <code>observeallproperties</code>,
+          <code>unobserveallproperties</code>, <code>queryallactions</code>, 
+          <code>subscribeallevents</code>, or
+          <code>unsubscribeallevents</code>.</span> (See
+          <a href="#td-forms-readall-example">an example</a> for an
+          usage of <code>form</code> in a Thing instance.)</p>
+          <p>The data schema for each of the property meta-interactions is
+          constructed by combining the data schemas of each
+          <code>PropertyAffordance</code> instance in a single
+          <code>ObjectSchema</code> instance, where the
+          <code>properties</code> <a href="#dfn-map" class=
+          "internalDFN" data-link-type="dfn">Map</a> of the
+          <code>ObjectSchema</code> instance contains each data
+          schema of the <code>PropertyAffordances</code> identified
+          by the name of the corresponding
+          <code>PropertyAffordances</code> instance.</p>
+          <p>If not specified otherwise (e.g., through a <a href=
+          "#dfn-context-ext" class="internalDFN" data-link-type=
+          "dfn">TD Context Extension</a>), the request data of the
+          <code>readmultipleproperties</code> operation is an
+          <a href="#dfn-array" class="internalDFN" data-link-type=
+          "dfn">Array</a> that contains the intended
+          <code>PropertyAffordances</code> instance names, which is
+          serialized to the content type specified by the
+          <code>Form</code> instance.</p></section>
+<section><h3><code>InteractionAffordance</code></h3><p>Metadata of a Thing that shows the possible choices to
+          <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a>, thereby suggesting
+          how <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> may interact with the
+          Thing. There are many types of potential affordances, but
+          <abbr title="World Wide Web Consortium">W3C</abbr> WoT
+          defines three types of Interaction Affordances:
+          Properties, Actions, and Events.</p><table class="def numbered"><caption>Vocabulary Terms in InteractionAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
+                a text for UI representation) based on a default
+                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance"><td><code>titles</code></td><td>Provides multi-language human-readable titles
+                (e.g., display a text for UI representation in
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance"><td><code>description</code></td><td>Provides additional (human-readable)
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance"><td><code>forms</code></td><td>Set of form hypermedia controls that describe
+                how an operation can be performed. Forms are
+                serializations of Protocol Bindings. The array cannot be empty.</td><td>mandatory</td><td><a>Array</a> of <a href="#form"><code>Form</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance"><td><code>uriVariables</code></td><td>Define URI template variables according to [[RFC6570]]  as collection
+                based on DataSchema declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since each variable needs
+                to be serialized to a string inside the <code>href</code> upon the execution of the operation. 
+                If the same variable is both declared in <a>Thing level</a> <code>uriVariables</code>and in Interaction Affordance level, 
+                the Interaction Affordance level variable takes precedence.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p>The class <code>InteractionAffordance</code> has the following subclasses:</p><ul><li><a href="#propertyaffordance"><code>PropertyAffordance</code></a></li>
+<li><a href="#actionaffordance"><code>ActionAffordance</code></a></li>
+<li><a href="#eventaffordance"><code>EventAffordance</code></a></li></ul></section>
+<section><h3><code>PropertyAffordance</code></h3><p>An Interaction Affordance that exposes state of the
+          Thing. This state can then be retrieved (read) and/or updated (write).
+           Things can also choose to
+          make Properties observable by pushing the new state after
+          a change.</p><table class="def numbered"><caption>Vocabulary Terms in PropertyAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance"><td><code>observable</code></td><td>A hint that indicates whether Servients hosting
+                the Thing and Intermediaries should provide a
+                Protocol Binding that supports the <code>observeproperty</code> and <code>unobserveproperty</code> operations 
+                for this Property.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table><p class="note">Property instances are also instances of
+            the class <a href="#dataschema" class="sec-ref">DataSchema</a>. Therefore, it can contain the
+            <code>type</code>, <code>unit</code>,
+            <code>readOnly</code> and <code>writeOnly</code>
+            members, among others.</p><p><code>PropertyAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> and
+          the <code>DataSchema</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+          <span class="rfc2119-assertion" id="td-op-for-property">When a Form instance is within a
+          <code>PropertyAffordance</code> instance, the value
+          assigned to <code>op</code> MUST be one of <code>readproperty</code>,
+          <code>writeproperty</code>, <code>observeproperty</code>,
+          <code>unobserveproperty</code> or an <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
+          containing a combination of these terms.</span></p><p class="note">
+		  It is considered to be good practice that each <code>observeproperty</code> has a corresponding
+		  <code>unobserveproperty</code> unless the protocol supports implicit unsubscription mechanisms
+		  (e.g., heartbeat to detect connection loss).</p><p class="note">
+		  The observation mechanism depends on the underlying protocol or sub-protocol. Having said that, it is not 
+          guaranteed that the current <a>Property</a> value will be provided once the subscription is initiated. Hence, it may be 
+          necessary to read the current <a>Property</a> value before/after the subscription to get a first value. 
+          </p></section>
+<section><h3><code>ActionAffordance</code></h3><p>An Interaction Affordance that allows to invoke a
+          function of the Thing, which manipulates state (e.g.,
+          toggling a lamp on or off) or triggers a process on the
+          Thing (e.g., dim a lamp over time).</p><table class="def numbered"><caption>Vocabulary Terms in ActionAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance"><td><code>input</code></td><td>Used to define the input data schema of the
+                Action.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance"><td><code>output</code></td><td>Used to define the output data schema of the
+                Action.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance"><td><code>safe</code></td><td>Signals if the Action is safe (=true) or not.
+                Used to signal if there is no internal state (cf.
+                resource state) is changed when invoking an Action.
+                In that case responses can be cached as
+                example.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance"><td><code>idempotent</code></td><td>Indicates whether the Action is idempotent
+                (=true) or not. Informs whether the Action can be
+                called repeatedly with the same result, if present,
+                based on the same input.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-synchronous--ActionAffordance"><td><code>synchronous</code></td><td>Indicates whether the action is synchronous (=true) or not. 
+                A synchronous action means that the response of action contains all the information 
+                about the result of the action and no further querying about the status of the action 
+                is needed. Lack of this keyword means that no claim on the synchronicity of the 
+                action can be made.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr></tbody></table><p><code>ActionAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+          <span class="rfc2119-assertion" id="td-op-for-action">When a Form instance is within an
+          <code>ActionAffordance</code> instance, the value
+          assigned to op MUST
+          either be <code>invokeaction</code>, <code>queryaction</code>, 
+          <code>cancelaction</code> or an 
+          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
+          containing a combination of these terms.
+          </span></p></section>
+<section><h3><code>EventAffordance</code></h3><p>An Interaction Affordance that describes an event
+          source, which asynchronously pushes event data to
+          <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating
+          alerts).</p><table class="def numbered"><caption>Vocabulary Terms in EventAffordance Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance"><td><code>subscription</code></td><td>Defines data that needs to be passed upon
+                subscription, e.g., filters or message format for
+                setting up Webhooks.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance"><td><code>data</code></td><td>Defines the data schema of the Event instance
+                messages pushed by the Thing.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-dataResponse--EventAffordance"><td><code>dataResponse</code></td><td>Defines the data schema of the Event response messages sent by the consumer in a response to a data message.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance"><td><code>cancellation</code></td><td>Defines any data that needs to be passed to
+                cancel a subscription, e.g., a specific message to
+                remove a Webhook.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a></td></tr></tbody></table><p><code>EventAffordance</code> is a <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
+          <code>InteractionAffordance</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
+          <span class="rfc2119-assertion" id="td-op-for-event">When
+          a Form instance is within an <code>EventAffordance</code>
+          instance, the value assigned to <code>op</code>
+          MUST be either
+          <code>subscribeevent</code>,
+          <code>unsubscribeevent</code>, or both terms within an
+          <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span></p><p class="note">
+		  It is considered to be good practice that each <code>subscribeevent</code> has a corresponding <code>unsubscribeevent</code> unless the protocol
+		  supports implicit unsubscription mechanisms (e.g., heartbeat to detect connection loss).</p>
+          <p>
+            EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs interested Consumers about state changes.
+            However, a main difference of EventAffordances is that not every change of the associated resource needs to trigger an event message to be emitted, e.g. a critical threshold for a numeric value.
+        Furthermore, EventAffordances allow for more complex subscribing and unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and <code>cancellation</code> DataSchema definitions.
+            Not all protocols might support these more advanced mechanisms, however, which is why in some scenarios, events may be very similar to observable PropertyAffordances.
+            In these cases, the choice between a Property and a Event for modelling the Affordance should be made based on the semantics of the underlying resource; for example, if the state of the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the appropriate choice.
+          </p>
           </section>
-          <section>
-            <h3><code>InteractionAffordance</code></h3>
-            <p>
-              Metadata of a Thing that shows the possible choices to
-              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a>, thereby suggesting how
-              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> may interact with the
-              Thing. There are many types of potential affordances, but
-              <abbr title="World Wide Web Consortium">W3C</abbr> WoT defines three types of Interaction Affordances:
-              Properties, Actions, and Events.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in InteractionAffordance Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance">
-                  <td><code>@type</code></td>
-                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance">
-                  <td><code>title</code></td>
-                  <td>
-                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
-                    language.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance">
-                  <td><code>titles</code></td>
-                  <td>
-                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
-                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance">
-                  <td><code>description</code></td>
-                  <td>Provides additional (human-readable) information based on a default language.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance">
-                  <td><code>descriptions</code></td>
-                  <td>
-                    Can be used to support (human-readable) information in different languages. Also see
-                    <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance">
-                  <td><code>forms</code></td>
-                  <td>
-                    Set of form hypermedia controls that describe how an operation can be performed. Forms are
-                    serializations of Protocol Bindings. The array cannot be empty.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a>Array</a> of <a href="#form"><code>Form</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance">
-                  <td><code>uriVariables</code></td>
-                  <td>
-                    Define URI template variables according to [[RFC6570]] as collection based on DataSchema
-                    declarations. The individual variables DataSchema cannot be an ObjectSchema or an ArraySchema since
-                    each variable needs to be serialized to a string inside the <code>href</code> upon the execution of
-                    the operation. If the same variable is both declared in <a>Thing level</a>
-                    <code>uriVariables</code>and in Interaction Affordance level, the Interaction Affordance level
-                    variable takes precedence.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>The class <code>InteractionAffordance</code> has the following subclasses:</p>
-            <ul>
-              <li>
-                <a href="#propertyaffordance"><code>PropertyAffordance</code></a>
-              </li>
-              <li>
-                <a href="#actionaffordance"><code>ActionAffordance</code></a>
-              </li>
-              <li>
-                <a href="#eventaffordance"><code>EventAffordance</code></a>
-              </li>
-            </ul>
-          </section>
-          <section>
-            <h3><code>PropertyAffordance</code></h3>
-            <p>
-              An Interaction Affordance that exposes state of the Thing. This state can then be retrieved (read) and/or
-              updated (write). Things can also choose to make Properties observable by pushing the new state after a
-              change.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in PropertyAffordance Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance">
-                  <td><code>observable</code></td>
-                  <td>
-                    A hint that indicates whether Servients hosting the Thing and Intermediaries should provide a
-                    Protocol Binding that supports the <code>observeproperty</code> and
-                    <code>unobserveproperty</code> operations for this Property.
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p class="note">
-              Property instances are also instances of the class <a href="#dataschema" class="sec-ref">DataSchema</a>.
-              Therefore, it can contain the <code>type</code>, <code>unit</code>, <code>readOnly</code> and
-              <code>writeOnly</code> members, among others.
-            </p>
-            <p>
-              <code>PropertyAffordance</code> is a
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-              <code>InteractionAffordance</code>
-              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> and the <code>DataSchema</code>
-              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-              <span class="rfc2119-assertion" id="td-op-for-property"
-                >When a Form instance is within a <code>PropertyAffordance</code> instance, the value assigned to
-                <code>op</code> MUST be one of <code>readproperty</code>, <code>writeproperty</code>,
-                <code>observeproperty</code>, <code>unobserveproperty</code> or an
-                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a> containing a combination of
-                these terms.</span
-              >
-            </p>
-            <p class="note">
-              It is considered to be good practice that each <code>observeproperty</code> has a corresponding
-              <code>unobserveproperty</code> unless the protocol supports implicit unsubscription mechanisms (e.g.,
-              heartbeat to detect connection loss).
-            </p>
-            <p class="note">
-              The observation mechanism depends on the underlying protocol or sub-protocol. Having said that, it is not
-              guaranteed that the current <a>Property</a> value will be provided once the subscription is initiated.
-              Hence, it may be necessary to read the current <a>Property</a> value before/after the subscription to get
-              a first value.
-            </p>
-          </section>
-          <section>
-            <h3><code>ActionAffordance</code></h3>
-            <p>
-              An Interaction Affordance that allows to invoke a function of the Thing, which manipulates state (e.g.,
-              toggling a lamp on or off) or triggers a process on the Thing (e.g., dim a lamp over time).
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in ActionAffordance Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance">
-                  <td><code>input</code></td>
-                  <td>Used to define the input data schema of the Action.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance">
-                  <td><code>output</code></td>
-                  <td>Used to define the output data schema of the Action.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance">
-                  <td><code>safe</code></td>
-                  <td>
-                    Signals if the Action is safe (=true) or not. Used to signal if there is no internal state (cf.
-                    resource state) is changed when invoking an Action. In that case responses can be cached as example.
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance">
-                  <td><code>idempotent</code></td>
-                  <td>
-                    Indicates whether the Action is idempotent (=true) or not. Informs whether the Action can be called
-                    repeatedly with the same result, if present, based on the same input.
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-synchronous--ActionAffordance">
-                  <td><code>synchronous</code></td>
-                  <td>
-                    Indicates whether the action is synchronous (=true) or not. A synchronous action means that the
-                    response of action contains all the information about the result of the action and no further
-                    querying about the status of the action is needed. Lack of this keyword means that no claim on the
-                    synchronicity of the action can be made.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              <code>ActionAffordance</code> is a
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-              <code>InteractionAffordance</code>
-              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-              <span class="rfc2119-assertion" id="td-op-for-action"
-                >When a Form instance is within an <code>ActionAffordance</code> instance, the value assigned to op MUST
-                either be <code>invokeaction</code>, <code>queryaction</code>, <code>cancelaction</code> or an
-                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>
-                containing a combination of these terms.
-              </span>
-            </p>
-          </section>
-          <section>
-            <h3><code>EventAffordance</code></h3>
-            <p>
-              An Interaction Affordance that describes an event source, which asynchronously pushes event data to
-              <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumers</a> (e.g., overheating alerts).
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in EventAffordance Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance">
-                  <td><code>subscription</code></td>
-                  <td>
-                    Defines data that needs to be passed upon subscription, e.g., filters or message format for setting
-                    up Webhooks.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance">
-                  <td><code>data</code></td>
-                  <td>Defines the data schema of the Event instance messages pushed by the Thing.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-dataResponse--EventAffordance">
-                  <td><code>dataResponse</code></td>
-                  <td>
-                    Defines the data schema of the Event response messages sent by the consumer in a response to a data
-                    message.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance">
-                  <td><code>cancellation</code></td>
-                  <td>
-                    Defines any data that needs to be passed to cancel a subscription, e.g., a specific message to
-                    remove a Webhook.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              <code>EventAffordance</code> is a
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> of the
-              <code>InteractionAffordance</code>
-              <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a>.
-              <span class="rfc2119-assertion" id="td-op-for-event"
-                >When a Form instance is within an <code>EventAffordance</code> instance, the value assigned to
-                <code>op</code>
-                MUST be either
-                <code>subscribeevent</code>, <code>unsubscribeevent</code>, or both terms within an
-                <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.</span
-              >
-            </p>
-            <p class="note">
-              It is considered to be good practice that each <code>subscribeevent</code> has a corresponding
-              <code>unsubscribeevent</code> unless the protocol supports implicit unsubscription mechanisms (e.g.,
-              heartbeat to detect connection loss).
-            </p>
-            <p>
-              EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs
-              interested Consumers about state changes. However, a main difference of EventAffordances is that not every
-              change of the associated resource needs to trigger an event message to be emitted, e.g. a critical
-              threshold for a numeric value. Furthermore, EventAffordances allow for more complex subscribing and
-              unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and
-              <code>cancellation</code> DataSchema definitions. Not all protocols might support these more advanced
-              mechanisms, however, which is why in some scenarios, events may be very similar to observable
-              PropertyAffordances. In these cases, the choice between a Property and a Event for modelling the
-              Affordance should be made based on the semantics of the underlying resource; for example, if the state of
-              the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the
-              appropriate choice.
-            </p>
-          </section>
-          <section>
-            <h3><code>VersionInfo</code></h3>
-            <p>
-              Metadata of a Thing that provides version information about the TD document. If required, additional
-              version information such as firmware and hardware version (term definitions outside of the TD namespace)
-              can be extended via the
-              <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a> mechanism.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in VersionInfo Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo">
-                  <td><code>instance</code></td>
-                  <td>Provides a version indicator of this TD.</td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-model--VersionInfo">
-                  <td><code>model</code></td>
-                  <td>Provides a version indicator of the underlying TM.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              It is recommended that the values within <code>instances</code> and <code>model</code> of the
-              <code>VersionInfo</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> follow
-              the semantic versioning pattern, where a sequence of three numbers separated by a dot indicates the major
-              version, minor version, and patch version, respectively. See [<cite
-                ><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0"
-                  >SEMVER</a
-                ></cite
-              >] for details.
-            </p>
-          </section>
-          <section>
-            <h3><code>MultiLanguage</code></h3>
-            <p></p>
-            <p>
-              A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags
-              described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of
-              this container in a Thing Description instance.
-            </p>
-            <p>
-              <span class="rfc2119-assertion" id="td-multilanguage-language-tag"
-                >Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in
-                [[!BCP47]].</span
-              >
-              <span class="rfc2119-assertion" id="td-multilanguage-value">
-                Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>.
-              </span>
-            </p>
-          </section>
+<section><h3><code>VersionInfo</code></h3><p>Metadata of a Thing that provides version information
+          about the TD document. If required, additional version
+          information such as firmware and hardware version (term
+          definitions outside of the TD namespace) can be extended
+          via the <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>
+          mechanism.</p><table class="def numbered"><caption>Vocabulary Terms in VersionInfo Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo"><td><code>instance</code></td><td>Provides a version indicator of this TD.
+                </td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-model--VersionInfo"><td><code>model</code></td><td>Provides a version indicator of the underlying TM.
+                </td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><p>It is recommended that the values within <code>instances</code> and <code>model</code> of
+          the <code>VersionInfo</code> <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> follow the
+          semantic versioning pattern, where a sequence of three
+          numbers separated by a dot indicates the major version,
+          minor version, and patch version, respectively. See
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0">SEMVER</a></cite>] for
+          details.</p></section>
+<section><h3><code>MultiLanguage</code></h3><p><p>A <a>Map</a> providing a set of human-readable texts in different languages identified by language tags described in [[BCP47]]. See <a href="#titles-descriptions-serialization-json"></a> for example usages of this container in a Thing Description instance.</p>
+            <p><span class="rfc2119-assertion" id="td-multilanguage-language-tag">Each name of the <code>MultiLanguage</code> <a>Map</a> MUST be a language tag as defined in [[!BCP47]].</span>
+            <span class="rfc2119-assertion" id="td-multilanguage-value"> Each value of the <code>MultiLanguage</code> <a>Map</a> MUST be of type <code>string</code>. </span> 
+            </p></section>
         </section>
 
         <section id="sec-data-schema-vocabulary-definition">
@@ -2044,579 +1552,122 @@
           </table>
 
           <!-- rendered from RDF definitions -->
-          <section>
-            <h3><code>DataSchema</code></h3>
-            <p>Metadata that describes the data format used. It can be used for validation.</p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in DataSchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema">
-                  <td><code>@type</code></td>
-                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema">
-                  <td><code>title</code></td>
-                  <td>
-                    Provides a human-readable title (e.g., display a text for UI representation) based on a default
-                    language.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema">
-                  <td><code>titles</code></td>
-                  <td>
-                    Provides multi-language human-readable titles (e.g., display a text for UI representation in
-                    different languages). Also see <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema">
-                  <td><code>description</code></td>
-                  <td>Provides additional (human-readable) information based on a default language.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema">
-                  <td><code>descriptions</code></td>
-                  <td>
-                    Can be used to support (human-readable) information in different languages. Also see
-                    <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema">
-                  <td><code>const</code></td>
-                  <td>Provides a constant value.</td>
-                  <td>optional</td>
-                  <td>any type</td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema">
-                  <td><code>default</code></td>
-                  <td>
-                    Supply a default value. The value SHOULD validate against the data schema in which it resides.
-                  </td>
-                  <td>optional</td>
-                  <td>any type</td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema">
-                  <td><code>unit</code></td>
-                  <td>
-                    Provides unit information that is used, e.g., in international science, engineering, and business.
-                    To preserve uniqueness, it is recommended that the value of the unit points to a semantic definition
-                    (also see Section
-                    <a href="#semantic-annotations-example-version-units" class="internalDFN" data-link-type="dfn"
-                      >Semantic Annotations</a
-                    >).
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema">
-                  <td><code>oneOf</code></td>
-                  <td>
-                    Used to ensure that the data is valid against one of the specified schemas in the array. This can be
-                    used to describe multiple input or output schemas.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema">
-                  <td><code>enum</code></td>
-                  <td>Restricted set of values provided as an array.</td>
-                  <td>optional</td>
-                  <td><a>Array</a> of any type</td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema">
-                  <td><code>readOnly</code></td>
-                  <td>
-                    Boolean value that is a hint to indicate whether a property interaction / value is read only (=true)
-                    or not (=false).
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema">
-                  <td><code>writeOnly</code></td>
-                  <td>
-                    Boolean value that is a hint to indicate whether a property interaction / value is write only
-                    (=true) or not (=false).
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema">
-                  <td><code>format</code></td>
-                  <td>
-                    Allows validation based on a format pattern such as "date-time", "email", "uri", etc. (Also see
-                    below.)
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-type--DataSchema">
-                  <td><code>type</code></td>
-                  <td>
-                    Assignment of JSON-based data types compatible with JSON Schema (one of boolean, integer, number,
-                    string, object, array, or null).
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> (one
-                    of <code>object</code>, <code>array</code>, <code>string</code>, <code>number</code>,
-                    <code>integer</code>, <code>boolean</code>, or <code>null</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>The class <code>DataSchema</code> has the following subclasses:</p>
-            <ul>
-              <li>
-                <a href="#arrayschema"><code>ArraySchema</code></a>
-              </li>
-              <li>
-                <a href="#booleanschema"><code>BooleanSchema</code></a>
-              </li>
-              <li>
-                <a href="#numberschema"><code>NumberSchema</code></a>
-              </li>
-              <li>
-                <a href="#integerschema"><code>IntegerSchema</code></a>
-              </li>
-              <li>
-                <a href="#objectschema"><code>ObjectSchema</code></a>
-              </li>
-              <li>
-                <a href="#stringschema"><code>StringSchema</code></a>
-              </li>
-              <li>
-                <a href="#nullschema"><code>NullSchema</code></a>
-              </li>
-            </ul>
-            <p>
-              The <code>format</code> string values are known from a fixed set of values and their corresponding format
-              rules defined in [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-json-schema"
-                  title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON"
-                  >JSON-SCHEMA</a
-                ></cite
-              >] (Section 7.3 Defined Formats in particular).
-              <span class="rfc2119-assertion" id="td-format-validation-known-values"
-                >Servients MAY use the <code>format</code> value to perform additional validation accordingly.</span
-              >
-              <span class="rfc2119-assertion" id="td-format-validation-other-values"
-                >When a value that is not found in the known set of values is assigned to <code>format</code>, such a
-                validation SHOULD succeed.</span
-              >
-            </p>
-            Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>,
-            <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string,
-            object, array, or null).
-            <p class="note">
-              The <code>format</code> term is not widely implemented by JSON Schema tools. In addition, the term
-              <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by
-              another mechanism or removed in a future JSON Schema version.
-            </p>
-          </section>
-          <section>
-            <h3><code>ArraySchema</code></h3>
-            <p>
-              Metadata describing data of type <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>.
-              This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
-              value <code>array</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in ArraySchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema">
-                  <td><code>items</code></td>
-                  <td>Used to define the characteristics of an array.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#dataschema"><code>DataSchema</code></a> or <a>Array</a> of
-                    <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema">
-                  <td><code>minItems</code></td>
-                  <td>Defines the minimum number of items that have to be in the array.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
-                      ><code>unsignedInt</code></a
-                    >
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema">
-                  <td><code>maxItems</code></td>
-                  <td>Defines the maximum number of items that have to be in the array.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
-                      ><code>unsignedInt</code></a
-                    >
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>BooleanSchema</code></h3>
-            <p>
-              Metadata describing data of type <code>boolean</code>. This
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
-              <code>boolean</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-          </section>
-          <section>
-            <h3><code>NumberSchema</code></h3>
-            <p>
-              Metadata describing data of type <code>number</code>. This
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
-              <code>number</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in NumberSchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema">
-                  <td><code>minimum</code></td>
-                  <td>
-                    Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--NumberSchema">
-                  <td><code>exclusiveMinimum</code></td>
-                  <td>
-                    Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema">
-                  <td><code>maximum</code></td>
-                  <td>
-                    Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--NumberSchema">
-                  <td><code>exclusiveMaximum</code></td>
-                  <td>
-                    Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--NumberSchema">
-                  <td><code>multipleOf</code></td>
-                  <td>
-                    Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>IntegerSchema</code></h3>
-            <p>
-              Metadata describing data of type <code>integer</code>. This
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
-              <code>integer</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in IntegerSchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema">
-                  <td><code>minimum</code></td>
-                  <td>
-                    Specifies a minimum numeric value, representing an inclusive lower limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--IntegerSchema">
-                  <td><code>exclusiveMinimum</code></td>
-                  <td>
-                    Specifies a minimum numeric value, representing an exclusive lower limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema">
-                  <td><code>maximum</code></td>
-                  <td>
-                    Specifies a maximum numeric value, representing an inclusive upper limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--IntegerSchema">
-                  <td><code>exclusiveMaximum</code></td>
-                  <td>
-                    Specifies a maximum numeric value, representing an exclusive upper limit. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--IntegerSchema">
-                  <td><code>multipleOf</code></td>
-                  <td>
-                    Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for
-                    associated number or integer types.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>ObjectSchema</code></h3>
-            <p>
-              Metadata describing data of type
-              <a href="#dfn-object" class="internalDFN" data-link-type="dfn">Object</a>. This
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
-              <code>object</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in ObjectSchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema">
-                  <td><code>properties</code></td>
-                  <td>Data schema nested definitions.</td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema">
-                  <td><code>required</code></td>
-                  <td>
-                    Defines which members of the object type are mandatory, i.e. which members are mandatory in the
-                    payload that is to be sent (e.g. input of <code>invokeaction</code>, <code>writeproperty</code>) and
-                    what members will be definitely delivered in the payload that is being received (e.g. output of
-                    <code>invokeaction</code>, <code>readproperty</code>)
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>StringSchema</code></h3>
-            <p>
-              Metadata describing data of type <code>string</code>. This
-              <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the value
-              <code>string</code> assigned to <code>type</code> in <code>DataSchema</code> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in StringSchema Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-minLength--StringSchema">
-                  <td><code>minLength</code></td>
-                  <td>Specifies the minimum length of a string. Only applicable for associated string types.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
-                      ><code>unsignedInt</code></a
-                    >
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-maxLength--StringSchema">
-                  <td><code>maxLength</code></td>
-                  <td>Specifies the maximum length of a string. Only applicable for associated string types.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"
-                      ><code>unsignedInt</code></a
-                    >
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-pattern--StringSchema">
-                  <td><code>pattern</code></td>
-                  <td>
-                    Provides a regular expression to express constraints of the string value. The regular expression
-                    must follow the [[ECMA-262]] dialect.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentEncoding--StringSchema">
-                  <td><code>contentEncoding</code></td>
-                  <td>
-                    Specifies the encoding used to store the contents, as specified in [[RFC2045]] (Section 6.1) and
-                    [[RFC4648]].
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>7bit</code>, <code>8bit</code>, <code>binary</code>, <code>quoted-printable</code>,
-                    <code>base16</code>, <code>base32</code>, or <code>base64</code>)
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentMediaType--StringSchema">
-                  <td><code>contentMediaType</code></td>
-                  <td>Specifies the MIME type of the contents of a string value, as described in [[RFC2046]].</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>image/png</code>, or <code>audio/mpeg</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p class="note">
-              The length of a string (i.e., <code>minLength</code> and <code>maxLength</code>) is defined as the number
-              of Unicode code points, as defined by [[RFC8259]]. Note that some
-              <a href="https://www.w3.org/TR/i18n-glossary/#dfn-grapheme" target="_blank">user-perceived characters</a>
-              are composed of more than one Unicode code point. Arbitrary index values might not fall on these grapheme
-              boundaries, so truncation according to <code>maxLength</code> might alter the appearance or meaning of the
-              string.
-            </p>
-          </section>
-          <section>
-            <h3><code>NullSchema</code></h3>
-            <p>
-              Metadata describing data of type <code>null</code>. This subclass is indicated by the value
-              <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. This Subclass
-              describes only one acceptable value, namely <code>null</code>. It is important to note that
-              <code>null</code> does not mean the absence of a value. It is analogous to <code>null</code> in
-              JavaScript, <code>None</code> in Python, <code>null</code> in Java and <code>nil</code> in Ruby
-              programming languages. It can be used as part of a <code>oneOf</code> declaration, where it is used to
-              indicate, that the data can also be <code>null</code>.
-            </p>
-          </section>
+          <section><h3><code>DataSchema</code></h3><p>Metadata that describes the data format used. It can
+          be used for validation.</p><table class="def numbered"><caption>Vocabulary Terms in DataSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types)</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema"><td><code>title</code></td><td>Provides a human-readable title (e.g., display
+                a text for UI representation) based on a default
+                language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema"><td><code>titles</code></td><td>Provides multi-language human-readable titles
+                (e.g., display a text for UI representation in
+                different languages). Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema"><td><code>description</code></td><td>Provides additional (human-readable)
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema"><td><code>const</code></td><td>Provides a constant value.</td><td>optional</td><td>any type</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-default--DataSchema"><td><code>default</code></td><td>Supply a default value. The value SHOULD validate against the data schema in which it resides.</td><td>optional</td><td>any type</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema"><td><code>unit</code></td><td>Provides unit information that is used, e.g.,
+                in international science, engineering, and
+                business. To preserve uniqueness, it is recommended that 
+                the value of the unit points to a semantic definition (also see Section <a href="#semantic-annotations-example-version-units"
+          class="internalDFN" data-link-type="dfn">Semantic Annotations</a>).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema"><td><code>oneOf</code></td><td>Used to ensure that the data is valid against
+                one of the specified schemas in the array.  This can be used to describe multiple input or output schemas.</td><td>optional</td><td><a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-enum--DataSchema"><td><code>enum</code></td><td>Restricted set of values provided as an
+                array.</td><td>optional</td><td><a>Array</a> of any type</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema"><td><code>readOnly</code></td><td>Boolean value that is a hint to indicate
+                whether a property interaction / value is read only
+                (=true) or not (=false).</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema"><td><code>writeOnly</code></td><td>Boolean value that is a hint to indicate
+                whether a property interaction / value is write
+                only (=true) or not (=false).</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema"><td><code>format</code></td><td>Allows validation based on a format pattern
+                such as "date-time", "email", "uri", etc. (Also see
+                below.)</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-type--DataSchema"><td><code>type</code></td><td>Assignment of JSON-based data types compatible
+                with JSON Schema (one of boolean, integer, number,
+                string, object, array, or null).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a> (one of <code>object</code>, <code>array</code>, <code>string</code>, <code>number</code>, <code>integer</code>, <code>boolean</code>, or <code>null</code>)</td></tr></tbody></table><p>The class <code>DataSchema</code> has the following subclasses:</p><ul><li><a href="#arrayschema"><code>ArraySchema</code></a></li>
+<li><a href="#booleanschema"><code>BooleanSchema</code></a></li>
+<li><a href="#numberschema"><code>NumberSchema</code></a></li>
+<li><a href="#integerschema"><code>IntegerSchema</code></a></li>
+<li><a href="#objectschema"><code>ObjectSchema</code></a></li>
+<li><a href="#stringschema"><code>StringSchema</code></a></li>
+<li><a href="#nullschema"><code>NullSchema</code></a></li></ul><p>The <code>format</code> string values are known from a
+          fixed set of values and their corresponding format rules
+          defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]
+          (Section 7.3 Defined Formats in particular). <span class="rfc2119-assertion" id="td-format-validation-known-values">Servients MAY use the
+          <code>format</code> value to perform additional
+          validation accordingly.</span> <span class="rfc2119-assertion" id="td-format-validation-other-values">When a value that is
+          not found in the known set of values is assigned to
+          <code>format</code>, such a validation SHOULD succeed.</span></p>
+          Vocabulary terms typed as <code>any</code> <code>type</code> (e.g., <code>const</code>, <code>default</code>) follow data types compatible with JSON Schema (boolean, integer, number, string, object, array, or null).
+          <p class="note">The <code>format</code> term is not widely implemented by JSON Schema tools. 
+          In addition, the term <code>format</code> is being discussed by the JSON Schema standardisation community and may be replaced by another mechanism or removed in a future JSON Schema version.</p></section>
+<section><h3><code>ArraySchema</code></h3><p>Metadata describing data of type <a href="#dfn-array" class="internalDFN" data-link-type="dfn">Array</a>. This
+          <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>array</code> assigned to <code>type</code> in
+          <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in ArraySchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema"><td><code>items</code></td><td>Used to define the characteristics of an
+                array.</td><td>optional</td><td><a href="#dataschema"><code>DataSchema</code></a> or <a>Array</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema"><td><code>minItems</code></td><td>Defines the minimum number of items that have
+                to be in the array.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema"><td><code>maxItems</code></td><td>Defines the maximum number of items that have
+                to be in the array.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr></tbody></table></section>
+<section><h3><code>BooleanSchema</code></h3><p>Metadata describing data of type <code>boolean</code>.
+          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>boolean</code> assigned to <code>type</code>
+          in <code>DataSchema</code> instances.</p></section>
+<section><h3><code>NumberSchema</code></h3><p>Metadata describing data of type <code>number</code>.
+          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>number</code> assigned to <code>type</code>
+          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in NumberSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema"><td><code>minimum</code></td><td>Specifies a minimum numeric value, representing an inclusive lower limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--NumberSchema"><td><code>exclusiveMinimum</code></td><td>Specifies a minimum numeric value, representing an exclusive lower limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema"><td><code>maximum</code></td><td>Specifies a maximum numeric value, representing an inclusive upper limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--NumberSchema"><td><code>exclusiveMaximum</code></td><td>Specifies a maximum numeric value, representing an exclusive upper limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--NumberSchema"><td><code>multipleOf</code></td><td>Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td></tr></tbody></table></section>
+<section><h3><code>IntegerSchema</code></h3><p>Metadata describing data of type <code>integer</code>.
+          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>integer</code> assigned to <code>type</code>
+          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in IntegerSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema"><td><code>minimum</code></td><td>Specifies a minimum numeric value, representing an inclusive lower limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMinimum--IntegerSchema"><td><code>exclusiveMinimum</code></td><td>Specifies a minimum numeric value, representing an exclusive lower limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema"><td><code>maximum</code></td><td>Specifies a maximum numeric value, representing an inclusive upper limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-exclusiveMaximum--IntegerSchema"><td><code>exclusiveMaximum</code></td><td>Specifies a maximum numeric value, representing an exclusive upper limit. Only
+                applicable for associated number or integer
+                types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-multipleOf--IntegerSchema"><td><code>multipleOf</code></td><td>Specifies the multipleOf value number. The value must strictly greater than 0. Only applicable for associated number or integer types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td></tr></tbody></table></section>
+<section><h3><code>ObjectSchema</code></h3><p>Metadata describing data of type <a href="#dfn-object" class="internalDFN" data-link-type="dfn">Object</a>.
+          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>object</code> assigned to <code>type</code>
+          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in ObjectSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema"><td><code>properties</code></td><td>Data schema nested definitions.</td><td>optional</td><td><a>Map</a> of <a href="#dataschema"><code>DataSchema</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema"><td><code>required</code></td><td>Defines which members of the object type are mandatory, i.e. which members are mandatory in the payload that is to be sent (e.g. input of <code>invokeaction</code>, <code>writeproperty</code>) and what members will be definitely delivered in the payload that is being received (e.g. output of <code>invokeaction</code>, <code>readproperty</code>)</td><td>optional</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+<section><h3><code>StringSchema</code></h3><p>Metadata describing data of type <code>string</code>.
+          This <a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">Subclass</a> is indicated by the
+          value <code>string</code> assigned to <code>type</code>
+          in <code>DataSchema</code> instances.</p><table class="def numbered"><caption>Vocabulary Terms in StringSchema Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-minLength--StringSchema"><td><code>minLength</code></td><td>Specifies the minimum length of a string. Only applicable for associated string types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-maxLength--StringSchema"><td><code>maxLength</code></td><td>Specifies the maximum length of a string. Only applicable for associated string types.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-pattern--StringSchema"><td><code>pattern</code></td><td>Provides a regular expression to express constraints of the string value. The regular expression must follow the [[ECMA-262]] dialect.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-contentEncoding--StringSchema"><td><code>contentEncoding</code></td><td>Specifies the encoding used to store the contents, as specified in [[RFC2045]] (Section 6.1) and [[RFC4648]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>7bit</code>, <code>8bit</code>, <code>binary</code>, <code>quoted-printable</code>, <code>base16</code>, <code>base32</code>, or <code>base64</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-contentMediaType--StringSchema"><td><code>contentMediaType</code></td><td>Specifies the MIME type of the contents of a string value, as described in [[RFC2046]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>image/png</code>, or <code>audio/mpeg</code>)</td></tr></tbody></table><p class="note">The length of a string (i.e., <code>minLength</code> and
+        <code>maxLength</code>) is defined as the number
+        of Unicode code points, as defined by [[RFC8259]].
+		Note that some <a href="https://www.w3.org/TR/i18n-glossary/#dfn-grapheme" target="_blank">user-perceived characters</a> are composed of more than one Unicode code point. Arbitrary index values might not fall on these grapheme boundaries, so truncation according to <code>maxLength</code> might alter the appearance or meaning of the string.
+		</p></section>
+<section><h3><code>NullSchema</code></h3><p>Metadata describing data of type <code>null</code>. This subclass is indicated by the value <code>null</code> assigned to <code>type</code> in <code>DataSchema</code> instances. 
+    This Subclass describes only one acceptable value, namely <code>null</code>. 
+    It is important to note that <code>null</code> does not mean the absence of a value. It is analogous to <code>null</code> in JavaScript, <code>None</code> in Python, <code>null</code> in Java and <code>nil</code> in Ruby programming languages. 
+    It can be used as part of a <code>oneOf</code> declaration, where it is used to indicate, that the data can also be <code>null</code>.</p></section>
         </section>
 
         <section id="sec-security-vocabulary-definition">
@@ -2640,713 +1691,229 @@
           </p>
 
           <!-- rendered from RDF definitions -->
-          <section>
-            <h3><code>SecurityScheme</code></h3>
-            <p></p>
-            <p>
-              Metadata describing the configuration of a security mechanism.
-              <span class="rfc2119-assertion" id="td-security-scheme-name"
-                >The value assigned to the name <code>scheme</code> MUST be defined within a
-                <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
-                included in the
-                <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>, either
-                in the standard
-                <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined in
-                <a href="#sec-vocabulary-definition" class="sec-ref"
-                  >§&nbsp;<bdi class="secno">5.</bdi> TD Information Model</a
-                >
-                or in a
-                <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context Extension</a>.</span
-              >
-            </p>
-            <p>
-              <span class="rfc2119-assertion" id="td-security-no-secrets"
-                >For all security schemes, any keys, passwords, or other sensitive information directly providing access
-                MUST NOT be stored in the TD and should instead be shared and stored out-of-band via other
-                mechanisms.</span
-              >
-              The purpose of a TD is to describe how to access a Thing if and only if a Consumer already has
-              authorization, and is not meant be used to grant that authorization.
-            </p>
-            <p>
-              Each security scheme object used in a TD defines a set of requirements to be met before access can be
-              granted. We say a security scheme is <em>satisfied</em> when all its requirements are met. In some cases
-              requirements from multiple security schemes will have to be met before access can be granted.
-            </p>
-            <p>
-              Security schemes generally may require additional authentication parameters, such as a password or key.
-              The location of this information is indicated by the value associated with the name <code>in</code>, often
-              in combination with the value associated with <code>name</code>. The value associated with
-              <code>in</code> can take one of the following values:
-            </p>
-            <dl>
-              <dt><code>header</code>:</dt>
-              <dd>
-                The parameter will be given in a header provided by the protocol, with the name of the header provided
-                by the value of <code>name</code>.
-              </dd>
-              <dt><code>query</code>:</dt>
-              <dd>
-                The parameter will be appended to the URI as a query parameter, with the name of the query parameter
-                provided by <code>name</code>.
-              </dd>
-              <dt><code>body</code>:</dt>
-              <dd>
-                The parameter will be provided in the body of the request payload, with the data schema element used
-                provided by <code>name</code>.
-                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer"
-                  >When used in the context of a <code>body</code> security information location, the value of
-                  <code>name</code> MUST be in the form of a JSON pointer [[!RFC6901]] relative to the root of the input
-                  <code>DataSchema</code> for each interaction it is used with.</span
-                >
-                Since this value is not a fragment identifier, and is not relative to the root of the TD but to
-                whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
-                it is a "pure" JSON pointer. Since this value is not a fragment identifier, it also does not need to
-                URL-encode special characters. The targeted element may or may not already exist at the specified
-                location in the referenced object or array schema (consequently the mechanism is not applicable to
-                simple types). If it does not, it will be inserted. This avoids having to duplicate definitions in the
-                data schemas of every interaction.
-                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-creatable"
-                  >When an element of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
-                  does not already exist in the indicated schema, it MUST be possible to insert the indicated element at
-                  the location indicated by the pointer.</span
-                >
-                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-array"
-                  >The JSON pointer used in the <code>body</code> locator MAY use the "<code>-</code>" character to
-                  indicate a non-existent array element when it is necessary to insert an element after the last element
-                  of an existing array.
-                </span>
-                <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-type"
-                  >The element referenced (or created) by a <code>body</code> security information location MUST be
-                  required and of type "<code>string</code>".</span
-                >
-                If <code>name</code> is not given, it is assumed the entire body is to be used as the security
-                parameter.
-              </dd>
-              <dt><code>cookie</code>:</dt>
-              <dd>The parameter is stored in a cookie identified by the value of <code>name</code>.</dd>
-              <dt><code>uri</code>:</dt>
-              <dd>
-                The parameter is embedded in the URI itself, which is encoded in the relevant interaction using a URI
-                template variable defined by the value of <code>name</code>. This is more general than the
-                <code>query</code> mechanism but more complex.
-                <span class="rfc2119-assertion" id="td-security-in-query-over-uri"
-                  >The value <code>uri</code> SHOULD be specified for the name <code>in</code> in a security scheme only
-                  if <code>query</code> is not applicable.</span
-                >
-                <span class="rfc2119-assertion" id="td-security-in-uri-variable"
-                  >The URIs provided in interactions where a security scheme using <code>uri</code> as the value for
-                  <code>in</code>
-                  MUST be a URI template including the defined variable.
-                </span>
-              </dd>
-              <dt><code>auto</code>:</dt>
-              <dd>
-                The location is determined as part of the protocol, or negotiated.
-                <span class="rfc2119-assertion" id="td-security-security-vocab-auto-in-no-name"
-                  >If a value of <code>auto</code> is set for the <code>in</code> field of a
-                  <code>SecurityScheme</code>, then the <code>name</code> field SHOULD NOT be set.</span
-                >
-                In this case, the application of the <code>SecurityScheme</code> is subject to the respective
-                specification for the given protocol (e.g. [[!RFC8288]] when using the
-                <code>BasicSecurityScheme</code> with HTTP).
-              </dd>
-            </dl>
-            <p>
-              If multiple parameters are needed for a security scheme, repeat the security scheme definition for each
-              parameter and combine them using a <code>combo</code> security scheme and <code>allOf</code>. In some
-              cases parameters may not actually be secret but a user may wish to leave them out of the TD to help
-              protect privacy. As an example of this, some security mechanisms require both a client identifier and a
-              secret key. In theory, the client identifier is public however it may be hard to update and pose a
-              tracking risk. In such a case it can be provided as an additional security parameter so it does not appear
-              in the TD.
-            </p>
-            <p>
-              <span class="rfc2119-assertion" id="td-security-uri-variables-distinct"
-                >The names of URI variables declared in a <code>SecurityScheme</code> MUST be distinct from all other
-                URI variables declared in the TD.</span
-              >
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in SecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme">
-                  <td><code>@type</code></td>
-                  <td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme">
-                  <td><code>description</code></td>
-                  <td>Provides additional (human-readable) information based on a default language.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme">
-                  <td><code>descriptions</code></td>
-                  <td>
-                    Can be used to support (human-readable) information in different languages. Also see
-                    <cite><a href="#multilanguage">MultiLanguage</a></cite
-                    >.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme">
-                  <td><code>proxy</code></td>
-                  <td>
-                    URI of the proxy server this security configuration provides access to. If not given, the
-                    corresponding security configuration is for the endpoint.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme">
-                  <td><code>scheme</code></td>
-                  <td>Identification of the security mechanism being configured.</td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>nosec</code>, <code>combo</code>, <code>basic</code>, <code>digest</code>,
-                    <code>bearer</code>, <code>psk</code>, <code>oauth2</code>, <code>apikey</code>, or
-                    <code>auto</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>The class <code>SecurityScheme</code> has the following subclasses:</p>
-            <ul>
-              <li>
-                <a href="#nosecurityscheme"><code>NoSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#autosecurityscheme"><code>AutoSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#basicsecurityscheme"><code>BasicSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#bearersecurityscheme"><code>BearerSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#psksecurityscheme"><code>PSKSecurityScheme</code></a>
-              </li>
-              <li>
-                <a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a>
-              </li>
-            </ul>
-          </section>
-          <section>
-            <h3><code>NoSecurityScheme</code></h3>
-            <p>
-              A security configuration corresponding to identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>nosec</code> (i.e., <code>"scheme": "nosec"</code>), indicating there is no authentication or other
-              mechanism required to access the resource.
-            </p>
-          </section>
-          <section>
-            <h3><code>AutoSecurityScheme</code></h3>
-            <p>
-              An automatic authentication security configuration identified by the term <code>auto</code> (i.e.,
-              <code>"scheme": "auto"</code>). This scheme indicates that the security parameters are going to be
-              negotiated by the underlying protocols at runtime, subject to the respective specifications for the
-              protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).
-            </p>
-          </section>
-          <section>
-            <h3><code>ComboSecurityScheme</code></h3>
-            <p>
-              A combination of other security schemes identified by the <a>Vocabulary Term</a> <code>combo</code> (i.e.,
-              <code>"scheme": "combo"</code>). Elements of this scheme define various ways in which other named schemes
-              defined in <code>securityDefinitions</code>, including other
-              <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> definitions, are to be combined to
-              create a new scheme definition.
-              <span class="rfc2119-assertion" id="td-security-combo-exclusive-oneof-or-allof"
-                >Exactly one of either <code>oneOf</code> or <code>allOf</code> <i>vocabulary terms</i> MUST be
-                included.</span
-              >
-              <!-- Redundant, table states "two or more" already <scan class="rfc2119-assertion">The array given as a value associated with either <code>oneOf</code> or <code>allOf</code> MUST have at least two elements.</scan> -->
-              Only security scheme definitions which can be used together can be combined with <code>allOf</code>. For
-              example, it is not possible in general to combine different OAuth 2.0 flows together using
-              <code>allOf</code> unless one applies to a proxy and one to the endpoint. Note that when multiple named
-              security scheme definitions are listed in a <code>security</code> field the same semantics apply as in an
-              <code>allOf</code> combination (and the same limitations on allowable combinations). The
-              <code>oneOf</code> combination is equivalent to using different security schemes on forms that are
-              otherwise identical. In this sense a <code>oneOf</code> scheme is not an essential feature but it does
-              avoid redundancy in such cases.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in ComboSecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--ComboSecurityScheme">
-                  <td><code>oneOf</code></td>
-                  <td>
-                    Array of two or more strings identifying other named security scheme definitions, any one of which,
-                    when satisfied, will allow access. Only one may be chosen for use.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-allOf--ComboSecurityScheme">
-                  <td><code>allOf</code></td>
-                  <td>
-                    Array of two or more strings identifying other named security scheme definitions, all of which must
-                    be satisfied for access.
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <!-- <p class="ednote" title="Recursive Use">The 
-<a href="#combosecurityscheme">ComboSecurityScheme</a> may be applied recursively to generate Boolean expressions for combinations of security schemes. One use case for this is when multiple security schemes are needed for a proxy in combination with multiple security schemes for an endpoint.  Suppose for example a proxy accepts either schemes A or B, and then the endpoint accepts either C or D.  Then the possible combinations are AC, AD, BC, and BD.  These could be expressed directly at the <code>Form</code> level but would require four-fold redundancy.  Instead, three <code>combo</code> nodes can be used to combine the four leaf schemes in the correct way into a single scheme.  It is not clear however if other use cases exist for deeper expression trees and if not, we may consider limiting the recursion depth to two.</p>-->
-          </section>
-          <section>
-            <h3><code>BasicSecurityScheme</code></h3>
-            <p>
-              Basic Authentication [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-rfc7617"
-                  title="The 'Basic' HTTP Authentication Scheme"
-                  >RFC7617</a
-                ></cite
-              >] security configuration identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>basic</code> (i.e., <code>"scheme": "basic"</code>), using an unencrypted username and password.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in BasicSecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme">
-                  <td><code>name</code></td>
-                  <td>Name for query, header, cookie, or uri parameters.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme">
-                  <td><code>in</code></td>
-                  <td>Specifies the location of security authentication information.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
-                    <code>auto</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>DigestSecurityScheme</code></h3>
-            <p>
-              Digest Access Authentication [<cite
-                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication"
-                  >RFC7616</a
-                ></cite
-              >] security configuration identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>digest</code> (i.e., <code>"scheme": "digest"</code>). This scheme is similar to basic
-              authentication but with added features to avoid man-in-the-middle attacks.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in DigestSecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme">
-                  <td><code>name</code></td>
-                  <td>Name for query, header, cookie, or uri parameters.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme">
-                  <td><code>in</code></td>
-                  <td>Specifies the location of security authentication information.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
-                    <code>auto</code>)
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme">
-                  <td><code>qop</code></td>
-                  <td>Quality of protection.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>auth</code>, or <code>auth-int</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>APIKeySecurityScheme</code></h3>
-            <p>
-              API key authentication security configuration identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>apikey</code> (i.e., <code>"scheme": "apikey"</code>). This scheme is to be used when the access
-              token is opaque, for example when a key in an unknown or proprietary format is provided by a cloud service
-              provider. In this case the key may not be using a standard token format. This scheme indicates that the
-              key provided by the service provider needs to be supplied as part of service requests using the mechanism
-              indicated by the <code>"in"</code> field.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in APIKeySecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme">
-                  <td><code>name</code></td>
-                  <td>Name for query, header, cookie, or uri parameters.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme">
-                  <td><code>in</code></td>
-                  <td>Specifies the location of security authentication information.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>,
-                    <code>uri</code>, or <code>auto</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>BearerSecurityScheme</code></h3>
-            <p>
-              Bearer Token [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-rfc6750"
-                  title="The OAuth 2.0 Authorization Framework: Bearer Token Usage"
-                  >RFC6750</a
-                ></cite
-              >] security configuration identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>bearer</code> (i.e., <code>"scheme": "bearer"</code>) for situations where bearer tokens are used
-              independently of OAuth2. If the <code>oauth2</code> scheme is specified it is not generally necessary to
-              specify this scheme as well as it is implied. For <code>format</code>, the value
-              <code>jwt</code> indicates conformance with [<cite
-                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)"
-                  >RFC7519</a
-                ></cite
-              >], <code>jws</code> indicates conformance with [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-rfc7797"
-                  title="JSON Web Signature (JWS) Unencoded Payload Option"
-                  >RFC7797</a
-                ></cite
-              >], <code>cwt</code> indicates conformance with [<cite
-                ><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)"
-                  >RFC8392</a
-                ></cite
-              >], and <code>jwe</code> indicates conformance with [<cite
-                ><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)"
-                  >RFC7516</a
-                ></cite
-              >], with values for <code>alg</code> interpreted consistently with those standards.
-              <span class="rfc2119-assertion" id="td-security-bearer-format-extensions"
-                >Other formats and algorithms for bearer tokens MAY be specified in vocabulary extensions</span
-              >.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in BearerSecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme">
-                  <td><code>authorization</code></td>
-                  <td>URI of the authorization server.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme">
-                  <td><code>name</code></td>
-                  <td>Name for query, header, cookie, or uri parameters.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme">
-                  <td><code>in</code></td>
-                  <td>Specifies the location of security authentication information.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or
-                    <code>auto</code>)
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme">
-                  <td><code>alg</code></td>
-                  <td>Encoding, encryption, or digest algorithm.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>ES256</code>, or <code>ES512-256</code>)
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme">
-                  <td><code>format</code></td>
-                  <td>Specifies format of security authentication information.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>PSKSecurityScheme</code></h3>
-            <p>
-              Pre-shared key authentication security configuration identified by the
-              <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
-              <code>psk</code> (i.e., <code>"scheme": "psk"</code>). This is meant to identify that a standard is used
-              for pre-shared keys such as TLS-PSK [[RFC4279]], and that the ciphersuite used for keys will be
-              established during protocol negotiation.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in PSKSecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-identity--PSKSecurityScheme">
-                  <td><code>identity</code></td>
-                  <td>Identifier providing information which can be used for selection or confirmation.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>OAuth2SecurityScheme</code></h3>
-            <p>
-              OAuth 2.0 authentication security configuration for systems conformant with [[!RFC6749]] and [[!RFC8252]],
-              <!-- and
-            (for the <code>device</code> flow) [[!RFC8628]],-->
-              identified by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e., <code>"scheme": "oauth2"</code>).
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in OAuth2SecurityScheme Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme">
-                  <td><code>authorization</code></td>
-                  <td>
-                    URI of the authorization server.<!-- In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]. -->
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme">
-                  <td><code>token</code></td>
-                  <td>URI of the token server.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme">
-                  <td><code>refresh</code></td>
-                  <td>URI of the refresh server.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme">
-                  <td><code>scopes</code></td>
-                  <td>
-                    Set of authorization scope identifiers provided as an array. These are provided in tokens returned
-                    by an authorization server and associated with forms in order to identify what resources a client
-                    may access and how. The values associated with a form SHOULD be chosen from those defined in an
-                    <code>OAuth2SecurityScheme</code> active on that form.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme">
-                  <td><code>flow</code></td>
-                  <td>Authorization flow.</td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>code</code>, or <code>client</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              <span class="rfc2119-assertion" id="td-security-oauth2-code-flow"
-                >For the <code>code</code> flow both <code>authorization</code> and <code>token</code>
-                <a>vocabulary terms</a> MUST be included.</span
-              >
-              <span class="rfc2119-assertion" id="td-security-oauth2-client-flow"
-                >For the <code>client</code> flow <code>token</code> <a>vocabulary term</a> MUST be included.</span
-              >
-              <span class="rfc2119-assertion" id="td-security-oauth2-client-flow-no-auth"
-                >For the <code>client</code> flow <code>authorization</code> <a>vocabulary term</a> MUST NOT be
-                included.</span
-              >
-              <!-- <span class="rfc2119-assertion" id="td-security-oauth2-device-flow">For the
+          <section><h3><code>SecurityScheme</code></h3><p><p>Metadata describing the configuration of a security
+          mechanism. <span class="rfc2119-assertion" id="td-security-scheme-name">The value assigned to the name
+          <code>scheme</code> MUST be defined within a 
+          <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a>
+          included in the <a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">Thing Description</a>,
+          either in the standard <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary</a> defined
+          in <a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD
+          Information Model</a> or in a <a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TD Context
+          Extension</a>.</span>
+          </p><p>
+          <span class="rfc2119-assertion" id="td-security-no-secrets">For all security schemes,
+          any keys, passwords, or other sensitive information directly providing access 
+          MUST NOT be stored in the TD and should instead
+          be shared and stored out-of-band via other mechanisms.</span> 
+          The purpose of a TD is to describe how to access a Thing if and only if a Consumer 
+          already has authorization, and is not meant be used to grant that authorization.
+          </p><p>Each security scheme object used in a TD defines a set of requirements to be met before access can be granted.
+          We say a security scheme is <em>satisfied</em> when all its requirements are met.
+          In some cases requirements from multiple security schemes will have to be met before access can be granted.
+          </p><p>
+          Security schemes generally may require additional authentication
+          parameters, such as a password or key.
+          The location of this information is indicated by the
+          value associated with the name <code>in</code>, often in combination with the value associated with <code>name</code>.
+          The value associated with <code>in</code> can take one of the following values:
+          </p>
+          <dl>
+          <dt><code>header</code>:</dt>
+          <dd>The parameter will be given
+            in a header provided by the protocol, with the name of the header
+            provided by the value of <code>name</code>.</dd>
+          <dt><code>query</code>:</dt>
+          <dd>The parameter will be appended to the URI as a query parameter, with the name of the 
+            query parameter provided by <code>name</code>.</dd>
+          <dt><code>body</code>:</dt>
+          <dd>The parameter will be provided in the body of the request payload, with the data schema element  
+            used provided by <code>name</code>.
+            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer">When used in the context of a 
+            <code>body</code> security information location, the value of <code>name</code> 
+            MUST be in the form of a JSON pointer [[!RFC6901]] relative to 
+            the root of the input <code>DataSchema</code> for each interaction it is used with.</span> 
+            Since this value is not a fragment identifier, and is not relative to the root of the TD but
+            to whichever data schemas the security scheme is bound to, this value should not start with <code>#</code>;
+            it is a "pure" JSON pointer.
+            Since this value is not a fragment identifier, it also does not
+            need to URL-encode special characters.
+            The targeted element may or may not already exist at the specified location in the referenced object or array schema (consequently the mechanism is not applicable to simple types).
+            If it does not, it will be inserted. This avoids having to duplicate definitions in the data schemas of
+            every interaction.
+            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-creatable">When an element
+            of a data schema indicated by a JSON pointer indicated in a <code>body</code> locator
+            does not already exist in the indicated schema, it MUST
+            be possible to insert the indicated element
+            at the location indicated by the pointer.</span>
+            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-array">The JSON pointer
+            used in the <code>body</code> locator MAY
+            use the "<code>-</code>" character to indicate a non-existent array element when 
+            it is necessary to insert an element after the last element of an existing array.
+            </span>
+            <span class="rfc2119-assertion" id="td-security-body-name-json-pointer-type">The element referenced
+            (or created) by a 
+            <code>body</code> security information location
+            MUST be required and of type "<code>string</code>".</span> 
+            If <code>name</code> is not given, it is assumed the entire body
+            is to be used as the security parameter.
+          </dd>
+          <dt><code>cookie</code>:</dt>
+          <dd>The parameter is stored in a cookie identified by the value of   
+            <code>name</code>.
+          </dd>
+          <dt><code>uri</code>:</dt>
+          <dd>The parameter is embedded in the URI itself, which is encoded in the
+          relevant interaction using a URI template variable defined by the value of <code>name</code>.
+          This is more general than the <code>query</code> mechanism but more complex. 
+          <span class="rfc2119-assertion" id="td-security-in-query-over-uri">The value <code>uri</code> 
+          SHOULD be specified 
+          for the name <code>in</code> in a security scheme only if
+          <code>query</code> is not applicable.</span>  
+          <span class="rfc2119-assertion" id="td-security-in-uri-variable">The URIs provided
+          in interactions where a security scheme using <code>uri</code> as the value for <code>in</code>
+          MUST be a URI template including the defined variable.
+          </span>  
+          </dd>
+          <dt><code>auto</code>:</dt>
+          <dd>The location is determined as part of the protocol, or negotiated. 
+          <span class="rfc2119-assertion" id="td-security-security-vocab-auto-in-no-name">If a value of <code>auto</code> 
+          is set for the <code>in</code> field of a <code>SecurityScheme</code>, 
+          then the <code>name</code> field SHOULD NOT be set.</span> 
+          In this case, the application of the <code>SecurityScheme</code> is subject to 
+          the respective specification for the given protocol (e.g. [[!RFC8288]] when using the 
+          <code>BasicSecurityScheme</code> with HTTP).
+          </dd>
+          </dl>
+          <p>
+          If multiple parameters are needed for a security scheme, repeat the security scheme definition for
+          each parameter and combine them using a <code>combo</code> security scheme and <code>allOf</code>.
+          In some cases parameters may not actually be secret but a user may wish to leave them
+          out of the TD to help protect privacy.  As an example of this, some security mechanisms
+          require both a client identifier and a secret key.  In theory, the client identifier is 
+          public however it may be hard to update and pose a tracking risk.  In such a case it can
+          be provided as an additional security parameter so it does not appear in the TD.
+          </p><p>
+          <span class="rfc2119-assertion" id="td-security-uri-variables-distinct">The names of URI variables 
+          declared in a <code>SecurityScheme</code> 
+          MUST be distinct from all other URI variables 
+          declared in the TD.</span></p><table class="def numbered"><caption>Vocabulary Terms in SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme"><td><code>@type</code></td><td>JSON-LD keyword to label the object with <a>semantic tags</a> (or types).</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr><tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme"><td><code>description</code></td><td>Provides additional (human-readable)
+                      information based on a default language.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme"><td><code>descriptions</code></td><td>Can be used to support (human-readable)
+                       information in different languages. Also see <cite><a href='#multilanguage'>MultiLanguage</a></cite>.</td><td>optional</td><td><a>Map</a> of <a href="#multilanguage"><code>MultiLanguage</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme"><td><code>proxy</code></td><td>URI of the proxy server this security
+                configuration provides access to. If not given, the
+                corresponding security configuration is for the
+                endpoint.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme"><td><code>scheme</code></td><td>Identification of the security mechanism being
+                configured.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>nosec</code>, <code>combo</code>, <code>basic</code>, <code>digest</code>, <code>bearer</code>, <code>psk</code>, <code>oauth2</code>, <code>apikey</code>, or <code>auto</code>)</td></tr></tbody></table><p>The class <code>SecurityScheme</code> has the following subclasses:</p><ul><li><a href="#nosecurityscheme"><code>NoSecurityScheme</code></a></li>
+<li><a href="#autosecurityscheme"><code>AutoSecurityScheme</code></a></li>
+<li><a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a></li>
+<li><a href="#basicsecurityscheme"><code>BasicSecurityScheme</code></a></li>
+<li><a href="#digestsecurityscheme"><code>DigestSecurityScheme</code></a></li>
+<li><a href="#apikeysecurityscheme"><code>APIKeySecurityScheme</code></a></li>
+<li><a href="#bearersecurityscheme"><code>BearerSecurityScheme</code></a></li>
+<li><a href="#psksecurityscheme"><code>PSKSecurityScheme</code></a></li>
+<li><a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a></li></ul></section>
+<section><h3><code>NoSecurityScheme</code></h3><p>A security configuration corresponding to identified
+          by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+          <code>nosec</code> (i.e., <code>"scheme":
+          "nosec"</code>), indicating there is no authentication or
+          other mechanism required to access the resource.</p></section>
+<section><h3><code>AutoSecurityScheme</code></h3><p>An automatic authentication security configuration identified by the term <code>auto</code> (i.e., <code>"scheme": "auto"</code>). This scheme indicates that the security parameters are going to be negotiated by the underlying protocols at runtime, subject to the respective specifications for the protocol (e.g. [[!RFC8288]] for Basic Authentication when using HTTP).</p></section>
+<section><h3><code>ComboSecurityScheme</code></h3><p>A combination of other security schemes identified by the <a>Vocabulary Term</a> <code>combo</code> (i.e., <code>"scheme": "combo"</code>).  Elements of this scheme define various ways in which other named schemes defined in <code>securityDefinitions</code>, including other <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> definitions, are to be combined to create a new scheme definition.  <span class="rfc2119-assertion" id="td-security-combo-exclusive-oneof-or-allof">Exactly one of either <code>oneOf</code> or <code>allOf</code> <i>vocabulary terms</i> MUST be included.</span> <!-- Redundant, table states "two or more" already <scan class="rfc2119-assertion">The array given as a value associated with either <code>oneOf</code> or <code>allOf</code> MUST have at least two elements.</scan> --> Only security scheme definitions which can be used together can be combined with <code>allOf</code>.  For example, it is not possible in general to combine different OAuth 2.0 flows together using <code>allOf</code> unless one applies to a proxy and one to the endpoint.  Note that when multiple named security scheme definitions are listed in a <code>security</code> field the same semantics apply as in an <code>allOf</code> combination (and the same limitations on allowable combinations).  The <code>oneOf</code> combination is equivalent to using different security schemes on forms that are otherwise identical.  In this sense a <code>oneOf</code> scheme is not an essential feature but it does avoid redundancy in such cases.</p><table class="def numbered"><caption>Vocabulary Terms in ComboSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-oneOf--ComboSecurityScheme"><td><code>oneOf</code></td><td>Array of two or more strings identifying other named security scheme definitions, any one of which, when satisfied, will allow access.  Only one may be chosen for use.</td><td>mandatory</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-allOf--ComboSecurityScheme"><td><code>allOf</code></td><td>Array of two or more strings identifying other named security scheme definitions, all of which must be satisfied for access.</td><td>mandatory</td><td><a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><!-- <p class="ednote" title="Recursive Use">The 
+<a href="#combosecurityscheme">ComboSecurityScheme</a> may be applied recursively to generate Boolean expressions for combinations of security schemes. One use case for this is when multiple security schemes are needed for a proxy in combination with multiple security schemes for an endpoint.  Suppose for example a proxy accepts either schemes A or B, and then the endpoint accepts either C or D.  Then the possible combinations are AC, AD, BC, and BD.  These could be expressed directly at the <code>Form</code> level but would require four-fold redundancy.  Instead, three <code>combo</code> nodes can be used to combine the four leaf schemes in the correct way into a single scheme.  It is not clear however if other use cases exist for deeper expression trees and if not, we may consider limiting the recursion depth to two.</p>--></section>
+<section><h3><code>BasicSecurityScheme</code></h3><p>Basic Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7617" title="The 'Basic' HTTP Authentication Scheme">RFC7617</a></cite>]
+          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>basic</code> (i.e.,
+          <code>"scheme": "basic"</code>), using an unencrypted
+          username and password.</p><table class="def numbered"><caption>Vocabulary Terms in BasicSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--BasicSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
+               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr></tbody></table></section>
+<section><h3><code>DigestSecurityScheme</code></h3><p>Digest Access Authentication [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication">RFC7616</a></cite>]
+          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>digest</code> (i.e.,
+          <code>"scheme": "digest"</code>). This scheme is similar
+          to basic authentication but with added features to avoid
+          man-in-the-middle attacks.</p><table class="def numbered"><caption>Vocabulary Terms in DigestSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--DigestSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
+               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-qop--DigestSecurityScheme"><td><code>qop</code></td><td>Quality of protection.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>auth</code>, or <code>auth-int</code>)</td></tr></tbody></table></section>
+<section><h3><code>APIKeySecurityScheme</code></h3><p>API key authentication security configuration
+          identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+          <code>apikey</code> (i.e., <code>"scheme":
+          "apikey"</code>). 
+          This scheme is to be used when the access token is opaque,
+          for example when a key in an unknown or proprietary format is provided by a cloud service provider.
+          In this case the key may not be using a standard token format.
+          This scheme indicates that the key provided by the service provider 
+          needs to be supplied as part 
+          of service requests using the mechanism indicated by the <code>"in"</code> field.</p><table class="def numbered"><caption>Vocabulary Terms in APIKeySecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-name--APIKeySecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
+               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme"><td><code>in</code></td><td>Specifies the location of security
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, <code>uri</code>, or <code>auto</code>)</td></tr></tbody></table></section>
+<section><h3><code>BearerSecurityScheme</code></h3><p>Bearer Token [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6750" title="The OAuth 2.0 Authorization Framework: Bearer Token Usage">RFC6750</a></cite>]
+          security configuration identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a> <code>bearer</code> (i.e.,
+          <code>"scheme": "bearer"</code>) for situations where
+          bearer tokens are used independently of OAuth2. If the
+          <code>oauth2</code> scheme is specified it is not
+          generally necessary to specify this scheme as well as it
+          is implied. For <code>format</code>, the value
+          <code>jwt</code> indicates conformance with
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>],
+          <code>jws</code> indicates conformance with
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7797" title="JSON Web Signature (JWS) Unencoded Payload Option">RFC7797</a></cite>],
+          <code>cwt</code> indicates conformance with
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)">RFC8392</a></cite>], and
+          <code>jwe</code> indicates conformance with
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>], with
+          values for <code>alg</code> interpreted consistently with
+          those standards. <span class="rfc2119-assertion" id="td-security-bearer-format-extensions">Other formats and
+          algorithms for bearer tokens MAY be specified in vocabulary
+          extensions</span>.</p><table class="def numbered"><caption>Vocabulary Terms in BearerSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-name--BearerSecurityScheme"><td><code>name</code></td><td>Name for query, header, cookie, or uri
+               parameters.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme"><td><code>in</code></td><td>Specifies the location of security
+            authentication information.  </td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>header</code>, <code>query</code>, <code>body</code>, <code>cookie</code>, or <code>auto</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme"><td><code>alg</code></td><td>Encoding, encryption, or digest algorithm.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>ES256</code>, or <code>ES512-256</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme"><td><code>format</code></td><td>Specifies format of security authentication
+                 information.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>jwt</code>, <code>cwt</code>, <code>jwe</code>, or <code>jws</code>)</td></tr></tbody></table></section>
+<section><h3><code>PSKSecurityScheme</code></h3><p>Pre-shared key authentication security configuration
+          identified by the <a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">Vocabulary Term</a>
+          <code>psk</code> (i.e., <code>"scheme":
+          "psk"</code>).
+          This is meant to identify that a standard is used for pre-shared keys such as TLS-PSK [[RFC4279]], 
+          and that the ciphersuite used for keys will be established during protocol negotiation.</p><table class="def numbered"><caption>Vocabulary Terms in PSKSecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-identity--PSKSecurityScheme"><td><code>identity</code></td><td>Identifier providing information which can be
+                   used for selection or confirmation.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+<section><h3><code>OAuth2SecurityScheme</code></h3><p>OAuth 2.0 authentication security configuration
+            for systems conformant with [[!RFC6749]] and [[!RFC8252]], <!-- and
+            (for the <code>device</code> flow) [[!RFC8628]],--> identified
+            by the <a>Vocabulary Term</a> <code>oauth2</code> (i.e.,
+            <code>"scheme": "oauth2"</code>).</p><table class="def numbered"><caption>Vocabulary Terms in OAuth2SecurityScheme Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme"><td><code>authorization</code></td><td>URI of the authorization server.<!-- In the case of the <code>device</code> flow, the URI provided for the <code>authorization</code> value refers to the device authorization endpoint [[!RFC8628]]. --></td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme"><td><code>token</code></td><td>URI of the token server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-refresh--OAuth2SecurityScheme"><td><code>refresh</code></td><td>URI of the refresh server.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided
+                as an array. These are provided in tokens returned
+                by an authorization server and associated with
+                forms in order to identify what resources a client
+                may access and how. The values associated with a
+                form SHOULD be chosen from those defined in an
+                <code>OAuth2SecurityScheme</code> active on that
+                form.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme"><td><code>flow</code></td><td>Authorization flow.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>code</code>, or <code>client</code>)</td></tr></tbody></table><p><span class="rfc2119-assertion" id="td-security-oauth2-code-flow">For
+            the <code>code</code> flow both <code>authorization</code> and <code>token</code> <a>vocabulary terms</a>
+            MUST be included.</span> <span class="rfc2119-assertion" id="td-security-oauth2-client-flow">For
+            the <code>client</code> flow <code>token</code> <a>vocabulary term</a> MUST be included.</span>
+            <span class="rfc2119-assertion" id="td-security-oauth2-client-flow-no-auth">For the
+            <code>client</code> flow <code>authorization</code> <a>vocabulary term</a> MUST NOT be included.</span>
+            <!-- <span class="rfc2119-assertion" id="td-security-oauth2-device-flow">For the
             <code>device</code> flow both <code>authorization</code> and <code>token</code> <a>vocabulary terms</a>
             MUST be included.</span> In the case of the <code>device</code> flow the value
             provided for <code>authorization</code> <a>vocabulary terms</a> refers to the device authorization endpoint
-            defined in [[!RFC8628]]. -->
-              The mandatory elements for each flow are summarized in the following table:
+            defined in [[!RFC8628]]. --> The mandatory elements for each flow are summarized in the
+            following table:
             </p>
-            <table class="def numbered">
-              <tr>
-                <th>Element</th>
-                <th><code>code</code></th>
-                <th><code>client</code></th>
-              </tr>
-              <tr>
-                <td><code>authorization</code></td>
-                <td>mandatory</td>
-                <td>omit</td>
-                <!-- <td>mandatory; refers to device authorization endpoint</td> -->
-              </tr>
-              <tr>
-                <td><code>token</code></td>
-                <td>mandatory</td>
-                <td>mandatory</td>
-                <!-- <td>mandatory</td> -->
-              </tr>
-              <tr>
-                <td><code>refresh</code></td>
-                <td>optional</td>
-                <td>optional</td>
-                <!-- <td>optional</td> -->
-              </tr>
-            </table>
+            <table class="def numbered"> <tr><th>Element</th><th><code>code</code></th><th><code>client</code></th></tr> <tr><td><code>authorization</code></td><td>mandatory</td><td>omit</td><!-- <td>mandatory; refers to device authorization endpoint</td> --></tr> <tr><td><code>token</code></td><td>mandatory</td><td>mandatory</td><!-- <td>mandatory</td> --></tr> <tr><td><code>refresh</code></td><td>optional</td><td>optional</td><!-- <td>optional</td> --></tr> </table>
             <!-- 
 	    <p class="ednote"> Note that the <code>OAuth2SecurityScheme</code> class definition lists these elements as "optional". 
             In fact whether they are mandatory or not depends on the flow.  The <code>token</code>
@@ -3371,8 +1938,7 @@
             however an alternative design where there is a separate element,
             <code>device_authorization</code>, which MUST be included for the <code>device</code>
             flow (and then the regular authorization endpoint then MUST NOT be used).</p>
-	    -->
-          </section>
+	    --></section>
         </section>
 
         <section id="sec-hypermedia-vocabulary-definition">
@@ -3388,843 +1954,587 @@
           </p>
 
           <!-- rendered from RDF definitions -->
-          <section>
-            <h3><code>Link</code></h3>
-            <p>
-              A link can be viewed as a statement of the form "<b><em>link context</em></b> has a
-              <b><em>relation type</em></b> resource at <b><em>link target</em></b
-              >", where the optional <b><em>target attributes</em></b> may further describe the resource.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in Link Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-href--Link">
-                  <td><code>href</code></td>
-                  <td>Target IRI of a link or submission target of a form.</td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-type--Link">
-                  <td><code>type</code></td>
-                  <td>
-                    Target attribute providing a hint indicating what the media type [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-rfc2046"
-                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
-                        >RFC2046</a
-                      ></cite
-                    >] of the result of dereferencing the link should be.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-rel--Link">
-                  <td><code>rel</code></td>
-                  <td>A link relation type identifies the semantics of a link.</td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link">
-                  <td><code>anchor</code></td>
-                  <td>
-                    Overrides the link context (by default the Thing itself identified by its <code>id</code>) with the
-                    given URI or IRI.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link">
-                  <td><code>sizes</code></td>
-                  <td>
-                    Target attribute that specifies one or more sizes for the referenced icon. Only applicable for
-                    relation type "icon". The value pattern follows {Height}x{Width} (e.g., "16x16", "16x16 32x32").
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-hreflang--Link">
-                  <td><code>hreflang</code></td>
-                  <td>
-                    The hreflang attribute specifies the language of a linked document. The value of this must be a
-                    valid language tag [[BCP47]].
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p class="note" title="hreflang type">
-              The <code>hreflang</code> attribute is allowed to be a <code>string</code> or <code>array</code> in this
-              version of the spec. Depending on the result of [[LINKSET-MEDIA-TYPES]] the values of
-              <code>hrefLang</code> can be restricted to <code>array</code> only.
-            </p>
-            <p>
-              Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a
-              Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description is an instance of a specific
-              Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended
-              to reuse existing and established
-              <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
-            </p>
-            <p>
-              In the following a best practice relation type table is introduced that is recommended to use within WoT
-              <a>Thing Description</a> or <a>Thing Model</a> instances.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Best practice relation type table
-              </caption>
-              <thead>
-                <tr>
-                  <th>Value</th>
-                  <th>Occurrence</th>
-                  <th>Explanation</th>
-                  <th>Source of value origin</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>
+          <section><h3><code>Link</code></h3><p>A link can be viewed as a statement of the form
+          "<b><em>link context</em></b> has a <b><em>relation
+          type</em></b> resource at <b><em>link target</em></b>",
+          where the optional <b><em>target attributes</em></b> may
+          further describe the resource.</p><table class="def numbered"><caption>Vocabulary Terms in Link Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Link"><td><code>href</code></td><td>Target IRI of a link or submission target of a
+                form.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-type--Link"><td><code>type</code></td><td>Target attribute providing a hint indicating
+                what the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]
+                of the result of dereferencing the link should
+                be.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-rel--Link"><td><code>rel</code></td><td>A link relation type identifies the semantics
+                of a link.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link"><td><code>anchor</code></td><td>Overrides the link context (by default the
+                Thing itself identified by its <code>id</code>)
+                with the given URI or IRI.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-sizes--Link"><td><code>sizes</code></td><td>Target attribute that specifies one or more sizes for the referenced icon. 
+                    Only applicable for relation type "icon". The value pattern follows 
+                    {Height}x{Width} (e.g., "16x16", "16x16 32x32").</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-hreflang--Link"><td><code>hreflang</code></td><td>The hreflang attribute specifies the language of a linked document. The value of this must be a valid language tag [[BCP47]].</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table><p class="note" title="hreflang type">
+        The <code>hreflang</code> attribute is allowed to be a <code>string</code> or <code>array</code> in this version of the spec. Depending on the result of [[LINKSET-MEDIA-TYPES]] the values of <code>hrefLang</code> can be restricted to <code>array</code> only.
+	</p>
+     <p>Link relations can be used to describe relations such as to other Things (e.g., a Switch Thing controls a Lamp Thing), to a specific kind of Thing Models (e.g., a Thing Description
+    is an instance of a specific Thing Model), or to further documentations information (e.g., device manual of a Thing). It is recommended to reuse existing and established 
+    <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA.</a>
+    </p>
+        <p>In the following a best practice relation type table is introduced that is recommended to use within WoT <a>Thing Description</a>
+    or <a>Thing Model</a> instances.      
+    </p>
+    <table class="def numbered">
+        <caption>Best practice relation type table</caption>
+        <thead>
+            <tr>
+                <th>Value</th>                
+                <th>Occurrence</th>
+                <th>Explanation</th>
+                <th>Source of value origin</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr >
+                <td>
                     <code>icon</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>Imports an icon associated to the <a>Thing</a> (e.g., for UI purposes).</td>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Imports an icon associated to the <a>Thing</a> (e.g., for UI purposes).</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr >
+                <td>
                     <code>service-doc</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>Relation to a resource that provide (human-readable) documentation or descriptions.</td>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Relation to a resource that provide (human-readable) documentation or descriptions.</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr >
+                <td>
                     <code>alternate</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>
-                    Point to alternative representation of the <a>Thing</a> (i.e. RDF-Turtle, human-readable HTML
-                    document, ...).
-                  </td>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Point to alternative representation of the <a>Thing</a> (i.e. RDF-Turtle, human-readable HTML document, ...).</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr >
+                <td>
                     <code>type</code>
-                  </td>
-                  <td>0..1</td>
-                  <td>
-                    Indicate that the <a>Thing</a> is an instance of the target resource such as to a
-                    <a>Thing Model</a>.
-                  </td>
-                  <td>
+                </td>
+                <td>
+                    0..1
+                </td>
+                <td>Indicate that the <a>Thing</a> is an instance of the target resource such as to a <a>Thing Model</a>.</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr >
+                <td>
                     <code>tm:extends</code>
-                  </td>
-                  <td>0..1</td>
-                  <td>
-                    Extends an existing definition of the target resource such as a <a>Thing Model</a>. Only applicable
-                    for Thing Model definitions.
-                  </td>
-                  <td>W3C WoT Thing Model</td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+                <td>
+                    0..1
+                </td>
+                <td>Extends an existing definition of the target resource such as a <a>Thing Model</a>. Only applicable for Thing Model definitions.</td>
+                <td>
+                    W3C WoT Thing Model
+                </td>
+            </tr>
+            <tr >
+                <td>
                     <code>tm:submodel</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>
-                    Used to compose one or multiple <a>Thing Models</a>. Only applicable for Thing Model definitions.
-                  </td>
-                  <td>W3C WoT Thing Model</td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Used to compose one or multiple <a>Thing Models</a>. Only applicable for Thing Model definitions.</td>
+                <td>
+                    W3C WoT Thing Model
+                </td>
+            </tr>                         
+            <tr >
+                <td>
                     <code>manifest</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>
-                    Point to the web app manifest of a web application which provides, e.g., a user interface with which
-                    a user can interact with the Thing (also see [[APPMANIFEST]]).
-                  </td>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Point to the web app manifest of a web application which provides, e.g., a user interface with which a user can interact with the Thing (also see [[APPMANIFEST]]).</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <code>proxy-to</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>
-                    Target resource provide the address of a proxy. Additional security metadata can be provided using
-                    the <code>proxy</code> field in a <a href="#securityscheme">SecurityScheme</a>.
-                  </td>
-                  <td>W3C WoT Security and WoT Binding Template</td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Target resource provide the address of a proxy. Additional security metadata can be provided using the <code>proxy</code> field in a <a href="#securityscheme">SecurityScheme</a>.</td>
+                <td>
+                    W3C WoT Security and WoT Binding Template
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <code>collection</code>
-                  </td>
-                  <td>0..1</td>
-                  <td>Points to a collections of <a>Things</a>.</td>
-                  <td>
+                </td>
+                <td>
+                    0..1
+                </td>
+                <td>Points to a collections of <a>Things</a>.</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <code>item</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>Points to a <a>Thing</a> that is member of the current <a>Thing</a> collections.</td>
-                  <td>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Points to a <a>Thing</a> that is member of the current <a>Thing</a> collections.</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <code>predecessor-version</code>
-                  </td>
-                  <td>0..1</td>
-                  <td>Points to a previous <a>Thing Description</a> or <a>Thing Model</a> version.</td>
-                  <td>
+                </td>
+                <td>
+                    0..1
+                </td>
+                <td>Points to a previous <a>Thing Description</a> or <a>Thing Model</a> version.</td>
+                <td>
                     <a href="https://www.iana.org/assignments/link-relations">IANA Link Relation</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <code>controlledBy</code>
-                  </td>
-                  <td>0..*</td>
-                  <td>Refers to a <a>Thing</a> that controls the context <a>Thing</a>.</td>
-                  <td>W3C Thing Description</td>
-                </tr>
-              </tbody>
-            </table>
+                </td>
+                <td>
+                    0..*
+                </td>
+                <td>Refers to a <a>Thing</a> that controls the context <a>Thing</a>.</td>
+                <td>
+                    W3C Thing Description
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    </section>
+<section><h3><code>Form</code></h3><p>A form can be viewed as a statement of "To perform an
+          <b><em>operation type</em></b> operation on <b><em>form
+          context</em></b>, make a <b><em>request method</em></b>
+          request to <b><em>submission target</em></b>" where the
+          optional <b><em>form fields</em></b> may further describe
+          the required request. In Thing Descriptions, the
+          <b><em>form context</em></b> is the surrounding Object,
+          such as Properties, Actions, and Events or the Thing
+          itself for meta-interactions.</p><table class="def numbered"><caption>Vocabulary Terms in Form Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-href--Form"><td><code>href</code></td><td>Target IRI of a link or submission target of a
+                form.</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form"><td><code>contentType</code></td><td>Assign a content type based on a media type
+                (e.g., <code>text/plain</code>) and potential
+                parameters (e.g., <code>charset=utf-8</code>) for
+                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form"><td><code>contentCoding</code></td><td>Content coding values indicate an encoding
+                transformation that has been or can be applied to a
+                representation. Content codings are primarily used
+                to allow a representation to be compressed or
+                otherwise usefully transformed without losing the
+                identity of its underlying media type and without
+                loss of information. Examples of content coding
+                include "gzip", "deflate", etc. .</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-security--Form"><td><code>security</code></td><td>Set of security definition names, chosen from
+                those defined in <code>securityDefinitions</code>.
+                These must all be satisfied for access to resources.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form"><td><code>scopes</code></td><td>Set of authorization scope identifiers provided
+                as an array. These are provided in tokens returned
+                by an authorization server and associated with
+                forms in order to identify what resources a client
+                may access and how. The values associated with a
+                form SHOULD be chosen from those defined in an
+                <code>OAuth2SecurityScheme</code> active on that
+                form.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-response--Form"><td><code>response</code></td><td>This optional term can be used if, e.g., the
+                output communication metadata differ from input
+                metadata (e.g., output contentType differ from the
+                input contentType). The response name contains
+                metadata that is only valid for the primary response
+                messages.</td><td>optional</td><td><a href="#expectedresponse"><code>ExpectedResponse</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-additionalResponses--Form"><td><code>additionalResponses</code></td><td>This optional term can be used if additional expected responses
+                are possible, e.g. for error reporting.  Each additional response needs to be 
+                distinguished from others in some way (for example, by specifying
+                a protocol-specific error code), and may also have its own data schema.</td><td>optional</td><td><a>Array</a> of <a href="#additionalexpectedresponse"><code>AdditionalExpectedResponse</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form"><td><code>subprotocol</code></td><td>Indicates the exact mechanism by which an
+                interaction will be accomplished for a given
+                protocol when there are multiple options. For
+                example, for HTTP and Events, it indicates which of
+                several available mechanisms should be used for
+                asynchronous notifications such as long polling
+                (<code>longpoll</code>), WebSub [<cite><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite>]
+                (<code>websub</code>), Server-Sent Events
+                (<code>sse</code>) [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite>] (also known as
+                EventSource). Please note that there is no
+                restriction on the subprotocol selection and other
+                mechanisms can also be announced by this
+                subprotocol term.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)</td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-op--Form"><td><code>op</code></td><td>Indicates the semantic intention of performing
+                the operation(s) described by the form. For
+                example, the Property interaction allows get and
+                set operations. The protocol binding may contain a
+                form for the get operation and a different form for
+                the set operation. The op attribute indicates which
+                form is for which and allows the client to select
+                the correct form for the operation required. op can
+                be assigned one or more interaction verb(s) each
+                representing a semantic intention of an
+                operation.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or <a>Array</a> of <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>, <code>unobserveproperty</code>, <code>invokeaction</code>, <code>queryaction</code>, <code>cancelaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>, <code>readallproperties</code>, <code>writeallproperties</code>, <code>readmultipleproperties</code>, <code>writemultipleproperties</code>, <code>observeallproperties</code>, <code>unobserveallproperties</code>, <code>subscribeallevents</code>, <code>unsubscribeallevents</code>, or <code>queryallactions</code>)</td></tr></tbody></table><p>Possible values for the <code>contentCoding</code>
+          property can be found, e.g., in the <a href=
+          "https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
+          IANA HTTP content coding registry</a>.</p>
+          <p>The list of possible operation types of a form is
+          fixed. As of this version of the specification, it only
+          includes the well-known types necessary to implement the
+          WoT interaction model described in [<cite><a class=
+          "bibref" data-link-type="biblio" href=
+          "#bib-wot-architecture11" title=
+          "Web of Things (WoT) Architecture 1.1">wot-architecture11</a></cite>].
+          Future versions of the standard may extend this list but
+          <span class="rfc2119-assertion" id=
+          "well-known-operation-types-only">operations types
+          MUST be restricted to the values in the
+          table below.</span></p>
+
+        <div id="table-operation-types">
+          <table class="def numbered">
+            <caption>Well-known operation types</caption>
+            <thead>
+              <tr>
+                <th>Operation Type</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>readproperty</td>
+                <td>Identifies the read operation on
+                  Property Affordances to retrieve the
+                  corresponding data.</td>
+              </tr>
+              <tr>
+                <td>writeproperty</td>
+                <td>Identifies the write operation on
+                  Property Affordances to update the
+                  corresponding data.</td>
+              </tr>
+              <tr>
+                <td>observeproperty</td>
+                <td>Identifies the observe operation on
+                  Property Affordances to be notified with
+                  the new data when the Property is
+                  updated.</td>
+              </tr>
+              <tr>
+                <td>unobserveproperty</td>
+                <td>Identifies the unobserve
+                  operation on Property Affordances to stop
+                  the corresponding notifications.</td>
+              </tr>
+              <tr>
+                <td>invokeaction</td>
+                <td>Identifies the invoke operation on
+                  Action Affordances to perform the
+                  corresponding action.</td>
+              </tr>
+              <tr>
+                <td>queryaction</td>
+                <td>Identifies the querying operation on
+                  Action Affordances to get the status of the
+                  corresponding action.</td>
+              </tr>
+              <tr>
+                <td>cancelaction</td>
+                <td>Identifies the cancel operation on
+                  Action Affordances to cancel the ongoing
+                  corresponding action.</td>
+              </tr>
+              <tr>
+                <td>subscribeevent</td>
+                <td>Identifies the subscribe operation
+                  on Event Affordances to be notified by
+                  the Thing when the event occurs.</td>
+              </tr>
+              <tr>
+                <td>unsubscribeevent</td>
+                <td>Identifies the unsubscribe
+                  operation on Event Affordances to stop
+                  the corresponding notifications.</td>
+              </tr>
+              <tr>
+                <td>readallproperties</td>
+                <td>Identifies the readallproperties
+                  operation on a Thing to retrieve the
+                  data of all Properties in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>writeallproperties</td>
+                <td>Identifies the writeallproperties
+                  operation on a Thing to update the
+                  data of all writable Properties in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>readmultipleproperties</td>
+                <td>Identifies the readmultipleproperties
+                  operation on a Thing to retrieve the
+                  data of selected Properties in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>writemultipleproperties</td>
+                <td>Identifies the writemultipleproperties
+                  operation on a Thing to update the
+                  data of selected writable Properties in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>observeallproperties</td>
+                <td>Identifies the observeallproperties operation on
+                  Properties to be notified with new data when any Property is
+                  updated.</td>
+              </tr>
+              <tr>
+                <td>unobserveallproperties</td>
+                <td>Identifies the unobserveallproperties operation on
+                  Properties to stop notifications from all Properties in a 
+                  single interaction.</td>
+              </tr>
+              <tr>
+                <td>queryallactions</td>
+                <td>Identifies the queryallactions operation on a Thing to get the status of
+                 all Actions in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>subscribeallevents</td>
+                <td>Identifies the subscribeallevents operation on Events to subscribe
+                  to notifications from all Events in a single interaction.</td>
+              </tr>
+              <tr>
+                <td>unsubscribeallevents</td>
+                <td>Identifies the unsubscribeallevents operation on Events to unsubscribe
+                  from notifications from all Events in a single interaction.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p>
+          A <a>Thing Description</a> of a WoT <a>producer</a> may have multiple forms entries with, e.g., different 
+          protocol and/or content types declarations that a <a>Consumer</a> could possibly support. In that case 
+          the Consumer may choose any form entry that works (e.g., the protocol and content type is supported) for them. 
+          When one form is chosen, it is expected that the <a>Consumer</a> will continue to use it as long as possible 
+          for every new interaction with the WoT <a>producer</a>.
+        </p>
+
+        <section id="sec-op-data-schema-mapping" class="informative">
+        <h4>Mapping op Values to Data Schemas</h4>
+
+        <p>
+            Protocols that can be used with TDs follow request-response or eventing mechanisms. 
+            The Data Schema of an affordance generally correlates with the <code>op</code> keywords used in <code>forms</code>.
+            The table below informatively summarizes the available data schema related terms with the <code>op</code> keywords.
+        </p>
+        <ul>
+            <li>Consumer to Thing applies for messages sent by the Consumer to the Thing, such as the value for writing a property.</li>
+            <li>Thing to Consumer applies for messages sent by the Thing to the Consumer, such as the value of a property value as the result of reading a property.</li>
+            <li>In case that there is no correlation with the data schema and the operation, it implies that no payload is required for executing the operation or no 
+            payload is expected as a result of the operation.</li>
+        </ul>
+
+        <table class="def numbered">
+        <caption>Mapping op Values to Data Schemas</caption>
+        <thead>
+            <tr>
+            <th>Operation Type</th>
+            <th>Consumer to Thing DataSchema Correlation</th>
+            <th>Thing to Consumer DataSchema Correlation</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+            <td>readproperty</td>
+            <td>No correlation.</td>
+            <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
+            </tr>
+            <tr>
+            <td>writeproperty</td>
+            <td>All fields in the Property Affordance without <code>"readOnly":true</code>.</td>
+            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+            </tr>
+            <tr>
+            <td>observeproperty</td>
+            <td>No correlation.</td>
+            <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
+            </tr>
+            <tr>
+            <td>unobserveproperty</td>
+            <td>No correlation.</td>
+            <td>No correlation.</td>
+            </tr>
+            <tr>
+            <td>invokeaction</td>
+            <td>Value of the <code>input</code> key.</td>
+            <td>Value of the <code>output</code> key.</td>
+            </tr>
+            <tr>
+            <td>queryaction</td>
+            <td>No correlation.</td>
+            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+            </tr>
+            <tr>
+            <td>cancelaction</td>
+            <td>No correlation.</td>
+            <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
+            </tr>
+            <tr>
+            <td>subscribeevent</td>
+            <td>Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code></td>
+            <td>Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code></td>
+            </tr>
+            <tr>
+            <td>unsubscribeevent</td>
+            <td>Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code></td>
+            <td>Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code></td>
+            </tr>
+        </tbody>
+        </table>
+        <p class="note" title="writeproperty and observeproperty relationship">
+            Writing to a property does not necessarily mean that a new value will be sent to the Consumer observing the property. 
+            It depends on the protocol and implementation.
+        </p>
+        <p class="note" title="Further Data Schemas mappings">
+            Further specification of how to map operations to data schemas, as well as mapping meta operations such as <code>readallproperties</code> 
+            can be found in the respective protocol specification of the [[WOT-BINDING-TEMPLATES]].
+        </p>
+        </section>
+
+        <section id="sec-response-usage">
+        <h4>Response-related Terms Usage</h4>
+
+          <p>The optional <code>response</code> name-value pair can
+          be used to provide metadata for the expected response
+          message. 
+          With the core vocabulary, it only includes
+          content type information, but TD Context Extensions could
+          be applied. <span class="rfc2119-assertion" id=
+          "td-expectedResponse-default-contentType">If no
+          <code>response</code> name-value pair is provided, it
+          MUST be assumed
+          that the content type of the response is equal to the
+          content type assigned to the Form instance.</span> Note
+          that <code>contentType</code> within an
+          <code>ExpectedResponse</code> 
+          <a href="#dfn-class" class=
+          "internalDFN" data-link-type="dfn">Class</a> does not
+          have a <a href="#dfn-default-value" class="internalDFN"
+          data-link-type="dfn">Default Value</a>. For instance, if
+          the value of the content type of the form is
+          <code>application/xml</code> the assumed value of the
+          content type of the response will be also
+          <code>application/xml</code>.</p>
+          <p>
+          In some cases additional responses might be possible.
+          One example of this is error responses but in some cases
+          there might also be additional successful responses.
+          In this case, the <code>response</code> name-value pair
+          is still used for the primary response but 
+          <code>additionalResponses</code> may also be provided,
+          whose value is an array of <code>AdditionalExpectedResponse</code>
+          objects.
+          Each additional response must be distinguished in some way from the primary
+          response, either by <code>contentType</code> or by
+          protocol-specific settings such as error code header values.
+          Each additional response may also have a data schema
+          which can differ from the normal output data schema for the
+          interaction.  
+          </p>
+          <p>In some use cases, input and output data might be
+          represented in a different form, for instance an Action
+          that accepts JSON, but returns an image. In such a case,
+          the optional <code>response</code> name-value pair can
+          describe the content type of the expected response.
+          <span class="rfc2119-assertion" id=
+          "td-expectedResponse-contentType">If the content type of
+          the expected response differs from the content type of
+          the form, the <code>Form</code> instance <em class=
+          "rfc2119" title="MUST">MUST</em> include a name-value
+          pair with the name <code>response</code>.</span> 
+          For instance, an <code>ActionAffordance</code> could only
+          accept <code>application/json</code> for its input data,
+          while it will respond with an <code>image/jpeg</code>
+          content type for its output data. In that case the
+          content types differ and the <code>response</code>
+          name-value pair has to be used to provide response
+          content type (<code>image/jpeg</code>) information to the
+          <a href="#dfn-consumer" class="internalDFN"
+          data-link-type="dfn">Consumer</a>.</p>
+          <p>
+          Similar considerations apply to additional responses,
+          although in this case the <code>contentType</code> is optional
+          if it is the same as the input content Type (e.g. JSON).
+          <span class="rfc2119-assertion" id=
+          "td-additionalExpectedResponse-contentType">If the content type of
+          an additional expected response differs from the content type of
+          the form, the <code>Form</code> instance <em class=
+          "rfc2119" title="MUST">MUST</em> include an entry in the array
+          associated with the name <code>additionalResponses</code>
+          that includes a value for the name <code>contentType</code>.</span> 
+          <span class="rfc2119-assertion" id=
+          "td-additionalExpectedResponse-schema">If the data schema of
+          an additional expected response differs from the output data schema of
+          the interaction, the <code>Form</code> instance <em class=
+          "rfc2119" title="MUST">MUST</em> include an entry in the array
+          associated with the name <code>additionalResponses</code> that
+          includes a value for the name <code>schema</code>.</span> 
+          </p>
+          <p>
+            The different cases on the variation of request and response are explained above.
+            The tables at <a href="#contentType-usage"></a> summarize these cases in a concise manner.
+          </p>
           </section>
-          <section>
-            <h3><code>Form</code></h3>
-            <p>
-              A form can be viewed as a statement of "To perform an <b><em>operation type</em></b> operation on
-              <b><em>form context</em></b
-              >, make a <b><em>request method</em></b> request to <b><em>submission target</em></b
-              >" where the optional <b><em>form fields</em></b> may further describe the required request. In Thing
-              Descriptions, the <b><em>form context</em></b> is the surrounding Object, such as Properties, Actions, and
-              Events or the Thing itself for meta-interactions.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in Form Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-href--Form">
-                  <td><code>href</code></td>
-                  <td>Target IRI of a link or submission target of a form.</td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form">
-                  <td><code>contentType</code></td>
-                  <td>
-                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
-                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-rfc2046"
-                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
-                        >RFC2046</a
-                      ></cite
-                    >].
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form">
-                  <td><code>contentCoding</code></td>
-                  <td>
-                    Content coding values indicate an encoding transformation that has been or can be applied to a
-                    representation. Content codings are primarily used to allow a representation to be compressed or
-                    otherwise usefully transformed without losing the identity of its underlying media type and without
-                    loss of information. Examples of content coding include "gzip", "deflate", etc. .
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-security--Form">
-                  <td><code>security</code></td>
-                  <td>
-                    Set of security definition names, chosen from those defined in <code>securityDefinitions</code>.
-                    These must all be satisfied for access to resources.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form">
-                  <td><code>scopes</code></td>
-                  <td>
-                    Set of authorization scope identifiers provided as an array. These are provided in tokens returned
-                    by an authorization server and associated with forms in order to identify what resources a client
-                    may access and how. The values associated with a form SHOULD be chosen from those defined in an
-                    <code>OAuth2SecurityScheme</code> active on that form.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-response--Form">
-                  <td><code>response</code></td>
-                  <td>
-                    This optional term can be used if, e.g., the output communication metadata differ from input
-                    metadata (e.g., output contentType differ from the input contentType). The response name contains
-                    metadata that is only valid for the primary response messages.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="#expectedresponse"><code>ExpectedResponse</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-additionalResponses--Form">
-                  <td><code>additionalResponses</code></td>
-                  <td>
-                    This optional term can be used if additional expected responses are possible, e.g. for error
-                    reporting. Each additional response needs to be distinguished from others in some way (for example,
-                    by specifying a protocol-specific error code), and may also have its own data schema.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a>Array</a> of <a href="#additionalexpectedresponse"><code>AdditionalExpectedResponse</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form">
-                  <td><code>subprotocol</code></td>
-                  <td>
-                    Indicates the exact mechanism by which an interaction will be accomplished for a given protocol when
-                    there are multiple options. For example, for HTTP and Events, it indicates which of several
-                    available mechanisms should be used for asynchronous notifications such as long polling
-                    (<code>longpoll</code>), WebSub [<cite
-                      ><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite
-                    >] (<code>websub</code>), Server-Sent Events (<code>sse</code>) [<cite
-                      ><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite
-                    >] (also known as EventSource). Please note that there is no restriction on the subprotocol
-                    selection and other mechanisms can also be announced by this subprotocol term.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                    (e.g., <code>longpoll</code>, <code>websub</code>, or <code>sse</code>)
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-op--Form">
-                  <td><code>op</code></td>
-                  <td>
-                    Indicates the semantic intention of performing the operation(s) described by the form. For example,
-                    the Property interaction allows get and set operations. The protocol binding may contain a form for
-                    the get operation and a different form for the set operation. The op attribute indicates which form
-                    is for which and allows the client to select the correct form for the operation required. op can be
-                    assigned one or more interaction verb(s) each representing a semantic intention of an operation.
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> or
-                    <a>Array</a> of
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a> (one
-                    of <code>readproperty</code>, <code>writeproperty</code>, <code>observeproperty</code>,
-                    <code>unobserveproperty</code>, <code>invokeaction</code>, <code>queryaction</code>,
-                    <code>cancelaction</code>, <code>subscribeevent</code>, <code>unsubscribeevent</code>,
-                    <code>readallproperties</code>, <code>writeallproperties</code>,
-                    <code>readmultipleproperties</code>, <code>writemultipleproperties</code>,
-                    <code>observeallproperties</code>, <code>unobserveallproperties</code>,
-                    <code>subscribeallevents</code>, <code>unsubscribeallevents</code>, or <code>queryallactions</code>)
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              Possible values for the <code>contentCoding</code> property can be found, e.g., in the
-              <a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">
-                IANA HTTP content coding registry</a
-              >.
-            </p>
-            <p>
-              The list of possible operation types of a form is fixed. As of this version of the specification, it only
-              includes the well-known types necessary to implement the WoT interaction model described in [<cite
-                ><a
-                  class="bibref"
-                  data-link-type="biblio"
-                  href="#bib-wot-architecture11"
-                  title="Web of Things (WoT) Architecture 1.1"
-                  >wot-architecture11</a
-                ></cite
-              >]. Future versions of the standard may extend this list but
-              <span class="rfc2119-assertion" id="well-known-operation-types-only"
-                >operations types MUST be restricted to the values in the table below.</span
-              >
-            </p>
-
-            <div id="table-operation-types">
-              <table class="def numbered">
-                <caption>
-                  Well-known operation types
-                </caption>
-                <thead>
-                  <tr>
-                    <th>Operation Type</th>
-                    <th>Description</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>readproperty</td>
-                    <td>Identifies the read operation on Property Affordances to retrieve the corresponding data.</td>
-                  </tr>
-                  <tr>
-                    <td>writeproperty</td>
-                    <td>Identifies the write operation on Property Affordances to update the corresponding data.</td>
-                  </tr>
-                  <tr>
-                    <td>observeproperty</td>
-                    <td>
-                      Identifies the observe operation on Property Affordances to be notified with the new data when the
-                      Property is updated.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>unobserveproperty</td>
-                    <td>
-                      Identifies the unobserve operation on Property Affordances to stop the corresponding
-                      notifications.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>invokeaction</td>
-                    <td>Identifies the invoke operation on Action Affordances to perform the corresponding action.</td>
-                  </tr>
-                  <tr>
-                    <td>queryaction</td>
-                    <td>
-                      Identifies the querying operation on Action Affordances to get the status of the corresponding
-                      action.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>cancelaction</td>
-                    <td>
-                      Identifies the cancel operation on Action Affordances to cancel the ongoing corresponding action.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>subscribeevent</td>
-                    <td>
-                      Identifies the subscribe operation on Event Affordances to be notified by the Thing when the event
-                      occurs.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>unsubscribeevent</td>
-                    <td>
-                      Identifies the unsubscribe operation on Event Affordances to stop the corresponding notifications.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>readallproperties</td>
-                    <td>
-                      Identifies the readallproperties operation on a Thing to retrieve the data of all Properties in a
-                      single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>writeallproperties</td>
-                    <td>
-                      Identifies the writeallproperties operation on a Thing to update the data of all writable
-                      Properties in a single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>readmultipleproperties</td>
-                    <td>
-                      Identifies the readmultipleproperties operation on a Thing to retrieve the data of selected
-                      Properties in a single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>writemultipleproperties</td>
-                    <td>
-                      Identifies the writemultipleproperties operation on a Thing to update the data of selected
-                      writable Properties in a single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>observeallproperties</td>
-                    <td>
-                      Identifies the observeallproperties operation on Properties to be notified with new data when any
-                      Property is updated.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>unobserveallproperties</td>
-                    <td>
-                      Identifies the unobserveallproperties operation on Properties to stop notifications from all
-                      Properties in a single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>queryallactions</td>
-                    <td>
-                      Identifies the queryallactions operation on a Thing to get the status of all Actions in a single
-                      interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>subscribeallevents</td>
-                    <td>
-                      Identifies the subscribeallevents operation on Events to subscribe to notifications from all
-                      Events in a single interaction.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>unsubscribeallevents</td>
-                    <td>
-                      Identifies the unsubscribeallevents operation on Events to unsubscribe from notifications from all
-                      Events in a single interaction.
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            <p>
-              A <a>Thing Description</a> of a WoT <a>producer</a> may have multiple forms entries with, e.g., different
-              protocol and/or content types declarations that a <a>Consumer</a> could possibly support. In that case the
-              Consumer may choose any form entry that works (e.g., the protocol and content type is supported) for them.
-              When one form is chosen, it is expected that the <a>Consumer</a> will continue to use it as long as
-              possible for every new interaction with the WoT <a>producer</a>.
-            </p>
-
-            <section id="sec-op-data-schema-mapping" class="informative">
-              <h4>Mapping op Values to Data Schemas</h4>
-
-              <p>
-                Protocols that can be used with TDs follow request-response or eventing mechanisms. The Data Schema of
-                an affordance generally correlates with the <code>op</code> keywords used in <code>forms</code>. The
-                table below informatively summarizes the available data schema related terms with the
-                <code>op</code> keywords.
-              </p>
-              <ul>
-                <li>
-                  Consumer to Thing applies for messages sent by the Consumer to the Thing, such as the value for
-                  writing a property.
-                </li>
-                <li>
-                  Thing to Consumer applies for messages sent by the Thing to the Consumer, such as the value of a
-                  property value as the result of reading a property.
-                </li>
-                <li>
-                  In case that there is no correlation with the data schema and the operation, it implies that no
-                  payload is required for executing the operation or no payload is expected as a result of the
-                  operation.
-                </li>
-              </ul>
-
-              <table class="def numbered">
-                <caption>
-                  Mapping op Values to Data Schemas
-                </caption>
-                <thead>
-                  <tr>
-                    <th>Operation Type</th>
-                    <th>Consumer to Thing DataSchema Correlation</th>
-                    <th>Thing to Consumer DataSchema Correlation</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>readproperty</td>
-                    <td>No correlation.</td>
-                    <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
-                  </tr>
-                  <tr>
-                    <td>writeproperty</td>
-                    <td>All fields in the Property Affordance without <code>"readOnly":true</code>.</td>
-                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-                  </tr>
-                  <tr>
-                    <td>observeproperty</td>
-                    <td>No correlation.</td>
-                    <td>All fields in the Property Affordance without <code>"writeOnly":true</code>.</td>
-                  </tr>
-                  <tr>
-                    <td>unobserveproperty</td>
-                    <td>No correlation.</td>
-                    <td>No correlation.</td>
-                  </tr>
-                  <tr>
-                    <td>invokeaction</td>
-                    <td>Value of the <code>input</code> key.</td>
-                    <td>Value of the <code>output</code> key.</td>
-                  </tr>
-                  <tr>
-                    <td>queryaction</td>
-                    <td>No correlation.</td>
-                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-                  </tr>
-                  <tr>
-                    <td>cancelaction</td>
-                    <td>No correlation.</td>
-                    <td>No correlation. <code>additionalResponses</code> can be used in the form level.</td>
-                  </tr>
-                  <tr>
-                    <td>subscribeevent</td>
-                    <td>
-                      Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code>
-                    </td>
-                    <td>
-                      Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>unsubscribeevent</td>
-                    <td>
-                      Value of the <code>subscription</code> key with all fields without <code>"readOnly":true</code>
-                    </td>
-                    <td>
-                      Value of the <code>subscription</code> key with all fields without <code>"writeOnly":true</code>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <p class="note" title="writeproperty and observeproperty relationship">
-                Writing to a property does not necessarily mean that a new value will be sent to the Consumer observing
-                the property. It depends on the protocol and implementation.
-              </p>
-              <p class="note" title="Further Data Schemas mappings">
-                Further specification of how to map operations to data schemas, as well as mapping meta operations such
-                as <code>readallproperties</code>
-                can be found in the respective protocol specification of the [[WOT-BINDING-TEMPLATES]].
-              </p>
-            </section>
-
-            <section id="sec-response-usage">
-              <h4>Response-related Terms Usage</h4>
-
-              <p>
-                The optional <code>response</code> name-value pair can be used to provide metadata for the expected
-                response message. With the core vocabulary, it only includes content type information, but TD Context
-                Extensions could be applied.
-                <span class="rfc2119-assertion" id="td-expectedResponse-default-contentType"
-                  >If no <code>response</code> name-value pair is provided, it MUST be assumed that the content type of
-                  the response is equal to the content type assigned to the Form instance.</span
-                >
-                Note that <code>contentType</code> within an
-                <code>ExpectedResponse</code>
-                <a href="#dfn-class" class="internalDFN" data-link-type="dfn">Class</a> does not have a
-                <a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">Default Value</a>. For instance,
-                if the value of the content type of the form is <code>application/xml</code> the assumed value of the
-                content type of the response will be also <code>application/xml</code>.
-              </p>
-              <p>
-                In some cases additional responses might be possible. One example of this is error responses but in some
-                cases there might also be additional successful responses. In this case, the
-                <code>response</code> name-value pair is still used for the primary response but
-                <code>additionalResponses</code> may also be provided, whose value is an array of
-                <code>AdditionalExpectedResponse</code> objects. Each additional response must be distinguished in some
-                way from the primary response, either by <code>contentType</code> or by protocol-specific settings such
-                as error code header values. Each additional response may also have a data schema which can differ from
-                the normal output data schema for the interaction.
-              </p>
-              <p>
-                In some use cases, input and output data might be represented in a different form, for instance an
-                Action that accepts JSON, but returns an image. In such a case, the optional
-                <code>response</code> name-value pair can describe the content type of the expected response.
-                <span class="rfc2119-assertion" id="td-expectedResponse-contentType"
-                  >If the content type of the expected response differs from the content type of the form, the
-                  <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include a name-value pair with
-                  the name <code>response</code>.</span
-                >
-                For instance, an <code>ActionAffordance</code> could only accept <code>application/json</code> for its
-                input data, while it will respond with an <code>image/jpeg</code> content type for its output data. In
-                that case the content types differ and the <code>response</code>
-                name-value pair has to be used to provide response content type (<code>image/jpeg</code>) information to
-                the
-                <a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">Consumer</a>.
-              </p>
-              <p>
-                Similar considerations apply to additional responses, although in this case the
-                <code>contentType</code> is optional if it is the same as the input content Type (e.g. JSON).
-                <span class="rfc2119-assertion" id="td-additionalExpectedResponse-contentType"
-                  >If the content type of an additional expected response differs from the content type of the form, the
-                  <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include an entry in the array
-                  associated with the name <code>additionalResponses</code> that includes a value for the name
-                  <code>contentType</code>.</span
-                >
-                <span class="rfc2119-assertion" id="td-additionalExpectedResponse-schema"
-                  >If the data schema of an additional expected response differs from the output data schema of the
-                  interaction, the <code>Form</code> instance <em class="rfc2119" title="MUST">MUST</em> include an
-                  entry in the array associated with the name <code>additionalResponses</code> that includes a value for
-                  the name <code>schema</code>.</span
-                >
-              </p>
-              <p>
-                The different cases on the variation of request and response are explained above. The tables at
-                <a href="#contentType-usage"></a> summarize these cases in a concise manner.
-              </p>
-            </section>
           </section>
-          <section>
-            <h3><code>ExpectedResponse</code></h3>
-            <p>Communication metadata describing the expected response message for the primary response.</p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in ExpectedResponse Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse">
-                  <td><code>contentType</code></td>
-                  <td>
-                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
-                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-rfc2046"
-                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
-                        >RFC2046</a
-                      ></cite
-                    >].
-                  </td>
-                  <td>mandatory</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-          <section>
-            <h3><code>AdditionalExpectedResponse</code></h3>
-            <p>Communication metadata describing the expected response message for additional responses.</p>
-            <table class="def numbered">
-              <caption>
-                Vocabulary Terms in AdditionalExpectedResponse Level
-              </caption>
-              <thead>
-                <tr>
-                  <th><a>Vocabulary term</a></th>
-                  <th>Description</th>
-                  <th>Assignment</th>
-                  <th>Type</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="rfc2119-table-assertion" id="td-vocab-success--AdditionalExpectedResponse">
-                  <td><code>success</code></td>
-                  <td>Signals if an additional response should not be considered an error.</td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-contentType--AdditionalExpectedResponse">
-                  <td><code>contentType</code></td>
-                  <td>
-                    Assign a content type based on a media type (e.g., <code>text/plain</code>) and potential parameters
-                    (e.g., <code>charset=utf-8</code>) for the media type [<cite
-                      ><a
-                        class="bibref"
-                        data-link-type="biblio"
-                        href="#bib-rfc2046"
-                        title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types"
-                        >RFC2046</a
-                      ></cite
-                    >].
-                  </td>
-                  <td><a href="#sec-default-values">with default</a></td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-                <tr class="rfc2119-table-assertion" id="td-vocab-schema--AdditionalExpectedResponse">
-                  <td><code>schema</code></td>
-                  <td>
-                    Used to define the output data schema for an additional response if it differs from the default
-                    output data schema. Rather than a <code>DataSchema</code> object, the name of a previous definition
-                    given in a <code>schemaDefinitions</code> map must be used.
-                  </td>
-                  <td>optional</td>
-                  <td>
-                    <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
+<section><h3><code>ExpectedResponse</code></h3><p>Communication metadata describing the expected
+          response message for the primary response.</p><table class="def numbered"><caption>Vocabulary Terms in ExpectedResponse Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type
+                (e.g., <code>text/plain</code>) and potential
+                parameters (e.g., <code>charset=utf-8</code>) for
+                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td>mandatory</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
+<section><h3><code>AdditionalExpectedResponse</code></h3><p>Communication metadata describing the expected
+          response message for additional responses.</p><table class="def numbered"><caption>Vocabulary Terms in AdditionalExpectedResponse Level</caption><thead><tr><th><a>Vocabulary term</a></th><th>Description</th><th>Assignment</th><th>Type</th></tr></thead><tbody><tr class="rfc2119-table-assertion" id="td-vocab-success--AdditionalExpectedResponse"><td><code>success</code></td><td>Signals if an additional response should not be considered an error.</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-contentType--AdditionalExpectedResponse"><td><code>contentType</code></td><td>Assign a content type based on a media type
+                (e.g., <code>text/plain</code>) and potential
+                parameters (e.g., <code>charset=utf-8</code>) for
+                the media type [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>].</td><td><a href="#sec-default-values">with default</a></td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr>
+<tr class="rfc2119-table-assertion" id="td-vocab-schema--AdditionalExpectedResponse"><td><code>schema</code></td><td>Used to define the output data schema 
+                for an additional response if it differs from the default
+                output data schema. 
+                Rather than a <code>DataSchema</code> object, the
+                name of a previous definition given in a 
+                <code>schemaDefinitions</code> map must be used.</td><td>optional</td><td><a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td></tr></tbody></table></section>
         </section>
       </section>
       <section id="sec-default-values">
@@ -6965,9 +5275,9 @@
 
         <p>
           With the <a>TD Context Extensions</a> in a Thing Description, the communication metadata can be supplemented
-          or new <a>Bindings</a> added through additional <a>Vocabulary Terms</a> serialized into JSON objects
-          representing a <code>Form</code> instance. Please see <a href="#binding-templates"></a> for further
-          information.
+          via <a>Bindings</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added through
+          additional <a>Vocabulary Terms</a> serialized into JSON objects representing a <code>Form</code> instance.
+          Please see <a href="#bindings"></a> for further information.
         </p>
       </section>
 
@@ -7043,15 +5353,19 @@
       </section>
     </section>
 
-    <section id="binding-templates">
-      <h2>Binding Templates</h2>
-      <section id="bindings-old-abstract">
-        <h3>Old Abstract</h3>
+    <section id="bindings">
+      <h2>Bindings</h2>
         <p>
-          W3C Web of Things enables applications to interact with and orchestrate connected Things at the Web scale. The
-          standardized abstract interaction model exposed by the WoT Thing Description enables applications to scale and
-          evolve independently of the individual Things.
-        </p>
+          Every message sent from a Consumer to the Thing and back needs to follow a network protocol, despite the Property, Action, Event abstraction provided by WoT.
+          The operations in the form level need to be bound to how the message needs to look like over the network.
+          Thus, every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>.
+          For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can then
+          infer the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP and it should expect HTTP-specific
+          terms in the form instance.
+          Furthermore, the payloads described by the <a>Data Schema</a> in the affordance level need to be serialized to the correct payload format.
+          Similar to how operations are bound to protocol messages, the
+       </p>
+
         <p>
           Many network-level protocols, standards and platforms for connected Things have already been developed, and
           have millions of devices deployed in the field today. These standards are converging on a common set of

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <!-- <link rel="stylesheet" href="testing/atrisk.css"> -->
     <meta charset="utf-8" />
     <meta name="color-scheme" content="light dark" />
-    <title>Web of Things (WoT) Thing Description - Next</title>
+    <title>Web of Things (WoT) Thing Description 2.0</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
       var respecConfig = {
@@ -14,7 +14,7 @@
         // previousPublishDate: "2023-12-05",
         prevRecURI: "https://www.w3.org/TR/2023/REC-wot-thing-description11-20231205/",
         // implementationReportURI: "https://w3c.github.io/wot-thing-description/testing/report11.html",
-        shortName: "wot-thing-description-next", // temporary for now
+        shortName: "wot-thing-description-2.0",
         copyrightStart: 2017,
         noLegacyStyle: true,
         inlineCSS: true,
@@ -395,9 +395,9 @@
     <section id="abstract">
       <p>
         This document describes a formal information model and a common representation for a Web of Things (WoT) Thing
-        Description Next Version. A Thing Description describes the metadata and interfaces of <a>Things</a>, where a
-        <a>Thing</a> is an abstraction of a physical or virtual entity that provides interactions to and participates in
-        the Web of Things. Thing Descriptions provide a set of interactions based on a small vocabulary that makes it
+        Description (TD), Version 2.0. A Thing Description describes the metadata and interfaces of <a>Things</a>, where
+        a <a>Thing</a> is an abstraction of a physical or virtual entity that provides interactions to and participates
+        in the Web of Things. Thing Descriptions provide a set of interactions based on a small vocabulary that makes it
         possible both to integrate diverse devices and to allow diverse applications to interoperate. Thing
         Descriptions, by default, are encoded in a JSON format that also allows JSON-LD processing. The latter provides
         a powerful foundation to represent knowledge about <a>Things</a> in a machine-understandable way. A Thing
@@ -9996,7 +9996,7 @@
             assertion (td-security-no-secrets) in Section <a href="#securityscheme"></a>
           </li>
           <li>Section <a href="#form-additionalResponses"></a> has been newly added.</li>
-          <li>Remove TD Context Extensions CoAP example in Section <a href="#adding-protocol-bindings"></a></li>
+          <li>Remove TD Context Extensions CoAP example in Section <a href="#adding-bindings"></a></li>
           <li>
             Remove reference to Binding Document in assertion (bindings-requirements-scheme) in Section
             <a href="#protocol-bindings"></a>

--- a/index.html
+++ b/index.html
@@ -7099,12 +7099,12 @@
         In summary, Bindings enable a Thing Description to be adapted to a specific protocol, data payload formats or
         both in specific ways. This is done through URI Schemes, additional descriptive vocabularies, Thing Models and
         examples that aim to guide the implementors of Things and Consumers alike. This section explains the overall
-        mechanism and gives basic guidance on creating new Bindings. The [[WOT-BINDINGS-REGISTRY]] contains the a
-        registry (list) of existing Bindings as well the requirements to follow to register new entries to the registry.
+        mechanism and gives basic guidance on creating new Bindings. The [[WOT-BINDINGS-REGISTRY]] contains a registry
+        (list) of existing Bindings as well the requirements to follow to register new entries to the registry.
       </p>
 
       <p>
-        When producting a TD for a particular IoT device, the corresponding Binding can be used to look up the
+        When producing a TD for a particular IoT device, the corresponding Binding can be used to look up the
         communication metadata that is to be provided in the <a>Thing Description</a>. [[[#fig-building-block]]] shows
         how Bindings are used. Based on the protocol or media type, a TD is created. The Consumer that is processing a
         TD implements the required Bindings that are present in the TD by including a corresponding protocol stack and
@@ -7368,7 +7368,7 @@
               additional parameters. In this specific case, the forms describe that reading this property with
               <code>http</code> or <code>coap</code> result in different content types. For structured media types, a
               Data Schema is generally provided in the affordance level as explained in
-              [[[#payload-bindings-dataschema]]] and [[#sec-data-schema-vocabulary-definition"]]. However, for
+              [[[#payload-bindings-dataschema]]] and [[[#sec-data-schema-vocabulary-definition]]]. However, for
               unstructured data such as images and videos, a Data Schema is typically not available.
             </p>
 
@@ -7427,7 +7427,7 @@
             <h6>Data Schemas</h6>
 
             <p>
-              Data Schema, as explained in [[#sec-data-schema-vocabulary-definition"]], describes the structure of the
+              Data Schema, as explained in [[[#sec-data-schema-vocabulary-definition]]], describes the structure of the
               messages, which are used together with media types. Even though it is largely inspired by JSON Schema
               [[json-schema]], it can be used for describing other payload types such as [[XML]], string-encoded images,
               bit representations of integers, etc. Data Schema SHOULD be used in addition to the media types.
@@ -7436,7 +7436,7 @@
               Depending on the case, the structure of the messages can be anything from a simple number to arrays or
               objects with multiple levels of nesting. Existing IoT Platforms and Standards have certain payload formats
               with variations on how the data is structured. As explained in
-              [[#sec-data-schema-vocabulary-definition"]], Data Schema can be used in a TD in one of the following
+              [[[#sec-data-schema-vocabulary-definition]]], Data Schema can be used in a TD in one of the following
               places:
             </p>
             <ul>

--- a/index.template.html
+++ b/index.template.html
@@ -4104,7 +4104,7 @@
         In summary, Bindings enable a Thing Description to be adapted to a specific protocol, data payload formats or
         both in specific ways. This is done through URI Schemes, additional descriptive vocabularies, Thing Models and
         examples that aim to guide the implementors of Things and Consumers alike. This section explains the overall
-        mechanism and gives basic guidance on creating new Bindings. The [[WOT-BINDINGS-REGISTRY]] contains the a
+        mechanism and gives basic guidance on creating new Bindings. The [[WOT-BINDINGS-REGISTRY]] contains a
         registry (list) of existing Bindings as well the requirements to follow to register new entries to the registry.
       </p>
 

--- a/index.template.html
+++ b/index.template.html
@@ -150,6 +150,14 @@
             publisher: "W3C",
             date: "July 2021"
           },
+          "WOT-BINDINGS-REGISTRY": {
+            title: "Web of Things (WoT) Bindings Registry",
+            //, href: "https://www.w3.org/TR/wot-bindings-registry/"
+            href: "https://w3c.github.io/wot-bindings-registry/",
+            authors: ["TODO"], //TODO: sync authors
+            publisher: "W3C",
+            date: "TODO" //TODO: Add publication date
+          },
           "MQTT": {
             title: "MQTT Version 3.1.1",
             href: "http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html",
@@ -778,11 +786,10 @@
           <code>href</code> is defined within the Forms level. Even if not defined, other levels can be used such as
           Links level.
         </dd>
-        <dt><dfn id="dfn-subspecification">Binding Template Subspecification</dfn>, <dfn>subspecification</dfn></dt>
+        <dt><dfn id="dfn-binding-specification">Binding Specification</dfn></dt>
         <dd>
-          A binding template document that is published separately from this document that specifies a binding template
-          for a protocol, payload format or platform. All binding template subspecifications respect the rules set in
-          the <a href="binding-templates">Binding Templates</a> section.
+          A binding specification is a document that specifies a binding
+          for a protocol or payload format or both. All bindings follow the rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
         </dd>
       </dl>
 
@@ -3970,9 +3977,9 @@
 
         <p>
           With the <a>TD Context Extensions</a> in a Thing Description, the communication metadata can be supplemented
-          or new <a>Bindings</a> added through additional <a>Vocabulary Terms</a> serialized into JSON objects
-          representing a <code>Form</code> instance. Please see <a href="#binding-templates"></a> for further
-          information.
+          via <a>Bindings</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added through
+          additional <a>Vocabulary Terms</a> serialized into JSON objects representing a <code>Form</code> instance.
+          Please see <a href="#bindings"></a> for further information.
         </p>
       </section>
 
@@ -4048,15 +4055,19 @@
       </section>
     </section>
 
-    <section id="binding-templates">
-      <h2>Binding Templates</h2>
-      <section id="bindings-old-abstract">
-        <h3>Old Abstract</h3>
+    <section id="bindings">
+      <h2>Bindings</h2>
         <p>
-          W3C Web of Things enables applications to interact with and orchestrate connected Things at the Web scale. The
-          standardized abstract interaction model exposed by the WoT Thing Description enables applications to scale and
-          evolve independently of the individual Things.
-        </p>
+          Every message sent from a Consumer to the Thing and back needs to follow a network protocol, despite the Property, Action, Event abstraction provided by WoT.
+          The operations in the form level need to be bound to how the message needs to look like over the network.
+          Thus, every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>.
+          For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can then
+          infer the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP and it should expect HTTP-specific
+          terms in the form instance.
+          Furthermore, the payloads described by the <a>Data Schema</a> in the affordance level need to be serialized to the correct payload format.
+          Similar to how operations are bound to protocol messages, the
+       </p>
+
         <p>
           Many network-level protocols, standards and platforms for connected Things have already been developed, and
           have millions of devices deployed in the field today. These standards are converging on a common set of

--- a/index.template.html
+++ b/index.template.html
@@ -791,6 +791,12 @@
           A binding specification is a document that specifies a binding for a protocol, a payload format, or both. All
           bindings follow the rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
         </dd>
+        <dt><dfn id="dfn-binding-instance">Binding Instance</dfn></dt>
+        <dd>
+          A binding instance is a form instance in a Thing Description containing a specific binding. For example, an
+          HTTP Binding instance is a <a>Form</a> which has <code>href</code> starting with <code>http://</code> or
+          <code>https://</code>.
+        </dd>
       </dl>
 
       <p>These definitions are further developed in <a href="#preliminary-definitions"></a>.</p>
@@ -4064,7 +4070,7 @@
         to have a submission target, given by the <code>href</code> member, as indicated in <a>Form</a>. For instance,
         if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can infer that the
         <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific terms in
-        an instance of this form.
+        an instance of this form. See [[[#protocol-bindings]]] for more explanation and examples.
       </p>
 
       <p>
@@ -4076,14 +4082,17 @@
         messages coming from the <a>Thing</a>, the <a>Consumer</a> can deserialize the data and present it to the
         application level. For example, a <a>Consumer</a> implemented in Python can read
         <code>application/json</code> as the value of <code>contentType</code> and serialize a Python dictionary data
-        structure into a JSON object.
+        structure into a JSON object. See [[[#payload-bindings]]] for more explanation and examples.
       </p>
 
       <p>
         The mechanism above are called Bindings in the Web of Things and a specific example is illustrated in
-        [[[#fig-mechanism]]]. Bindings enable a Thing Description to be adapted to a specific protocol, data payload
-        formats or both in specific ways. This is done through URI Schemes, additional descriptive vocabularies, Thing
-        Models and examples that aim to guide the implementors of Things and Consumers alike.
+        [[[#fig-mechanism]]] with an excerpt of a TD of a robot arm with of HTTP and JSON Bindings. Here, the Consumer
+        intends to invoke an action of the robot arm (<code>goTo</code>) in order to move it to the position x equals 12
+        and y equals 100. In order to do so, it creates the correct payload, serializes it and sends it using the
+        correct protocol options. The Thing gets the message over the network and responds with a message that
+        corresponds to its TD. Other protocols, payload formats or their combination are possible and are explained in
+        [[[#binding-overview]]].
       </p>
 
       <figure id="fig-mechanism">
@@ -4092,119 +4101,44 @@
       </figure>
 
       <p>
-        This section explains the overall mechanism and gives basic guidance on creating new Bindings. The
-        [[WOT-BINDINGS-REGISTRY]] contains the a registry (list) of existing Bindings as well the requirements to follow
-        to register new entries to the registry.
+        In summary, Bindings enable a Thing Description to be adapted to a specific protocol, data payload formats or
+        both in specific ways. This is done through URI Schemes, additional descriptive vocabularies, Thing Models and
+        examples that aim to guide the implementors of Things and Consumers alike. This section explains the overall
+        mechanism and gives basic guidance on creating new Bindings. The [[WOT-BINDINGS-REGISTRY]] contains the a
+        registry (list) of existing Bindings as well the requirements to follow to register new entries to the registry.
       </p>
 
-      <section id="binding-introduction">
-        <h4>Introduction to Binding Templates</h4>
-        <p>
-          IoT addresses multiple use cases from different application domains, while requiring different deployment
-          patterns for devices. This results in different protocols and media types, creating the central challenge for
-          the Web of Things: enabling interactions with the plethora of different <a>IoT platforms</a> and devices that
-          do not follow any particular standard, but provide an eligible interface over a suitable network protocol. WoT
-          is addressing this challenge through Binding Templates.
-        </p>
+      <p>
+        When producting a TD for a particular IoT device, the corresponding Binding can be used to look up the
+        communication metadata that is to be provided in the <a>Thing Description</a>. [[[#fig-building-block]]] shows
+        how Bindings are used. Based on the protocol or media type, a TD is created. The Consumer that is processing a
+        TD implements the required Bindings that are present in the TD by including a corresponding protocol stack and
+        media type encoder/decoder by configuring the stack (or its messages) according to the information given in the
+        TD such as serialization format of the messages and header options.
+      </p>
 
-        <p>
-          Binding Templates consist of multiple specifications, referred to as a <a>subspecification</a> in this
-          document, that enable an application client (a WoT <a>Consumer</a>) to interact, using WoT Thing
-          Description[[WOT-THING-DESCRIPTION]] (TD), with Things that exhibit diverse protocols, payload formats and a
-          combination of these in platforms and frameworks. The mechanism that allows Consumers to interact with a
-          variety of Things is called the Binding Mechanism, without which TDs could not build Hypermedia Controls as
-          explained in the [[WOT-ARCHITECTURE]].
-        </p>
+      <figure id="fig-building-block">
+        <img
+          src="visualization/binding-templates.svg"
+          alt="Platforms, Protocols and Media Types as building blocks for binding templates and TD"
+        />
+        <figcaption>Platforms, Protocols and Media Types as building blocks for binding templates and TD</figcaption>
+      </figure>
 
-        <p>
-          When describing a particular IoT device or platform, the corresponding Binding Template can be used to look up
-          the communication metadata that is to be provided in the <a>Thing Description</a> to support that platform.
-          [[[#fig-building-block]]] shows how Binding Templates are used. Based on the protocol, media type or platform
-          binding template, a TD is created. The Consumer that is processing a TD implements the required Binding
-          Template that is present in the TD by including a corresponding protocol stack, media type encoder/decoder or
-          platform stack and by configuring the stack (or its messages) according to the information given in the TD
-          such as serialization format of the messages and header options.
-        </p>
+      <p class="note">
+        The editors of this specification also recommend reading the related chapters in [[WOT-ARCHITECTURE]], such as
+        <a href="https://www.w3.org/TR/wot-architecture11/#sec-binding-templates"
+          >WoT Binding Templates Building Block</a
+        >, <a href="https://www.w3.org/TR/wot-architecture11/#sec-hypermedia-controls">Hypermedia Controls</a>,
+        <a href="https://www.w3.org/TR/wot-architecture11/#sec-protocol-bindings">Protocol Bindings</a> and
+        <a href="https://www.w3.org/TR/wot-architecture11/#media-types">Media Types</a>.
+      </p>
 
-        <figure id="fig-building-block">
-          <img
-            src="visualization/binding-templates.svg"
-            alt="Platforms, Protocols and Media Types as building blocks for binding templates and TD"
-          />
-          <figcaption>Platforms, Protocols and Media Types as building blocks for binding templates and TD</figcaption>
-        </figure>
-
-        <p>
-          Each Interaction Affordance in a TD needs to have a binding to a protocol and to a payload format.
-          [[[#fig-mechanism]]] below illustrates an excerpt of a TD of a robot arm with of HTTP and JSON bindings. Here,
-          the Consumer intends to invoke an action of the robot arm (<code>goTo</code>) in order to move it to the
-          position x equals 12 and y equals 100. In order to do so, it creates the correct payload, serializes it and
-          sends it using the correct protocol options. The Thing gets the message over the network and responds with a
-          message that corresponds to its TD. Other protocols, payload formats or their combination are possible and are
-          explained in [[[#binding-overview]]].
-        </p>
-
-        <p class="ednote">
-          The editors also recommend reading the related chapters in [[WOT-ARCHITECTURE]], such as
-          <a href="https://www.w3.org/TR/wot-architecture11/#sec-binding-templates"
-            >WoT Binding Templates Building Block</a
-          >, <a href="https://www.w3.org/TR/wot-architecture11/#sec-hypermedia-controls">Hypermedia Controls</a>,
-          <a href="https://www.w3.org/TR/wot-architecture11/#sec-protocol-bindings">Protocol Bindings</a> and
-          <a href="https://www.w3.org/TR/wot-architecture11/#media-types">Media Types</a>.
-        </p>
-      </section>
-
-      <section id="binding-overview">
-        <h4>Binding Template Mechanisms</h4>
-
-        <p>
-          TDs can be bound to specific protocols, payload formats and platforms. This is possible through the three core
-          mechanisms that allow WoT to be used in various domains and scenarios. This section explains how these binding
-          mechanism types are structured, should be specified, and links to corresponding binding documents
-          (subspecifications). These 3 types of mechanisms are:
-        </p>
-        <ul>
-          <li>
-            <b>Protocols</b>: Application layer protocols (e.g., HTTP[[?RFC7231]], CoAP[[?RFC7252]], MQTT[[?MQTT]],
-            etc.) whose different message types are mapped to the WoT Thing Description[[WOT-THING-DESCRIPTION]] forms
-            via reusable vocabulary and extensions.
-          </li>
-          <li>
-            <b>Payloads</b>: Different payload formats and media types [[IANA-MEDIA-TYPES]] which can be represented in
-            a TD via Data Schemas or forms.
-          </li>
-          <li>
-            <b>Platforms</b>: Platforms and frameworks who combine the use of protocols and payloads in a certain way,
-            which can be represented via entire Thing Models described by the [[WOT-THING-DESCRIPTION]] or examples of
-            TDs.
-          </li>
-        </ul>
-
-        <p>
-          Each <a>Binding Template Subspecification</a> is an independent document that has a separate list of authors
-          and publication date. This section explains the binding mechanism by giving requirements per respective
-          binding category and links to the respective subspecification. These can be found in sections
-          [[[#protocol-bindings]]], [[[#payload-bindings]]] and [[[#platform-bindings]]].
-        </p>
-
-        <figure id="fig-overview">
-          <img
-            src="visualization/binding-templates-overview.drawio.svg"
-            alt="Binding Templates Overview and the relationships between each document type"
-          />
-          <figcaption>Binding Templates Overview and the Relationships between each Document Type</figcaption>
-        </figure>
-
-        <p>
-          Each Protocol and Payload Binding Template is specified in a way that they stay independent from each other.
-          This means that each document can be read independently from the other and can be also developed
-          independently. However, Platform Binding Templates are dependent on the Protocol and Payload Binding
-          Templates, since a given platform uses different protocols and payload formats that need to be specified first
-          in their respective binding templates and referred to within a Platform Binding Template.
-        </p>
+      <section id="binding-mechanisms">
+        <h4>Binding Mechanisms</h4>
 
         <section id="protocol-bindings">
-          <h5>Protocol Binding Templates</h5>
+          <h5>Protocol Bindings</h5>
           <p>
             [[WOT-THING-DESCRIPTION]] defines abstract operations such as <code>readproperty</code>,
             <code>invokeaction</code>
@@ -4225,22 +4159,22 @@
           </p>
           <p>
             Common methods found in REST and PubSub protocols are GET, PUT, POST, DELETE, PUBLISH, and SUBSCRIBE.
-            Binding Templates describe how these existing methods and associated vocabularies can be used in a
+            Binding specifications describe how these existing methods and associated vocabularies can be used in a
             <a>Thing Description</a> to bind to the WoT operations. This is done by defining the URI scheme of the
             protocol and mapping the protocol methods to the abstract WoT operations such as <code>readproperty</code>,
             <code>invokeaction</code> and <code>subscribeevent</code>. In some cases, additional instructions are
             provided to explain how the vocabulary terms should be used in different cases of protocol usage.
           </p>
           <p>
-            The examples below show the binding of the <code>readproperty</code> operation for the HTTP and Modbus
-            protocols. Please note that these are examples and please always refer to the corresponding binding to learn
-            about the relevant vocabulary terms and their values.
+            The examples below show binding instances of the <code>readproperty</code> operation for the HTTP and Modbus
+            protocols. Please note that these are examples and please always refer to the corresponding binding
+            specification to learn about the relevant vocabulary terms and their values.
           </p>
           <table>
             <tbody>
               <tr>
                 <td style="vertical-align: top; width: 50%">
-                  <pre class="example" title="Binding example of a readproperty operation to HTTP">
+                  <pre class="example" title="Binding instance of a readproperty operation to HTTP">
                                       {
                                           "href": "http://example.com/props/temperature",
                                           "op": "readproperty",
@@ -4250,12 +4184,11 @@
                   >
                 </td>
                 <td style="vertical-align: top; width: 50%">
-                  <pre class="example" title="Binding example of a readproperty operation to Modbus">
+                  <pre class="example" title="Binding instance of a readproperty operation to Modbus">
                                       {
-                                          "href": "modbus+tcp://127.0.0.1:60000/1",
+                                          "href": "modbus+tcp://127.0.0.1:60000/1/4",
                                           "op": "readproperty",
-                                          "modv:function": "readCoil",
-                                          "modv:address": 1
+                                          "modv:function": "readCoil"
                                       }
                                   </pre
                   >
@@ -4273,20 +4206,20 @@
             </li>
             <li>
               Right Example: To do a <code>readproperty</code> of the subject Property Affordance using the
-              <code>readCoil</code> function of Modbus at coil <code>1</code> of the device with the
-              <code>127.0.0.1</code> address at its port <code>60000</code>
+              <code>readCoil</code> function of Modbus at coil <code>4</code> of the device with the
+              <code>127.0.0.1</code> IP address and unitID <code>1</code> at its port <code>60000</code>
             </li>
           </ul>
           <p>
-            These bindings and their statements are possible for other operations and protocols as well. Below are
-            examples for <code>invokeaction</code> and <code>subscribeevent</code>:
+            These binding instances and their statements are possible for other operations and protocols as well. Below
+            are examples for <code>invokeaction</code> and <code>subscribeevent</code>:
           </p>
 
           <table>
             <tbody>
               <tr>
                 <td style="vertical-align: top; width: 50%">
-                  <pre class="example" title="Binding example of an invokeaction operation to HTTP">
+                  <pre class="example" title="Binding instance of an invokeaction operation to HTTP">
                                       {
                                           "op": "invokeaction",
                                           "href": "http://192.168.1.32:8081/example/levelaction",
@@ -4296,7 +4229,7 @@
                   >
                 </td>
                 <td style="vertical-align: top; width: 50%">
-                  <pre class="example" title="Binding example of a subscribeevent operation to MQTT">
+                  <pre class="example" title="Binding instance of a subscribeevent operation to MQTT">
                                       {
                                           "op": "subscribeevent",
                                           "href": "mqtt://iot.platform.com:8088",
@@ -4326,11 +4259,10 @@
 
           <p>
             In some cases, header options or other parameters of the protocols need to be included. Given that these are
-            highly protocol dependent, please refer to the bindings listed in [[[#protocol-bindings-table]]].
-            Additionally, protocols may have defined Subprotocols that can be used for some interaction types. For
-            example, to receive asynchronous notifications using HTTP, some servers may support long polling
-            (<code>longpoll</code>), WebSub [[WebSub]] (<code>websub</code>) and Server-Sent Events [[eventsource]]
-            (<code>sse</code>).
+            highly protocol dependent, please refer to the bindings listed in [[[WOT-BINDINGS-REGISTRY]]]. Additionally,
+            protocols may have defined Subprotocols that can be used for some interaction types. For example, to receive
+            asynchronous notifications using HTTP, some servers may support long polling (<code>longpoll</code>), WebSub
+            [[WebSub]] (<code>websub</code>) and Server-Sent Events [[eventsource]] (<code>sse</code>).
           </p>
 
           <section>
@@ -4367,173 +4299,14 @@
           </section>
 
           <section>
-            <h6>Terms Specified by Protocol Binding Templates</h6>
-            <p>
-              Overall, a protocol binding template specifies the values and structure of certain vocabulary terms in a
-              TD. The table below lists the vocabulary term, the class it belongs to and whether the subspecification is
-              required to specify the values the term can take. In addition to these, additional terms for describing
-              protocol options are typically added.
-            </p>
-
-            <table class="def numbered" id="table-protocol-terms">
-              <caption>
-                Terms specified by Protocol Binding Templates
-              </caption>
-              <thead>
-                <tr>
-                  <th>Vocabulary Term</th>
-                  <th>Class</th>
-                  <th>Specification Requirement</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>@context</td>
-                  <td>Thing</td>
-                  <td>mandatory</td>
-                </tr>
-                <tr>
-                  <td>href</td>
-                  <td>Form</td>
-                  <td>mandatory</td>
-                </tr>
-                <tr>
-                  <td>subprotocol</td>
-                  <td>Form</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentType</td>
-                  <td>Form</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentType</td>
-                  <td>ExpectedResponse</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentType</td>
-                  <td>AdditionalExpectedResponse</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentCoding</td>
-                  <td>Form</td>
-                  <td>optional</td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section id="protocol-bindings-table">
-            <h6>Existing Protocol Binding Templates</h6>
-            <p>
-              The table below summarizes the currently specified protocols in their respective
-              <a>Binding Template Subspecification</a>.
-            </p>
-            <table class="def numbered">
-              <caption>
-                Existing Protocol Binding Templates
-              </caption>
-              <thead>
-                <tr>
-                  <th>Abbreviation</th>
-                  <th>Name</th>
-                  <th>Link to Binding Template</th>
-                  <th>Link to Ontology</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>HTTP</td>
-                  <td>Hypertext Transfer Protocol</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td><a href="https://www.w3.org/TR/HTTP-in-RDF10/">Ontology</a></td>
-                </tr>
-                <tr>
-                  <td>CoAP</td>
-                  <td>Constrained Application Protocol</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/ontology.html"
-                      >Ontology</a
-                    >
-                  </td>
-                </tr>
-                <tr>
-                  <td>MQTT</td>
-                  <td>Message Queuing Telemetry Transport</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/ontology.html"
-                      >Ontology</a
-                    >
-                  </td>
-                </tr>
-                <tr>
-                  <td>Modbus</td>
-                  <td>Modbus</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/modbus/ontology.html"
-                      >Ontology</a
-                    >
-                  </td>
-                </tr>
-                <tr>
-                  <td>BACnet</td>
-                  <td>Building Automation and Control Networks</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/bacnet/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/bacnet/bacnet-model.ttl"
-                      >Ontology</a
-                    >
-                  </td>
-                </tr>
-                <tr>
-                  <td>PROFINET</td>
-                  <td>Process Field Network</td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/profinet/index.html"
-                      >Binding Template</a
-                    >
-                  </td>
-                  <td>Not available</td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section>
-            <h6>Using a Thing Description with a Protocol Binding Template Subspecification</h6>
+            <h6>Using a Thing Description with a Protocol Binding</h6>
 
             <p>
-              Protocol Binding Templates contain vocabularies that extend the vocabulary found in the
+              Protocol Binding Specifications contain vocabularies that extend the vocabulary found in the
               [[WOT-THING-DESCRIPTION]]. This means that the way a TD is consumed and how the interactions happen with
               the Thing are adapted to such vocabularies. The steps below explain how this process typically looks like.
-              <!-- this text should be extended after the PR 262 is merged -->
             </p>
+            <!-- TODO: Add assertions and sync with other binding assertions -->
             <ol>
               <li>
                 <b>Detect the protocol:</b> Upon the activation of a form to execute the operation, the
@@ -4546,8 +4319,8 @@
               </li>
               <li>
                 <b>Validate the forms part of the TD</b>: Using the JSON Schema instances provided in the respective
-                subspecification or through programmatically checking key value pairs, the <a>Consumer</a> MAY validate
-                the respective form terms in order to verify they are correctly specified in the TD instance.
+                binding specification or through programmatically checking key value pairs, the <a>Consumer</a> MAY
+                validate the respective form terms in order to verify they are correctly specified in the TD instance.
               </li>
               <li>
                 <b>Start communication:</b> The <a>Consumer</a> SHOULD send requests for the chosen operation as
@@ -4560,71 +4333,10 @@
               </li>
             </ol>
           </section>
-
-          <section>
-            <h6>Creating a new Protocol Binding Template Subspecification</h6>
-
-            <p>
-              When creating a new protocol binding template <a>subspecification</a>, e.g. based on a new communication
-              protocol, the proposed document should enable implementations of this binding in an interoperable way for
-              Consumer and Producer implementations. More specifically, each
-              <a>Binding Template Subspecification</a> MUST specify the following:
-            </p>
-            <ul>
-              <li>
-                <b>URI Scheme:</b> For identification of the used protocol, a standardized URI scheme [[RFC3986]] value
-                MUST be declared in the form of a string. This URI Scheme is used in TDs at top level
-                <code>base</code> or in the <code>href</code> term of the <code>forms</code>
-                container. These can be officially registered ones at IANA [[iana-uri-schemes]] (e.g.
-                <code>"https://"</code>, <code>"coap://"</code>) or they can be declared in the protocol
-                subspecification (e.g. <code>"mqtt://"</code>, <code>"modbus+tcp://"</code>). How the full URI can be
-                constructed for different affordances (or resources) MUST be specified as well.
-              </li>
-              <li>
-                <b><code>@context</code> Usage and Ontology:</b> A vocabulary that allows adding protocol options to a
-                Thing Description forms SHOULD be provided to allow semantic annotations of the operations with protocol
-                specific information. The prefix and IRI to be used in the <code>@context</code> in order to link to the
-                vocabulary of the protocol SHOULD be also provided. The prefix SHOULD use the <code>v</code> suffix
-                notation in order to avoid confusion with the URI scheme of the protocol (e.g. <code>htv</code> for HTTP
-                and <code>mqv</code> for MQTT). For instructions on how to create a vocabulary, please refer to our
-                <a href="./VOCABULARY-CREATION-GUIDE.md"> Vocabulary Creation Guide</a>.
-              </li>
-              <li>
-                <b>Mapping to WoT Operations:</b> Most protocols have a set of methods or verbs that adds a meaning to
-                the messages of the protocol. A protocol binding template MUST be able to map WoT operation types
-                (<code>readproperty</code>, <code>invokeaction</code>, etc.) to concrete protocol message types or
-                methods. When specifying the mapping, the mapping SHOULD be bidirectional, i.e. it should be clear how
-                to do a <code>readproperty</code> operation with the given protocol and how an existing implementation's
-                endpoints can be mapped to a WoT operation should be also clear.
-              </li>
-              <li>
-                <b>JSON Schema:</b> A JSON Schema to validate the forms of a TD using the Protocol Binding SHOULD be
-                provided. This allows validation of the URI scheme and the vocabulary terms. The JSON Schema instance
-                SHOULD follow the template provided in
-                <a href="https://github.com/w3c/wot-binding-templates/blob/main/bindings/protocols/template.schema.json"
-                  >the Binding Templates GitHub Repository.</a
-                >
-              </li>
-              <li>
-                <b>Specification:</b> The official specification document of the protocol SHOULD be provided. This
-                SHOULD be a static version, i.e. the exact document used during the writing of the binding that is
-                guaranteed to not change. If this is not possible, the specification should be marked with a date of
-                access. When the specification is not publicly available and cannot be linked with a static version, an
-                editor's note should be provided in the introduction, explaining how to get access to the specification.
-              </li>
-            </ul>
-
-            <p>
-              A template is also provided for new protocol binding template specifications at
-              <a href="https://github.com/w3c/wot-binding-templates/blob/main/bindings/index.template.html"
-                >the GitHub Repository.</a
-              >
-            </p>
-          </section>
         </section>
 
         <section id="payload-bindings">
-          <h5>Payload Binding Templates</h5>
+          <h5>Payload Bindings</h5>
           <p>
             [[WOT-THING-DESCRIPTION]] defines two mechanisms to describe how a payload of a message over any protocol
             can look like. Firstly, media types [[IANA-MEDIA-TYPES]] describe the serialization used for sending and
@@ -4637,9 +4349,7 @@
 
           <p>
             In the rest of this section at [[[#payload-bindings-contentType]]] and [[[#payload-bindings-dataschema]]],
-            you can find examples of how payload bindings can look like. At [[[#payload-bindings-table]]] you can find
-            the current payload binding templates and [[[#payload-bindings-creating]]] explains how new payload binding
-            templates can be created.
+            you can find examples of how payload bindings can look like.
           </p>
           <section id="payload-bindings-contentType">
             <h6>Content Types</h6>
@@ -4663,10 +4373,8 @@
               additional parameters. In this specific case, the forms describe that reading this property with
               <code>http</code> or <code>coap</code> result in different content types. For structured media types, a
               Data Schema is generally provided in the affordance level as explained in
-              [[[#payload-bindings-dataschema]]] and
-              <a data-cite="WOT-THING-DESCRIPTION#sec-data-schema-vocabulary-definition">
-                in the Data Schema section of the TD specification</a
-              >. However, for unstructured data such as images and videos, a Data Schema is typically not available.
+              [[[#payload-bindings-dataschema]]] and [[#sec-data-schema-vocabulary-definition"]]. However, for
+              unstructured data such as images and videos, a Data Schema is typically not available.
             </p>
 
             <pre class="example" title="JSON and CBOR media types in forms" id="example-payload-binding">
@@ -4724,16 +4432,17 @@
             <h6>Data Schemas</h6>
 
             <p>
-              Data Schema, as explained in [[WOT-THING-DESCRIPTION]], describes the structure of the messages, which are
-              used together with media types. Even though it is largely inspired by JSON Schema [[json-schema]], it can
-              be used for describing other payload types such as [[XML]], string-encoded images, bit representations of
-              integers, etc. Data Schema SHOULD be used in addition to the media types.
+              Data Schema, as explained in [[#sec-data-schema-vocabulary-definition"]], describes the structure of the
+              messages, which are used together with media types. Even though it is largely inspired by JSON Schema
+              [[json-schema]], it can be used for describing other payload types such as [[XML]], string-encoded images,
+              bit representations of integers, etc. Data Schema SHOULD be used in addition to the media types.
             </p>
             <p>
               Depending on the case, the structure of the messages can be anything from a simple number to arrays or
               objects with multiple levels of nesting. Existing IoT Platforms and Standards have certain payload formats
-              with variations on how the data is structured. As explained in [[WOT-THING-DESCRIPTION]], Data Schema can
-              be used in a TD in one of the following places:
+              with variations on how the data is structured. As explained in
+              [[#sec-data-schema-vocabulary-definition"]], Data Schema can be used in a TD in one of the following
+              places:
             </p>
             <ul>
               <li>
@@ -4797,122 +4506,9 @@
               </tbody>
             </table>
           </section>
-          <section>
-            <h6>Terms Specified by Payload Binding Templates</h6>
-            <p>
-              Overall, a payload binding template specifies the values and structure of certain vocabulary terms in a
-              TD. The table below lists the vocabulary term, the class it belongs to and whether the subspecification is
-              required to specify the values the term can take. In addition to these, additional vocabulary terms can be
-              added and restrictions to Data Schema terms can be placed.
-            </p>
-
-            <table class="def numbered" id="table-payload-terms">
-              <caption>
-                Terms specified by Payload Binding Templates
-              </caption>
-              <thead>
-                <tr>
-                  <th>Term</th>
-                  <th>Class</th>
-                  <th>Specification Requirement</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>contentType</td>
-                  <td>Form</td>
-                  <td>mandatory</td>
-                </tr>
-                <tr>
-                  <td>contentType</td>
-                  <td>ExpectedResponse</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentType</td>
-                  <td>AdditionalExpectedResponse</td>
-                  <td>optional</td>
-                </tr>
-                <tr>
-                  <td>contentCoding</td>
-                  <td>Form</td>
-                  <td>optional</td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section id="payload-bindings-table">
-            <h6>Existing Payload Binding Templates</h6>
-            The table below summarizes the currently specified payload binding templates.
-
-            <table class="def numbered">
-              <caption>
-                Existing Platform Binding Templates
-              </caption>
-              <thead>
-                <tr>
-                  <th>Abbreviation</th>
-                  <th>Name</th>
-                  <th>Media Type</th>
-                  <th>Link</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>JSON</td>
-                  <td>JavaScript Object Notation</td>
-                  <td><code>application/json</code></td>
-                  <td>Planned</td>
-                </tr>
-                <tr>
-                  <td>XML</td>
-                  <td>eXtensible Markup Language</td>
-                  <td><code>application/xml</code></td>
-                  <td>
-                    <a href="https://w3c.github.io/wot-binding-templates/bindings/payloads/xml/index.html">Link</a>
-                    (Work in Progress)
-                  </td>
-                </tr>
-                <tr>
-                  <td>text</td>
-                  <td>text</td>
-                  <td><code>text/plain</code></td>
-                  <td>Planned</td>
-                </tr>
-                <tr>
-                  <td>Unstructured Data</td>
-                  <td>Unstructured Data</td>
-                  <td>various</td>
-                  <td>Planned</td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section id="payload-bindings-creating">
-            <h6>Creating a new Payload Binding Template Subspecification</h6>
-
-            <p>
-              Each payload binding template <a>subspecification</a>, SHOULD contain the respective media type. Ideally
-              this media type has been registered at the IANA registry [[IANA-MEDIA-TYPES]] with a corresponding mime
-              type (e.g. <code>application/json</code>). If it is not registered, the binding document can propose a
-              mime type. Additionally, how that media type is represented in a Data Schema SHOULD be demonstrated with
-              examples. In all cases, the following information SHOULD be provided:
-            </p>
-
-            <ul>
-              <li>
-                <b>Specification:</b> The official specification document of the payload format SHOULD be provided. This
-                SHOULD be a static version, i.e. the exact document used during the writing of the binding that is
-                guaranteed to not change. If this is not possible, the specification should be marked with a date of
-                access. When the specification is not publicly available and cannot be linked with a static version, an
-                editor's note should be provided in the introduction, explaining how to get access to the specification.
-              </li>
-            </ul>
-          </section>
         </section>
 
+        <!-- TODO: Change to combining bindings -->
         <section id="platform-bindings">
           <h5>Platform Binding Templates</h5>
           <p>
@@ -4938,64 +4534,6 @@
             the usage of protocol or media type, corresponding protocol or payload binding templates MUST be created
             first.
           </p>
-
-          <section id="platform-bindings-table">
-            <h6>Existing Platform Binding Templates</h6>
-            <p>
-              The table below summarizes the currently specified platform binding template <a>subspecification</a>s.
-            </p>
-
-            <table class="def">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Link</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>Philips Hue</td>
-                  <td>Planned</td>
-                </tr>
-                <tr>
-                  <td>ECHONET</td>
-                  <td>Planned</td>
-                </tr>
-                <tr>
-                  <td>OPC-UA</td>
-                  <td>Planned</td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section>
-            <h6>Creating a new Platform Binding Template Subspecification</h6>
-
-            <p>
-              Depending on the platform and the variety of devices it proposes, each platform binding template
-              <a>subspecification</a> will be structured differently. When the platforms offer a <i>reasonable</i> set
-              of device types, a Thing Model for each device type SHOULD be provided. In other cases, possible devices
-              SHOULD be generalized by providing a set of example Thing Models or TDs. In all cases, the following
-              information SHOULD be provided:
-            </p>
-            <ul>
-              <li>
-                <b>Protocol:</b> The protocol used by the platform SHOULD be specified and linked to a protocol binding
-                template <a>subspecification</a> when a corresponding one exists.
-              </li>
-              <li>
-                <b>Media Type:</b> The media type used by the platform SHOULD be specified and linked to a payload
-                binding template <a>subspecification</a> when a corresponding one exists.
-              </li>
-              <li>
-                <b>API Documentation:</b> A static link pointing to the used API Documentation or Specification of the
-                platform SHOULD be provided. When the documentation is not publicly available and cannot be included in
-                a static version in the respective folder, an editor's note should be provided in the introduction,
-                explaining how to get access to the documentation.
-              </li>
-            </ul>
-          </section>
         </section>
       </section>
     </section>

--- a/index.template.html
+++ b/index.template.html
@@ -793,9 +793,9 @@
         </dd>
         <dt><dfn id="dfn-binding-instance">Binding Instance</dfn></dt>
         <dd>
-          A binding instance is a form instance in a Thing Description containing a specific binding. For example, an
-          HTTP Binding instance is a <a>Form</a> which has <code>href</code> starting with <code>http://</code> or
-          <code>https://</code>.
+          A binding instance is a form instance in a Thing Description containing a specific binding, implementing a
+          <a>Binding Specification</a>. For example, an HTTP Binding instance is a <a href="#form">Form</a> which has
+          <code>href</code> starting with <code>http://</code> or <code>https://</code>.
         </dd>
       </dl>
 
@@ -1157,8 +1157,8 @@
           <p>
             In a TD, concrete data formats are specified in Forms (see <a href="#form"></a>) using content types. When
             the value of a content type in an instance of the Form is <code>application/json</code>, the data schema can
-            be processed directly by JSON Schema processors. Otherwise, Web of Things (WoT) Binding Templates
-            [[?WOT-BINDING-TEMPLATES]] defines data schema's available mappings to other content types such as XML
+            be processed directly by JSON Schema processors. Otherwise, entries in Web of Things (WoT) Bindings Registry
+            [[?WOT-BINDINGS-REGISTRY]] defines data schema's available mappings to other content types such as XML
             [[?xml]]. If the content type in an instance of the Form is not <code>application/json</code> and if no
             mapping is defined for the content type, specifying a data schema does not make sense for the content type.
           </p>
@@ -3983,9 +3983,9 @@
 
         <p>
           With the <a>TD Context Extensions</a> in a Thing Description, the communication metadata can be supplemented
-          via <a>Bindings</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added through
-          additional <a>Vocabulary Terms</a> serialized into JSON objects representing a <code>Form</code> instance.
-          Please see <a href="#bindings"></a> for further information.
+          via <a>Binding Specifications</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added
+          through additional <a>Vocabulary Terms</a> serialized into JSON objects representing a
+          <code>Form</code> instance. Please see <a href="#bindings"></a> for further information.
         </p>
       </section>
 
@@ -4067,20 +4067,20 @@
         Every message sent from a Consumer to the Thing and back needs to travel over a network protocol, despite the
         Property&ndash;Action&ndash;Event abstraction provided by WoT. The operations in the Forms level need to be
         bound to how the message is meant to look, over the network. Thus, every form in a WoT Thing Description needs
-        to have a submission target, given by the <code>href</code> member, as indicated in <a>Form</a>. For instance,
-        if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can infer that the
-        <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific terms in
-        an instance of this form. See [[[#protocol-bindings]]] for more explanation and examples.
+        to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>.
+        For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can infer
+        that the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific
+        terms in an instance of this form. See [[[#protocol-bindings]]] for more explanation and examples.
       </p>
 
       <p>
         Furthermore, the payloads described by the <a>Data Schema</a> in the Affordance Level need to be serialized to a
         data format and sent on the network protocol. Similar to how operations are bound to protocol messages, the
         <a>Data Schema</a> is bound to a data format indicated by the <code>contentType</code> or protocol-specific
-        terms provided in the <a>Form</a>. From these terms, a <a>Consumer</a> can infer the required serialization
-        method and transform the application-level data to the data to be sent on the network protocol. Similarly, for
-        messages coming from the <a>Thing</a>, the <a>Consumer</a> can deserialize the data and present it to the
-        application level. For example, a <a>Consumer</a> implemented in Python can read
+        terms provided in the <a href="#form">Form</a>. From these terms, a <a>Consumer</a> can infer the required
+        serialization method and transform the application-level data to the data to be sent on the network protocol.
+        Similarly, for messages coming from the <a>Thing</a>, the <a>Consumer</a> can deserialize the data and present
+        it to the application level. For example, a <a>Consumer</a> implemented in Python can read
         <code>application/json</code> as the value of <code>contentType</code> and serialize a Python dictionary data
         structure into a JSON object. See [[[#payload-bindings]]] for more explanation and examples.
       </p>
@@ -4092,7 +4092,7 @@
         and y equals 100. In order to do so, it creates the correct payload, serializes it and sends it using the
         correct protocol options. The Thing gets the message over the network and responds with a message that
         corresponds to its TD. Other protocols, payload formats or their combination are possible and are explained in
-        [[[#binding-overview]]].
+        [[[#binding-mechanisms]]].
       </p>
 
       <figure id="fig-mechanism">
@@ -4120,9 +4120,9 @@
       <figure id="fig-building-block">
         <img
           src="visualization/binding-templates.svg"
-          alt="Platforms, Protocols and Media Types as building blocks for binding templates and TD"
+          alt="Protocols, Media Types and their combinations as building blocks for TDs"
         />
-        <figcaption>Platforms, Protocols and Media Types as building blocks for binding templates and TD</figcaption>
+        <figcaption>Protocols, Media Types and their combinations as building blocks TDs</figcaption>
       </figure>
 
       <p class="note">
@@ -4293,8 +4293,8 @@
               protocol indicated in <code>href</code> of the forms (or the <code>base</code>). For WebSockets, the
               IANA-registered Websocket Subprotocols [[iana-web-socket-registry]] may be used. For CoAP,
               <code>"subprotocol":"cov:observe"</code> can be used to describe asynchronous observation operations as
-              defined by [[RFC6741]]. The subprotocols can be defined and explained as a part of a protocol or platform
-              binding subspecification.
+              defined by [[RFC6741]]. The subprotocols can be defined and explained as a part of a protocol
+              <a>binding specification</a>.
             </p>
           </section>
 
@@ -4508,31 +4508,26 @@
           </section>
         </section>
 
-        <!-- TODO: Change to combining bindings -->
-        <section id="platform-bindings">
-          <h5>Platform Binding Templates</h5>
+        <section id="bindings-combinations">
+          <h5>Payload and Protocol Bindings</h5>
           <p>
-            There are already various IoT platforms on the market that allows exposing physical and virtual Things to
-            the Internet. These platforms generally require a certain use of a protocol and payload. Thus, they can be
-            seen as a combination of the <a href="#protocol-bindings"></a> and <a href="#payload-bindings"></a>. In
-            these cases, the use of protocol and payload bindings needs to be supported with how they are related to
-            each other in the specific platform.
+            In cases like IoT platforms or standards like OPC-UA or BACnet, the protocol, media type and data structure
+            can be specified. In these cases, their <a>binding specification</a> can either depend on a set of
+            <a href="#protocol-bindings"></a> and <a href="#payload-bindings"></a> or specify protocol, media type and
+            data structure at the same time.
           </p>
 
           <p>
-            For example, Things of a certain platform can require the usage of HTTP and Websockets together with certain
-            JSON payload structures. Thus, Platform Binding <a>subspecification</a>s provide Thing Models and examples
-            of TDs that allow to semantically group multiple binding templates. This allows creation of TDs for these
-            platforms in a consistent manner and makes it easier to develop <a>Consumer</a>s for them.
+            In the case of IoT platforms, there can be a requirement about the usage of HTTP together with certain JSON
+            payload structures. Thus, the corresponding <a>binding specification</a> provides Thing Models and examples
+            of TDs that allow to semantically group multiple bindings. This requires having a
+            <a>binding specification</a> for HTTP and JSON in the first place.
           </p>
 
           <p>
-            Since Platform Binding Templates combine the usage of protocol and payload binding templates, the vocabulary
-            terms and values they can specify are the combination of vocabulary terms in [[[#table-protocol-terms]]] and
-            [[[#table-payload-terms]]]. Similarly, a Platform Binding subspecification SHOULD NOT introduce new protocol
-            binding templates or media types inside its own document. If a Platform Binding subspecification requires
-            the usage of protocol or media type, corresponding protocol or payload binding templates MUST be created
-            first.
+            In the case of standards like OPC-UA or BACnet, the <a>binding specification</a> contains requirements on
+            the protocol, media type and possibly also on data structure. Thus, the <a>binding specification</a> is
+            enough on its own to specify how a <a>binding instance</a> should look like.
           </p>
         </section>
       </section>
@@ -6840,13 +6835,13 @@
       <h2>Example Thing Description Instances with Protocol Bindings</h2>
 
       <p>
-        The following TD examples uses HTTP, CoAP and MQTT Protocol Binding Templates. These TDs have Context Extensions
-        which assume that there is a CoAP and MQTT in RDF vocabulary similar to [[?HTTP-in-RDF10]] that is accessible
-        via the namespaces <code>http://www.example.org/coap-binding#</code> and
+        The following TD examples uses HTTP, CoAP and MQTT Protocol Bindings. These TDs have Context Extensions which
+        assume that there is a CoAP and MQTT in RDF vocabulary similar to [[?HTTP-in-RDF10]] that is accessible via the
+        namespaces <code>http://www.example.org/coap-binding#</code> and
         <code>http://www.example.org/mqtt-binding#</code>, respectively. Please note that the TD context at
         <code>"https://www.w3.org/2022/wot/td/v1.1"</code> already includes the [[?HTTP-in-RDF10]], so HTTP context
-        extensions can be directly used. Note that, each Binding Template <a>subspecification</a> contains the most
-        up-to-date vocabulary terms and examples.
+        extensions can be directly used. Note that, each <a>Binding Specification</a> contains the most up-to-date
+        vocabulary terms and examples.
       </p>
 
       <p>The context extensions we see below have the following instructions to the TD Consumer:</p>
@@ -6884,9 +6879,7 @@
           <li>Protocol Binding: CoAP [[?RFC7252]] over TLS</li>
           <li>
             Comment: Also see
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html"
-              >CoAP Binding Template</a
-            >.
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html">CoAP Binding</a>.
           </li>
         </ul>
 
@@ -7047,9 +7040,7 @@
             Comment: An MQTT client (Thing) frequently publishes the illuminance data (number is serialized in text
             format) to the topic <code>/illuminance</code> by the MQTT broker running behind the address
             <code>192.168.1.187:1883</code>. Also see
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html"
-              >MQTT Binding Template</a
-            >
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html">MQTT Binding</a>
           </li>
         </ul>
         <aside class="example with-default">
@@ -7305,15 +7296,10 @@
           <li>Protocol Binding: HTTP, CoAP [[?RFC7252]], and MQTT [[?MQTT]]</li>
           <li>
             Comment: Each interaction affordance has one form with one protocol. Also see
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html"
-              >HTTP Binding Template</a
-            >,
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html"
-              >CoAP Binding Template</a
-            >, and
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html"
-              >MQTT Binding Template</a
-            >.
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html">HTTP Binding</a>,
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html">CoAP Binding</a>,
+            and
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html">MQTT Binding</a>.
           </li>
         </ul>
 
@@ -7432,15 +7418,10 @@
             <code>concentration</code> event can be subscribed to via CoAP and MQTT. In this case, the Consumer would
             pick the form it can support based on its internal implementation, e.g. whether it has CoAP protocol stack
             or not. Also see
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html"
-              >HTTP Binding Template</a
-            >,
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html"
-              >CoAP Binding Template</a
-            >, and
-            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html"
-              >MQTT Binding Template</a
-            >.
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html">HTTP Binding</a>,
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html">CoAP Binding</a>,
+            and
+            <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt/index.html">MQTT Binding</a>.
           </li>
         </ul>
 

--- a/index.template.html
+++ b/index.template.html
@@ -4075,7 +4075,7 @@
 
       <p>
         Furthermore, the payloads described by the <a>Data Schema</a> in the Affordance Level need to be serialized to a
-        data format and sent on the network protocol. Similar to how operations are bound to protocol messages, the
+        data format and sent on the network protocol. Similar to the way operations are bound to protocol messages, the
         <a>Data Schema</a> is bound to a data format indicated by the <code>contentType</code> or protocol-specific
         terms provided in the <a href="#form">Form</a>. From these terms, a <a>Consumer</a> can infer the required
         serialization method and transform the application-level data to the data to be sent on the network protocol.
@@ -4089,9 +4089,9 @@
         The mechanism above are called Bindings in the Web of Things and a specific example is illustrated in
         [[[#fig-mechanism]]] with an excerpt of a TD of a robot arm with of HTTP and JSON Bindings. Here, the Consumer
         intends to invoke an action of the robot arm (<code>goTo</code>) in order to move it to the position x equals 12
-        and y equals 100. In order to do so, it creates the correct payload, serializes it and sends it using the
+        and y equals 100. To do so, it creates the correct payload, serializes it, and sends it using the
         correct protocol options. The Thing gets the message over the network and responds with a message that
-        corresponds to its TD. Other protocols, payload formats or their combination are possible and are explained in
+        corresponds to its TD. Other protocols, payload formats, and/or their combination are possible and are explained in
         [[[#binding-mechanisms]]].
       </p>
 
@@ -4120,9 +4120,9 @@
       <figure id="fig-building-block">
         <img
           src="visualization/binding-templates.svg"
-          alt="Protocols, Media Types and their combinations as building blocks for TDs"
+          alt="Protocols, Media Types, and their combinations, as building blocks for TDs"
         />
-        <figcaption>Protocols, Media Types and their combinations as building blocks TDs</figcaption>
+        <figcaption>Protocols, Media Types, and their combinations, as building blocks for TDs</figcaption>
       </figure>
 
       <p class="note">
@@ -4518,16 +4518,16 @@
           </p>
 
           <p>
-            In the case of IoT platforms, there can be a requirement about the usage of HTTP together with certain JSON
+            In IoT platforms, there can be a requirement about the usage of HTTP together with certain JSON
             payload structures. Thus, the corresponding <a>binding specification</a> provides Thing Models and examples
-            of TDs that allow to semantically group multiple bindings. This requires having a
+            of TDs that allow semantic grouping of multiple bindings. This requires having a
             <a>binding specification</a> for HTTP and JSON in the first place.
           </p>
 
           <p>
-            In the case of standards like OPC-UA or BACnet, the <a>binding specification</a> contains requirements on
-            the protocol, media type and possibly also on data structure. Thus, the <a>binding specification</a> is
-            enough on its own to specify how a <a>binding instance</a> should look like.
+            In standards like OPC-UA or BACnet, the <a>binding specification</a> contains requirements on
+            the protocol and media type, and possibly also on data structure. Thus, the <a>binding specification</a> is
+            enough on its own to specify how a <a>binding instance</a> should look.
           </p>
         </section>
       </section>
@@ -6835,12 +6835,12 @@
       <h2>Example Thing Description Instances with Protocol Bindings</h2>
 
       <p>
-        The following TD examples uses HTTP, CoAP and MQTT Protocol Bindings. These TDs have Context Extensions which
-        assume that there is a CoAP and MQTT in RDF vocabulary similar to [[?HTTP-in-RDF10]] that is accessible via the
+        The following TD example uses HTTP, CoAP, and MQTT Protocol Bindings. These TDs have Context Extensions which
+        assume that there are CoAP-in-RDF and MQTT-in-RDF vocabularies similar to [[?HTTP-in-RDF10]] that are accessible via the
         namespaces <code>http://www.example.org/coap-binding#</code> and
         <code>http://www.example.org/mqtt-binding#</code>, respectively. Please note that the TD context at
         <code>"https://www.w3.org/2022/wot/td/v1.1"</code> already includes the [[?HTTP-in-RDF10]], so HTTP context
-        extensions can be directly used. Note that, each <a>Binding Specification</a> contains the most up-to-date
+        extensions can be used directly. Note that each <a>Binding Specification</a> contains the most up-to-date
         vocabulary terms and examples.
       </p>
 
@@ -7416,7 +7416,7 @@
             the
             <code>brightness</code> property can be read via HTTP and CoAP, and observed via MQTT;
             <code>concentration</code> event can be subscribed to via CoAP and MQTT. In this case, the Consumer would
-            pick the form it can support based on its internal implementation, e.g. whether it has CoAP protocol stack
+            pick the form it can support based on its internal implementation, e.g., whether it has a CoAP protocol stack
             or not. Also see
             <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html">HTTP Binding</a>,
             <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html">CoAP Binding</a>,

--- a/index.template.html
+++ b/index.template.html
@@ -789,8 +789,12 @@
         <dt><dfn id="dfn-binding-specification">Binding Specification</dfn></dt>
         <dd>
           A binding specification is a document that specifies a binding
+<<<<<<< HEAD
           for a protocol, a payload format, or both. All bindings follow the
           rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
+=======
+          for a protocol or payload format or both. All bindings follow the rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
+>>>>>>> e3a9fb83 (start reorganizing the intro for bindings)
         </dd>
       </dl>
 
@@ -3979,6 +3983,7 @@
         <p>
           With the <a>TD Context Extensions</a> in a Thing Description, the communication metadata can be supplemented
 <<<<<<< HEAD
+<<<<<<< HEAD
           via <a>Bindings</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added through
           additional <a>Vocabulary Terms</a> serialized into JSON objects representing a <code>Form</code> instance.
           Please see <a href="#bindings"></a> for further information.
@@ -3987,6 +3992,16 @@
           representing a <code>Form</code> instance. Please see <a href="#binding-templates"></a> for further
           information.
 >>>>>>> ba277e48 (change to td 2.0 and fix broken links (#2113))
+=======
+          or new <a>Protocol Bindings</a> added through additional <a>Vocabulary Terms</a> serialized into JSON objects
+          representing a <code>Form</code> instance. Please see <a href="#binding-templates"></a> for further
+          information.
+=======
+          via <a>Bindings</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added through
+          additional <a>Vocabulary Terms</a> serialized into JSON objects representing a <code>Form</code> instance.
+          Please see <a href="#bindings"></a> for further information.
+>>>>>>> 6ba44ea7 (start reorganizing the intro for bindings)
+>>>>>>> e3a9fb83 (start reorganizing the intro for bindings)
         </p>
       </section>
 
@@ -4065,6 +4080,7 @@
     <section id="bindings">
       <h2>Bindings</h2>
         <p>
+<<<<<<< HEAD
           Every message sent from a Consumer to the Thing and back needs to
           travel over a network protocol, despite the
           Property&ndash;Action&ndash;Event abstraction provided by WoT.
@@ -4073,6 +4089,14 @@
           For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can
           infer that the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific
           terms in an instance of this form.
+=======
+          Every message sent from a Consumer to the Thing and back needs to follow a network protocol, despite the Property, Action, Event abstraction provided by WoT.
+          The operations in the form level need to be bound to how the message needs to look like over the network.
+          Thus, every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>.
+          For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can then
+          infer the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP and it should expect HTTP-specific
+          terms in the form instance.
+>>>>>>> e3a9fb83 (start reorganizing the intro for bindings)
           Furthermore, the payloads described by the <a>Data Schema</a> in the affordance level need to be serialized to the correct payload format.
           Similar to how operations are bound to protocol messages, the
        </p>

--- a/index.template.html
+++ b/index.template.html
@@ -788,13 +788,8 @@
         </dd>
         <dt><dfn id="dfn-binding-specification">Binding Specification</dfn></dt>
         <dd>
-          A binding specification is a document that specifies a binding
-<<<<<<< HEAD
-          for a protocol, a payload format, or both. All bindings follow the
-          rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
-=======
-          for a protocol or payload format or both. All bindings follow the rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
->>>>>>> e3a9fb83 (start reorganizing the intro for bindings)
+          A binding specification is a document that specifies a binding for a protocol, a payload format, or both. All
+          bindings follow the rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
         </dd>
       </dl>
 
@@ -3982,26 +3977,9 @@
 
         <p>
           With the <a>TD Context Extensions</a> in a Thing Description, the communication metadata can be supplemented
-<<<<<<< HEAD
-<<<<<<< HEAD
           via <a>Bindings</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added through
           additional <a>Vocabulary Terms</a> serialized into JSON objects representing a <code>Form</code> instance.
           Please see <a href="#bindings"></a> for further information.
-=======
-          or new <a>Protocol Bindings</a> added through additional <a>Vocabulary Terms</a> serialized into JSON objects
-          representing a <code>Form</code> instance. Please see <a href="#binding-templates"></a> for further
-          information.
->>>>>>> ba277e48 (change to td 2.0 and fix broken links (#2113))
-=======
-          or new <a>Protocol Bindings</a> added through additional <a>Vocabulary Terms</a> serialized into JSON objects
-          representing a <code>Form</code> instance. Please see <a href="#binding-templates"></a> for further
-          information.
-=======
-          via <a>Bindings</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added through
-          additional <a>Vocabulary Terms</a> serialized into JSON objects representing a <code>Form</code> instance.
-          Please see <a href="#bindings"></a> for further information.
->>>>>>> 6ba44ea7 (start reorganizing the intro for bindings)
->>>>>>> e3a9fb83 (start reorganizing the intro for bindings)
         </p>
       </section>
 
@@ -4109,18 +4087,13 @@
       </p>
 
       <figure id="fig-mechanism">
-        <img
-          src="visualization/binding-mechanism.drawio.svg"
-          alt="Binding Templates mechanism with a TD, Thing and Consumer"
-        />
-        <figcaption>
-          Binding Templates Mechanism inside a TD excerpt with messages of its Thing and a Consumer.
-        </figcaption>
+        <img src="visualization/binding-mechanism.drawio.svg" alt="Bindings mechanism with a TD, Thing and Consumer" />
+        <figcaption>Bindings Mechanism inside a TD excerpt with messages of its Thing and a Consumer.</figcaption>
       </figure>
 
       <p>
         This section explains the overall mechanism and gives basic guidance on creating new Bindings. The
-        [[WOT-BINDING-REGISTRY]] contains the a registry (list) of existing Bindings as well the requirements to follow
+        [[WOT-BINDINGS-REGISTRY]] contains the a registry (list) of existing Bindings as well the requirements to follow
         to register new entries to the registry.
       </p>
 

--- a/index.template.html
+++ b/index.template.html
@@ -4109,7 +4109,7 @@
       </p>
 
       <p>
-        When producting a TD for a particular IoT device, the corresponding Binding can be used to look up the
+        When producing a TD for a particular IoT device, the corresponding Binding can be used to look up the
         communication metadata that is to be provided in the <a>Thing Description</a>. [[[#fig-building-block]]] shows
         how Bindings are used. Based on the protocol or media type, a TD is created. The Consumer that is processing a
         TD implements the required Bindings that are present in the TD by including a corresponding protocol stack and

--- a/index.template.html
+++ b/index.template.html
@@ -789,7 +789,8 @@
         <dt><dfn id="dfn-binding-specification">Binding Specification</dfn></dt>
         <dd>
           A binding specification is a document that specifies a binding
-          for a protocol or payload format or both. All bindings follow the rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
+          for a protocol, a payload format, or both. All bindings follow the
+          rules of the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]].
         </dd>
       </dl>
 
@@ -4058,12 +4059,14 @@
     <section id="bindings">
       <h2>Bindings</h2>
         <p>
-          Every message sent from a Consumer to the Thing and back needs to follow a network protocol, despite the Property, Action, Event abstraction provided by WoT.
-          The operations in the form level need to be bound to how the message needs to look like over the network.
+          Every message sent from a Consumer to the Thing and back needs to
+          travel over a network protocol, despite the
+          Property&ndash;Action&ndash;Event abstraction provided by WoT.
+          The operations in the Forms level need to be bound to how the message is meant to look, over the network.
           Thus, every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>.
-          For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can then
-          infer the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP and it should expect HTTP-specific
-          terms in the form instance.
+          For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can
+          infer that the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific
+          terms in an instance of this form.
           Furthermore, the payloads described by the <a>Data Schema</a> in the affordance level need to be serialized to the correct payload format.
           Similar to how operations are bound to protocol messages, the
        </p>

--- a/index.template.html
+++ b/index.template.html
@@ -4079,49 +4079,51 @@
 
     <section id="bindings">
       <h2>Bindings</h2>
-        <p>
-<<<<<<< HEAD
-          Every message sent from a Consumer to the Thing and back needs to
-          travel over a network protocol, despite the
-          Property&ndash;Action&ndash;Event abstraction provided by WoT.
-          The operations in the Forms level need to be bound to how the message is meant to look, over the network.
-          Thus, every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>.
-          For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can
-          infer that the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific
-          terms in an instance of this form.
-=======
-          Every message sent from a Consumer to the Thing and back needs to follow a network protocol, despite the Property, Action, Event abstraction provided by WoT.
-          The operations in the form level need to be bound to how the message needs to look like over the network.
-          Thus, every form in a WoT Thing Description needs to have a submission target, given by the <code>href</code> member, as indicated in <a href="#form">Form</a>.
-          For instance, if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can then
-          infer the <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP and it should expect HTTP-specific
-          terms in the form instance.
->>>>>>> e3a9fb83 (start reorganizing the intro for bindings)
-          Furthermore, the payloads described by the <a>Data Schema</a> in the affordance level need to be serialized to the correct payload format.
-          Similar to how operations are bound to protocol messages, the
-       </p>
+      <p>
+        Every message sent from a Consumer to the Thing and back needs to travel over a network protocol, despite the
+        Property&ndash;Action&ndash;Event abstraction provided by WoT. The operations in the Forms level need to be
+        bound to how the message is meant to look, over the network. Thus, every form in a WoT Thing Description needs
+        to have a submission target, given by the <code>href</code> member, as indicated in <a>Form</a>. For instance,
+        if the target starts with <code>http</code> or <code>https</code>, a <a>Consumer</a> can infer that the
+        <a>Thing</a> implements the <a>Protocol Binding</a> based on HTTP, and it should expect HTTP-specific terms in
+        an instance of this form.
+      </p>
 
-        <p>
-          Many network-level protocols, standards and platforms for connected Things have already been developed, and
-          have millions of devices deployed in the field today. These standards are converging on a common set of
-          transport protocols and transfer layers, but each has peculiar content formats, payload schemas, and data
-          types.
-        </p>
-        <p>
-          Despite using unique formats and data models, the high-level interactions exposed by most connected things can
-          be modeled using the Property, Action, and Event interaction affordances of the WoT Thing Description.
-        </p>
-        <p>
-          Binding Templates enable a Thing Description to be adapted to a specific protocol, data payload formats or
-          platforms that combine both in specific ways. This is done through additional descriptive vocabularies, Thing
-          Models and examples that aim to guide the implementors of Things and Consumers alike.
-        </p>
-        <p>
-          This section acts as a base and explains how other binding templates should be designed. Concrete binding
-          templates are then provided in their respective documents, referred to as subspecifications, that are linked
-          to from this document.
-        </p>
-      </section>
+      <p>
+        Furthermore, the payloads described by the <a>Data Schema</a> in the Affordance Level need to be serialized to a
+        data format and sent on the network protocol. Similar to how operations are bound to protocol messages, the
+        <a>Data Schema</a> is bound to a data format indicated by the <code>contentType</code> or protocol-specific
+        terms provided in the <a>Form</a>. From these terms, a <a>Consumer</a> can infer the required serialization
+        method and transform the application-level data to the data to be sent on the network protocol. Similarly, for
+        messages coming from the <a>Thing</a>, the <a>Consumer</a> can deserialize the data and present it to the
+        application level. For example, a <a>Consumer</a> implemented in Python can read
+        <code>application/json</code> as the value of <code>contentType</code> and serialize a Python dictionary data
+        structure into a JSON object.
+      </p>
+
+      <p>
+        The mechanism above are called Bindings in the Web of Things and a specific example is illustrated in
+        [[[#fig-mechanism]]]. Bindings enable a Thing Description to be adapted to a specific protocol, data payload
+        formats or both in specific ways. This is done through URI Schemes, additional descriptive vocabularies, Thing
+        Models and examples that aim to guide the implementors of Things and Consumers alike.
+      </p>
+
+      <figure id="fig-mechanism">
+        <img
+          src="visualization/binding-mechanism.drawio.svg"
+          alt="Binding Templates mechanism with a TD, Thing and Consumer"
+        />
+        <figcaption>
+          Binding Templates Mechanism inside a TD excerpt with messages of its Thing and a Consumer.
+        </figcaption>
+      </figure>
+
+      <p>
+        This section explains the overall mechanism and gives basic guidance on creating new Bindings. The
+        [[WOT-BINDING-REGISTRY]] contains the a registry (list) of existing Bindings as well the requirements to follow
+        to register new entries to the registry.
+      </p>
+
       <section id="binding-introduction">
         <h4>Introduction to Binding Templates</h4>
         <p>
@@ -4168,16 +4170,6 @@
           message that corresponds to its TD. Other protocols, payload formats or their combination are possible and are
           explained in [[[#binding-overview]]].
         </p>
-
-        <figure id="fig-mechanism">
-          <img
-            src="visualization/binding-mechanism.drawio.svg"
-            alt="Binding Templates mechanism with a TD, Thing and Consumer"
-          />
-          <figcaption>
-            Binding Templates Mechanism inside a TD excerpt with messages of its Thing and a Consumer.
-          </figcaption>
-        </figure>
 
         <p class="ednote">
           The editors also recommend reading the related chapters in [[WOT-ARCHITECTURE]], such as

--- a/index.template.html
+++ b/index.template.html
@@ -1158,7 +1158,7 @@
             In a TD, concrete data formats are specified in Forms (see <a href="#form"></a>) using content types. When
             the value of a content type in an instance of the Form is <code>application/json</code>, the data schema can
             be processed directly by JSON Schema processors. Otherwise, entries in Web of Things (WoT) Bindings Registry
-            [[?WOT-BINDINGS-REGISTRY]] defines data schema's available mappings to other content types such as XML
+            [[?WOT-BINDINGS-REGISTRY]] define available mappings from data schemas to other content types such as XML
             [[?xml]]. If the content type in an instance of the Form is not <code>application/json</code> and if no
             mapping is defined for the content type, specifying a data schema does not make sense for the content type.
           </p>
@@ -2353,7 +2353,7 @@
             <h3><code>ComboSecurityScheme</code></h3>
 
             <p>
-              To avoid redundancy in this case, e.g. repeating the details of the <code>form</code> elements, a
+              To avoid redundancy in this case, e.g., repeating the details of the <code>form</code> elements, a
               <a href="#combosecurityscheme"><code>ComboSecurityScheme</code></a> with <code>oneOf</code> can be used
               instead.
             </p>
@@ -3645,7 +3645,7 @@
             that can be checked by looking only at the TD itself.
           </p>
           <p>
-            Minimal Validation is appropriate where validation needs to be self-contained (e.g. devices on isolated
+            Minimal Validation is appropriate where validation needs to be self-contained (e.g., devices on isolated
             networks). It does not attempt to validate context extensions and vocabularies.
           </p>
           <p>
@@ -4089,9 +4089,9 @@
         The mechanism above are called Bindings in the Web of Things and a specific example is illustrated in
         [[[#fig-mechanism]]] with an excerpt of a TD of a robot arm with of HTTP and JSON Bindings. Here, the Consumer
         intends to invoke an action of the robot arm (<code>goTo</code>) in order to move it to the position x equals 12
-        and y equals 100. To do so, it creates the correct payload, serializes it, and sends it using the
-        correct protocol options. The Thing gets the message over the network and responds with a message that
-        corresponds to its TD. Other protocols, payload formats, and/or their combination are possible and are explained in
+        and y equals 100. To do so, it creates the correct payload, serializes it, and sends it using the correct
+        protocol options. The Thing gets the message over the network and responds with a message that corresponds to
+        its TD. Other protocols, payload formats, and/or their combination are possible and are explained in
         [[[#binding-mechanisms]]].
       </p>
 
@@ -4509,25 +4509,25 @@
         </section>
 
         <section id="bindings-combinations">
-          <h5>Payload and Protocol Bindings</h5>
+          <h5>Protocol and Payload Bindings</h5>
           <p>
-            In cases like IoT platforms or standards like OPC-UA or BACnet, the protocol, media type and data structure
+            In cases like IoT platforms or standards like OPC-UA or BACnet, the protocol, media type, and data structure
             can be specified. In these cases, their <a>binding specification</a> can either depend on a set of
-            <a href="#protocol-bindings"></a> and <a href="#payload-bindings"></a> or specify protocol, media type and
+            <a href="#protocol-bindings"></a> and <a href="#payload-bindings"></a> or specify protocol, media type, and
             data structure at the same time.
           </p>
 
           <p>
-            In IoT platforms, there can be a requirement about the usage of HTTP together with certain JSON
-            payload structures. Thus, the corresponding <a>binding specification</a> provides Thing Models and examples
-            of TDs that allow semantic grouping of multiple bindings. This requires having a
-            <a>binding specification</a> for HTTP and JSON in the first place.
+            In IoT platforms, there can be a requirement about the use of HTTP together with certain JSON payload
+            structures. Thus, the corresponding <a>binding specification</a> provides Thing Models and examples of TDs
+            that allow semantic grouping of multiple bindings. This requires having a <a>binding specification</a> for
+            HTTP and JSON in the first place.
           </p>
 
           <p>
-            In standards like OPC-UA or BACnet, the <a>binding specification</a> contains requirements on
-            the protocol and media type, and possibly also on data structure. Thus, the <a>binding specification</a> is
-            enough on its own to specify how a <a>binding instance</a> should look.
+            In standards like OPC-UA or BACnet, the <a>binding specification</a> contains requirements on the protocol
+            and media type, and possibly also on data structure. Thus, the <a>binding specification</a> is enough on its
+            own to specify how a <a>binding instance</a> should look.
           </p>
         </section>
       </section>
@@ -4684,7 +4684,7 @@
           <p>
             Per default the Thing Description supports the <a>Protocol Binding</a> based on HTTP by including the HTTP
             RDF vocabulary definitions from <em>HTTP Vocabulary in RDF 1.0</em> [[?HTTP-in-RDF10]]. This vocabulary can
-            be directly used within TD instances by the usage of the prefix <code>htv</code>, which points to
+            be directly used within TD instances by the use of the prefix <code>htv</code>, which points to
             <code>http://www.w3.org/2011/http#</code>. Further details of <a>Protocol Binding</a> based on HTTP can be
             found in [[?WOT-BINDING-TEMPLATES]].
           </p>
@@ -4866,7 +4866,7 @@
             In the case of a <code>forms</code> entry that has multiple <code>op</code> values the usage of the
             <code>htv:methodName</code> is not permitted. A <a>TD Processor</a> will extend the multiple
             <code>op</code> values to separate <code>forms</code> entries and associates a single operation with the
-            default assumption. The address information (e.g. <code>href</code>) and other metadata are taken over in
+            default assumption. The address information (e.g., <code>href</code>) and other metadata are taken over in
             the extended version.
           </p>
 
@@ -5954,7 +5954,7 @@
               typed as string.
             </span>
 
-            After replacing the placeholder, e.g. when creating a Thing Description instance, the original type is
+            After replacing the placeholder, e.g., when creating a Thing Description instance, the original type is
             applied with the corresponding replaced value.
           </p>
 
@@ -6312,7 +6312,7 @@
           the garage door opener and car charger so A can use them. The scope however may be limited so that A cannot
           access certain administrative functions of these Things (for example, to change how long the garage door can
           remain open, or to change the charging rate). In addition, the access should expire after A is expected to
-          have left, e.g. after one week.
+          have left, e.g., after one week.
         </p>
         <dl>
           <dt>Mitigations:</dt>
@@ -6362,7 +6362,7 @@
           substitution, for example inserting the values of these strings into marked places in a HTML template to
           create final HTML, any HTML markup in the original string will be interpreted in the context of the browser
           displaying the dashboard. It is possible for an attacker to embed scripts in HTML in various ways and have
-          these scripts executed upon user interaction or even automatically (e.g. upon page load, or upon an error,
+          these scripts executed upon user interaction or even automatically (e.g., upon page load, or upon an error,
           which can be done intentionally). Since the string will be generated by the TD <a>producer</a> and the
           dashboard will be generated by a different origin, this is a form of cross-site-scripting (XSS) attack.
         </p>
@@ -6586,7 +6586,7 @@
           <dt>Mitigation:</dt>
           <dd>
             The <code>id</code> field in TDs is intentionally not required to be globally unique. There are several
-            cryptographic mechanisms (e.g. random UUIDs) available to generate suitable IDs in a distributed fashion
+            cryptographic mechanisms (e.g., random UUIDs) available to generate suitable IDs in a distributed fashion
             that do not require a central registry. These mechanisms typically have a very low probability of generating
             duplicate identifiers, and this needs to be taken into account in the system design; for example, by
             detecting duplicates and regenerating IDs when necessary. The scope of IDs also does not need to be global:
@@ -6836,8 +6836,8 @@
 
       <p>
         The following TD example uses HTTP, CoAP, and MQTT Protocol Bindings. These TDs have Context Extensions which
-        assume that there are CoAP-in-RDF and MQTT-in-RDF vocabularies similar to [[?HTTP-in-RDF10]] that are accessible via the
-        namespaces <code>http://www.example.org/coap-binding#</code> and
+        assume that there are CoAP-in-RDF and MQTT-in-RDF vocabularies similar to [[?HTTP-in-RDF10]] that are accessible
+        via the namespaces <code>http://www.example.org/coap-binding#</code> and
         <code>http://www.example.org/mqtt-binding#</code>, respectively. Please note that the TD context at
         <code>"https://www.w3.org/2022/wot/td/v1.1"</code> already includes the [[?HTTP-in-RDF10]], so HTTP context
         extensions can be used directly. Note that each <a>Binding Specification</a> contains the most up-to-date
@@ -7416,8 +7416,8 @@
             the
             <code>brightness</code> property can be read via HTTP and CoAP, and observed via MQTT;
             <code>concentration</code> event can be subscribed to via CoAP and MQTT. In this case, the Consumer would
-            pick the form it can support based on its internal implementation, e.g., whether it has a CoAP protocol stack
-            or not. Also see
+            pick the form it can support based on its internal implementation, e.g., whether it has a CoAP protocol
+            stack or not. Also see
             <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/http/index.html">HTTP Binding</a>,
             <a href="https://w3c.github.io/wot-binding-templates/bindings/protocols/coap/index.html">CoAP Binding</a>,
             and

--- a/index.template.html
+++ b/index.template.html
@@ -4,7 +4,7 @@
     <!-- <link rel="stylesheet" href="testing/atrisk.css"> -->
     <meta charset="utf-8" />
     <meta name="color-scheme" content="light dark" />
-    <title>Web of Things (WoT) Thing Description - Next</title>
+    <title>Web of Things (WoT) Thing Description 2.0</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove">
       var respecConfig = {
@@ -14,7 +14,7 @@
         // previousPublishDate: "2023-12-05",
         prevRecURI: "https://www.w3.org/TR/2023/REC-wot-thing-description11-20231205/",
         // implementationReportURI: "https://w3c.github.io/wot-thing-description/testing/report11.html",
-        shortName: "wot-thing-description-next", // temporary for now
+        shortName: "wot-thing-description-2.0",
         copyrightStart: 2017,
         noLegacyStyle: true,
         inlineCSS: true,
@@ -395,9 +395,9 @@
     <section id="abstract">
       <p>
         This document describes a formal information model and a common representation for a Web of Things (WoT) Thing
-        Description Next Version. A Thing Description describes the metadata and interfaces of <a>Things</a>, where a
-        <a>Thing</a> is an abstraction of a physical or virtual entity that provides interactions to and participates in
-        the Web of Things. Thing Descriptions provide a set of interactions based on a small vocabulary that makes it
+        Description (TD), Version 2.0. A Thing Description describes the metadata and interfaces of <a>Things</a>, where
+        a <a>Thing</a> is an abstraction of a physical or virtual entity that provides interactions to and participates
+        in the Web of Things. Thing Descriptions provide a set of interactions based on a small vocabulary that makes it
         possible both to integrate diverse devices and to allow diverse applications to interoperate. Thing
         Descriptions, by default, are encoded in a JSON format that also allows JSON-LD processing. The latter provides
         a powerful foundation to represent knowledge about <a>Things</a> in a machine-understandable way. A Thing
@@ -3978,9 +3978,15 @@
 
         <p>
           With the <a>TD Context Extensions</a> in a Thing Description, the communication metadata can be supplemented
+<<<<<<< HEAD
           via <a>Bindings</a> from the WoT Bindings Registry [[WOT-BINDINGS-REGISTRY]], which are added through
           additional <a>Vocabulary Terms</a> serialized into JSON objects representing a <code>Form</code> instance.
           Please see <a href="#bindings"></a> for further information.
+=======
+          or new <a>Protocol Bindings</a> added through additional <a>Vocabulary Terms</a> serialized into JSON objects
+          representing a <code>Form</code> instance. Please see <a href="#binding-templates"></a> for further
+          information.
+>>>>>>> ba277e48 (change to td 2.0 and fix broken links (#2113))
         </p>
       </section>
 
@@ -8701,7 +8707,7 @@
             assertion (td-security-no-secrets) in Section <a href="#securityscheme"></a>
           </li>
           <li>Section <a href="#form-additionalResponses"></a> has been newly added.</li>
-          <li>Remove TD Context Extensions CoAP example in Section <a href="#adding-protocol-bindings"></a></li>
+          <li>Remove TD Context Extensions CoAP example in Section <a href="#adding-bindings"></a></li>
           <li>
             Remove reference to Binding Document in assertion (bindings-requirements-scheme) in Section
             <a href="#protocol-bindings"></a>

--- a/index.template.html
+++ b/index.template.html
@@ -3425,7 +3425,7 @@
             },
             "unitSystem": {
                 "type": "string",
-                "enum": ["metric_value","imperial_value","uscustomary_value"],
+                "enum": ["metric","imperial","uscustomary"],
                 "description": "System of Measurement that will be used for the values"
             }
         },

--- a/index.template.html
+++ b/index.template.html
@@ -4104,8 +4104,8 @@
         In summary, Bindings enable a Thing Description to be adapted to a specific protocol, data payload formats or
         both in specific ways. This is done through URI Schemes, additional descriptive vocabularies, Thing Models and
         examples that aim to guide the implementors of Things and Consumers alike. This section explains the overall
-        mechanism and gives basic guidance on creating new Bindings. The [[WOT-BINDINGS-REGISTRY]] contains a
-        registry (list) of existing Bindings as well the requirements to follow to register new entries to the registry.
+        mechanism and gives basic guidance on creating new Bindings. The [[WOT-BINDINGS-REGISTRY]] contains a registry
+        (list) of existing Bindings as well the requirements to follow to register new entries to the registry.
       </p>
 
       <p>
@@ -4373,7 +4373,7 @@
               additional parameters. In this specific case, the forms describe that reading this property with
               <code>http</code> or <code>coap</code> result in different content types. For structured media types, a
               Data Schema is generally provided in the affordance level as explained in
-              [[[#payload-bindings-dataschema]]] and [[#sec-data-schema-vocabulary-definition"]]. However, for
+              [[[#payload-bindings-dataschema]]] and [[[#sec-data-schema-vocabulary-definition]]]. However, for
               unstructured data such as images and videos, a Data Schema is typically not available.
             </p>
 
@@ -4432,7 +4432,7 @@
             <h6>Data Schemas</h6>
 
             <p>
-              Data Schema, as explained in [[#sec-data-schema-vocabulary-definition"]], describes the structure of the
+              Data Schema, as explained in [[[#sec-data-schema-vocabulary-definition]]], describes the structure of the
               messages, which are used together with media types. Even though it is largely inspired by JSON Schema
               [[json-schema]], it can be used for describing other payload types such as [[XML]], string-encoded images,
               bit representations of integers, etc. Data Schema SHOULD be used in addition to the media types.
@@ -4441,7 +4441,7 @@
               Depending on the case, the structure of the messages can be anything from a simple number to arrays or
               objects with multiple levels of nesting. Existing IoT Platforms and Standards have certain payload formats
               with variations on how the data is structured. As explained in
-              [[#sec-data-schema-vocabulary-definition"]], Data Schema can be used in a TD in one of the following
+              [[[#sec-data-schema-vocabulary-definition]]], Data Schema can be used in a TD in one of the following
               places:
             </p>
             <ul>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Specification 'Web of Things (WoT) Thing Description'",
   "main": "render.js",
   "scripts": {
-    "render": "bash ./render.sh",
+    "render": "bash ./render.sh && prettier . --write",
     "assertions": "node assertions.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:validation": "mocha validation/**/*.test.js",


### PR DESCRIPTION
<!-- Changes to WoT documents follow the [asynchronous decision policy](https://github.com/w3c/wot/blob/main/policies/async-decision.md). Please fill below to speed up the process -->

## Description of Changes

I am reworking the intro to take into account the registry, the change of naming (binding template -> binding), and the existence of overlapping content. 

## Related Issue

<!-- Put the issue number after # -->

Will close point 4 of #2112 

## Type of Change

- [Normative](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Normative Label](https://img.shields.io/github/labels/w3c/wot-thing-description/normative%20change) as there are two assertions in current


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/pull/2118.html" title="Last updated on Aug 7, 2025, 12:50 PM UTC (8aa89a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/2118/b0fbec2...8aa89a9.html" title="Last updated on Aug 7, 2025, 12:50 PM UTC (8aa89a9)">Diff</a>