### PR TITLE
Add categorization for TD-related Architecture assertions 1 to 9

### DIFF
--- a/planning/work-items/other-documents-sync/arch.md
+++ b/planning/work-items/other-documents-sync/arch.md
@@ -22,33 +22,41 @@ Continuation of https://github.com/w3c/wot-thing-description/issues/2120
 
 ##### 6.1.1.1 Thing Descriptions
 
-- [ ] 1. In W3C WoT, the description metadata for a Thing instance MUST be available as a WoT Thing Description (TD) [WOT-THING-DESCRIPTION]. ([arch-td-metadata](https://www.w3.org/TR/wot-architecture11/#arch-td-metadata))
+- [x] 1. In W3C WoT, the description metadata for a Thing instance MUST be available as a WoT Thing Description (TD) [WOT-THING-DESCRIPTION]. ([arch-td-metadata](https://www.w3.org/TR/wot-architecture11/#arch-td-metadata))
 
-  - Category: A1 / A2 / A3 / B / C (example)
+  - A3 (add to [Behavioral Assertions](https://w3c.github.io/wot-thing-description/#behavior)?)
 
-- [ ] 2. There MAY be other representations of a Thing such as an HTML-based user interface, simply an image of the physical entity, or even non-Web representations in closed systems. ([arch-other-thing-representations](https://www.w3.org/TR/wot-architecture11/#arch-other-thing-representations))
+- [x] 2. There MAY be other representations of a Thing such as an HTML-based user interface, simply an image of the physical entity, or even non-Web representations in closed systems. ([arch-other-thing-representations](https://www.w3.org/TR/wot-architecture11/#arch-other-thing-representations))
+  - D
 
-- [ ] 3. To be considered a Thing, however, at least one TD representation MUST be available. ([arch-td-mandatory](https://www.w3.org/TR/wot-architecture11/#arch-td-mandatory))
+- [x] 3. To be considered a Thing, however, at least one TD representation MUST be available. ([arch-td-mandatory](https://www.w3.org/TR/wot-architecture11/#arch-td-mandatory))
+  - A3 (add to [Behavioral Assertions](https://w3c.github.io/wot-thing-description/#behavior)?)
 
 #### 6.1.2 Links
 
-- [ ] 4. WoT Thing Descriptions and WoT Thing Models MAY link to other Things, WoT Thing Models, and other resources on the Web to form a Web of Things. ([arch-td-linking](https://www.w3.org/TR/wot-architecture11/#arch-td-linking))
+- [x] 4. WoT Thing Descriptions and WoT Thing Models MAY link to other Things, WoT Thing Models, and other resources on the Web to form a Web of Things. ([arch-td-linking](https://www.w3.org/TR/wot-architecture11/#arch-td-linking))
+  - A1 ([5.3.4.1 Link](https://w3c.github.io/wot-thing-description/#link))
 
-- [ ] 5. Things MUST be hosted on networked system components with a software stack to realize interaction through a network-facing interface, the WoT Interface of a Thing. ([arch-networked](https://www.w3.org/TR/wot-architecture11/#arch-networked))
+- [x] 5. Things MUST be hosted on networked system components with a software stack to realize interaction through a network-facing interface, the WoT Interface of a Thing. ([arch-networked](https://www.w3.org/TR/wot-architecture11/#arch-networked))
+  - D
 
 ### 6.5 Interaction Model
 
-- [ ] 6. In addition to navigation affordances (i.e., Web links), Things MAY offer three other types of Interaction Affordances defined by this specification: Properties, Actions, and Events. ([arch-affordances](https://www.w3.org/TR/wot-architecture11/#arch-affordances))
+- [x] 6. In addition to navigation affordances (i.e., Web links), Things MAY offer three other types of Interaction Affordances defined by this specification: Properties, Actions, and Events. ([arch-affordances](https://www.w3.org/TR/wot-architecture11/#arch-affordances))
+  - D
 
 #### 6.5.1 Properties
 
-- [ ] 7. If the data format is not fully specified by the Protocol Binding used (e.g., through a media type), Properties MAY contain one data schema for the exposed state. ([arch-property-dataschema](https://www.w3.org/TR/wot-architecture11/#arch-property-dataschema))
+- [x] 7. If the data format is not fully specified by the Protocol Binding used (e.g., through a media type), Properties MAY contain one data schema for the exposed state. ([arch-property-dataschema](https://www.w3.org/TR/wot-architecture11/#arch-property-dataschema))
+  - A1 ([8.1.2.2 Data Schemas](https://w3c.github.io/wot-thing-description/#payload-bindings-dataschema))
 
 #### 6.5.2 Actions
 
-- [ ] 8. An Action MAY manipulate state that is not directly exposed (cf. Properties), manipulate multiple Properties at a time, or manipulate Properties based on internal logic (e.g., toggle). ([arch-action-functions](https://www.w3.org/TR/wot-architecture11/#arch-action-functions))
+- [x] 8. An Action MAY manipulate state that is not directly exposed (cf. Properties), manipulate multiple Properties at a time, or manipulate Properties based on internal logic (e.g., toggle). ([arch-action-functions](https://www.w3.org/TR/wot-architecture11/#arch-action-functions))
+  - A1 ([5.3.1.4 ActionAffordance](https://w3c.github.io/wot-thing-description/#actionaffordance))
 
-- [ ] 9. Invoking an Action MAY also trigger a process on the Thing that manipulates state (including physical state through actuators) over time. ([arch-action-process](https://www.w3.org/TR/wot-architecture11/#arch-action-process))
+- [x] 9. Invoking an Action MAY also trigger a process on the Thing that manipulates state (including physical state through actuators) over time. ([arch-action-process](https://www.w3.org/TR/wot-architecture11/#arch-action-process))
+  - A1 ([5.3.1.4 ActionAffordance](https://w3c.github.io/wot-thing-description/#actionaffordance))
 
 - [ ] 10. If the data format is not fully specified by the Protocol Binding used (e.g., through a media type), Actions MAY contain data schemas for input parameters and output results. ([arch-action-dataschema](https://www.w3.org/TR/wot-architecture11/#arch-action-dataschema))
 


### PR DESCRIPTION
## Description of Changes

I categorized assertions 1 through 9 in the Architecture document.
For the items labeled A1, there may not be a directly corresponding assertion, but I believe the necessary content is covered in the entire section I linked.

## Related Issue

#2126

## Type of Change

- [Editorial (non-normative)](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Editorial Label](https://img.shields.io/github/labels/w3c/wot-thing-description/Editorial).