### PR TITLE
Provide 2 assertion colors depending on dark/light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,7 +383,10 @@
     <!-- ASSERTION HIGHLIGHTING -->
     <style>
       .rfc2119-assertion {
-        background-color: rgb(230, 230, 230);
+        background-color: #e6e6e6;
+      }
+      .darkmode .rfc2119-assertion {
+        background-color: #223a2c;
       }
       .at-risk {
         background-color: yellow;

--- a/index.template.html
+++ b/index.template.html
@@ -383,7 +383,10 @@
     <!-- ASSERTION HIGHLIGHTING -->
     <style>
       .rfc2119-assertion {
-        background-color: rgb(230, 230, 230);
+        background-color: #e6e6e6;
+      }
+      .darkmode .rfc2119-assertion {
+        background-color: #223a2c;
       }
       .at-risk {
         background-color: yellow;


### PR DESCRIPTION
fixes https://github.com/w3c/wot-thing-description/issues/2138


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-thing-description/pull/2139.html" title="Last updated on Sep 11, 2025, 2:52 PM UTC (a012304)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/2139/b31160a...danielpeintner:a012304.html" title="Last updated on Sep 11, 2025, 2:52 PM UTC (a012304)">Diff</a>