### PR TITLE
Add categorization for TD-related Architecture assertions 37 to 45

### DIFF
--- a/planning/work-items/other-documents-sync/arch.md
+++ b/planning/work-items/other-documents-sync/arch.md
@@ -143,12 +143,15 @@ Continuation of https://github.com/w3c/wot-thing-description/issues/2120
 #### 10.3.2 Security Credentials Storage Risk
 
 - [x] 37. The WoT Runtime SHOULD securely store any provisioned security credentials, guaranteeing their integrity and confidentiality. ([arch-security-consideration-secure-cred-storage](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-secure-cred-storage))
+
   - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
 - [x] 38. In case there are more than one tenant on a single WoT-enabled device, a WoT Runtime implementation SHOULD isolate each tenant's provisioned security credentials from other tenants. ([arch-security-consideration-secure-cred-isolation](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-secure-cred-isolation))
+
   - B (https://w3c.github.io/wot-security/#wot-threat-model-stakeholders)
 
 - [x] 39. In order to minimize a risk that provisioned security credentials get compromised, the WoT Runtime implementation SHOULD NOT expose any API for scripts to query provisioned security credentials. ([arch-security-consideration-no-expose-cred](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-no-expose-cred))
+
   - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
 - [x] 40. Such credentials (or even better, abstract operations that use them but do not expose them) SHOULD only be accessible to the underlying protocol implementation that uses them. ([arch-security-consideration-limit-cred-access](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-limit-cred-access))
@@ -157,6 +160,7 @@ Continuation of https://github.com/w3c/wot-thing-description/issues/2120
 ### 10.4 Trusted Environment Risks
 
 - [x] 41. Trust relationships SHOULD be as restricted as possible, ideally pairwise and limited to precisely the access required. ([arch-security-consideration-limit-trust](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-limit-trust))
+
   - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
 - [x] 42. In the case of implicit access control via access to a common network a segmented network SHOULD be used. ([arch-security-consideration-segmented-network](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-segmented-network))
@@ -165,12 +169,15 @@ Continuation of https://github.com/w3c/wot-thing-description/issues/2120
 ### 10.5 Secure Transport
 
 - [x] 43. When a Thing is made available on the public internet so it can be accessed by anyone, from anywhere, then it MUST be protected by secure transport such as TLS or DTLS. ([arch-security-consideration-tls-mandatory-pub](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-mandatory-pub))
+
   - B (https://w3c.github.io/wot-security/#sec-pract-system-user-data)
 
 - [x] 44. When a Thing is made available on a private network then it SHOULD be protected by secure transport such as TLS or DTLS. ([arch-security-consideration-tls-recommended-priv](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-recommended-priv))
+
   - B (https://w3c.github.io/wot-security/#sec-pract-system-user-data)
 
 - [x] 45. Private networks such as a LAN, protected by a firewall, MAY use the Trusted Environment approach of depending on network security only. ([arch-security-consideration-tls-optional-on-lan](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-optional-on-lan))
+
   - B (https://w3c.github.io/wot-security/)
 
 - [ ] 46. When secure transport over TCP is appropriate, then at least TLS 1.3 [RFC8446] SHOULD be used. ([arch-security-consideration-tls-1-3](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-1-3))

--- a/planning/work-items/other-documents-sync/arch.md
+++ b/planning/work-items/other-documents-sync/arch.md
@@ -142,41 +142,41 @@ Continuation of https://github.com/w3c/wot-thing-description/issues/2120
 
 #### 10.3.2 Security Credentials Storage Risk
 
-- [x] 37. The WoT Runtime SHOULD securely store any provisioned security credentials, guaranteeing their integrity and confidentiality. ([arch-security-consideration-secure-cred-storage](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-secure-cred-storage))
+- [ ] 37. The WoT Runtime SHOULD securely store any provisioned security credentials, guaranteeing their integrity and confidentiality. ([arch-security-consideration-secure-cred-storage](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-secure-cred-storage))
 
   - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
-- [x] 38. In case there are more than one tenant on a single WoT-enabled device, a WoT Runtime implementation SHOULD isolate each tenant's provisioned security credentials from other tenants. ([arch-security-consideration-secure-cred-isolation](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-secure-cred-isolation))
+- [ ] 38. In case there are more than one tenant on a single WoT-enabled device, a WoT Runtime implementation SHOULD isolate each tenant's provisioned security credentials from other tenants. ([arch-security-consideration-secure-cred-isolation](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-secure-cred-isolation))
 
   - B (https://w3c.github.io/wot-security/#wot-threat-model-stakeholders)
 
-- [x] 39. In order to minimize a risk that provisioned security credentials get compromised, the WoT Runtime implementation SHOULD NOT expose any API for scripts to query provisioned security credentials. ([arch-security-consideration-no-expose-cred](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-no-expose-cred))
+- [ ] 39. In order to minimize a risk that provisioned security credentials get compromised, the WoT Runtime implementation SHOULD NOT expose any API for scripts to query provisioned security credentials. ([arch-security-consideration-no-expose-cred](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-no-expose-cred))
 
   - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
-- [x] 40. Such credentials (or even better, abstract operations that use them but do not expose them) SHOULD only be accessible to the underlying protocol implementation that uses them. ([arch-security-consideration-limit-cred-access](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-limit-cred-access))
+- [ ] 40. Such credentials (or even better, abstract operations that use them but do not expose them) SHOULD only be accessible to the underlying protocol implementation that uses them. ([arch-security-consideration-limit-cred-access](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-limit-cred-access))
   - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
 ### 10.4 Trusted Environment Risks
 
-- [x] 41. Trust relationships SHOULD be as restricted as possible, ideally pairwise and limited to precisely the access required. ([arch-security-consideration-limit-trust](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-limit-trust))
+- [ ] 41. Trust relationships SHOULD be as restricted as possible, ideally pairwise and limited to precisely the access required. ([arch-security-consideration-limit-trust](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-limit-trust))
 
   - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
-- [x] 42. In the case of implicit access control via access to a common network a segmented network SHOULD be used. ([arch-security-consideration-segmented-network](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-segmented-network))
+- [ ] 42. In the case of implicit access control via access to a common network a segmented network SHOULD be used. ([arch-security-consideration-segmented-network](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-segmented-network))
   - B (https://w3c.github.io/wot-security/)
 
 ### 10.5 Secure Transport
 
-- [x] 43. When a Thing is made available on the public internet so it can be accessed by anyone, from anywhere, then it MUST be protected by secure transport such as TLS or DTLS. ([arch-security-consideration-tls-mandatory-pub](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-mandatory-pub))
+- [ ] 43. When a Thing is made available on the public internet so it can be accessed by anyone, from anywhere, then it MUST be protected by secure transport such as TLS or DTLS. ([arch-security-consideration-tls-mandatory-pub](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-mandatory-pub))
 
   - B (https://w3c.github.io/wot-security/#sec-pract-system-user-data)
 
-- [x] 44. When a Thing is made available on a private network then it SHOULD be protected by secure transport such as TLS or DTLS. ([arch-security-consideration-tls-recommended-priv](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-recommended-priv))
+- [ ] 44. When a Thing is made available on a private network then it SHOULD be protected by secure transport such as TLS or DTLS. ([arch-security-consideration-tls-recommended-priv](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-recommended-priv))
 
   - B (https://w3c.github.io/wot-security/#sec-pract-system-user-data)
 
-- [x] 45. Private networks such as a LAN, protected by a firewall, MAY use the Trusted Environment approach of depending on network security only. ([arch-security-consideration-tls-optional-on-lan](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-optional-on-lan))
+- [ ] 45. Private networks such as a LAN, protected by a firewall, MAY use the Trusted Environment approach of depending on network security only. ([arch-security-consideration-tls-optional-on-lan](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-optional-on-lan))
 
   - B (https://w3c.github.io/wot-security/)
 

--- a/planning/work-items/other-documents-sync/arch.md
+++ b/planning/work-items/other-documents-sync/arch.md
@@ -142,27 +142,36 @@ Continuation of https://github.com/w3c/wot-thing-description/issues/2120
 
 #### 10.3.2 Security Credentials Storage Risk
 
-- [ ] 37. The WoT Runtime SHOULD securely store any provisioned security credentials, guaranteeing their integrity and confidentiality. ([arch-security-consideration-secure-cred-storage](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-secure-cred-storage))
+- [x] 37. The WoT Runtime SHOULD securely store any provisioned security credentials, guaranteeing their integrity and confidentiality. ([arch-security-consideration-secure-cred-storage](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-secure-cred-storage))
+  - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
-- [ ] 38. In case there are more than one tenant on a single WoT-enabled device, a WoT Runtime implementation SHOULD isolate each tenant's provisioned security credentials from other tenants. ([arch-security-consideration-secure-cred-isolation](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-secure-cred-isolation))
+- [x] 38. In case there are more than one tenant on a single WoT-enabled device, a WoT Runtime implementation SHOULD isolate each tenant's provisioned security credentials from other tenants. ([arch-security-consideration-secure-cred-isolation](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-secure-cred-isolation))
+  - B (https://w3c.github.io/wot-security/#wot-threat-model-stakeholders)
 
-- [ ] 39. In order to minimize a risk that provisioned security credentials get compromised, the WoT Runtime implementation SHOULD NOT expose any API for scripts to query provisioned security credentials. ([arch-security-consideration-no-expose-cred](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-no-expose-cred))
+- [x] 39. In order to minimize a risk that provisioned security credentials get compromised, the WoT Runtime implementation SHOULD NOT expose any API for scripts to query provisioned security credentials. ([arch-security-consideration-no-expose-cred](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-no-expose-cred))
+  - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
-- [ ] 40. Such credentials (or even better, abstract operations that use them but do not expose them) SHOULD only be accessible to the underlying protocol implementation that uses them. ([arch-security-consideration-limit-cred-access](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-limit-cred-access))
+- [x] 40. Such credentials (or even better, abstract operations that use them but do not expose them) SHOULD only be accessible to the underlying protocol implementation that uses them. ([arch-security-consideration-limit-cred-access](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-limit-cred-access))
+  - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
 ### 10.4 Trusted Environment Risks
 
-- [ ] 41. Trust relationships SHOULD be as restricted as possible, ideally pairwise and limited to precisely the access required. ([arch-security-consideration-limit-trust](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-limit-trust))
+- [x] 41. Trust relationships SHOULD be as restricted as possible, ideally pairwise and limited to precisely the access required. ([arch-security-consideration-limit-trust](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-limit-trust))
+  - B (https://w3c.github.io/wot-security/#wot-threat-model-assets)
 
-- [ ] 42. In the case of implicit access control via access to a common network a segmented network SHOULD be used. ([arch-security-consideration-segmented-network](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-segmented-network))
+- [x] 42. In the case of implicit access control via access to a common network a segmented network SHOULD be used. ([arch-security-consideration-segmented-network](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-segmented-network))
+  - B (https://w3c.github.io/wot-security/)
 
 ### 10.5 Secure Transport
 
-- [ ] 43. When a Thing is made available on the public internet so it can be accessed by anyone, from anywhere, then it MUST be protected by secure transport such as TLS or DTLS. ([arch-security-consideration-tls-mandatory-pub](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-mandatory-pub))
+- [x] 43. When a Thing is made available on the public internet so it can be accessed by anyone, from anywhere, then it MUST be protected by secure transport such as TLS or DTLS. ([arch-security-consideration-tls-mandatory-pub](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-mandatory-pub))
+  - B (https://w3c.github.io/wot-security/#sec-pract-system-user-data)
 
-- [ ] 44. When a Thing is made available on a private network then it SHOULD be protected by secure transport such as TLS or DTLS. ([arch-security-consideration-tls-recommended-priv](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-recommended-priv))
+- [x] 44. When a Thing is made available on a private network then it SHOULD be protected by secure transport such as TLS or DTLS. ([arch-security-consideration-tls-recommended-priv](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-recommended-priv))
+  - B (https://w3c.github.io/wot-security/#sec-pract-system-user-data)
 
-- [ ] 45. Private networks such as a LAN, protected by a firewall, MAY use the Trusted Environment approach of depending on network security only. ([arch-security-consideration-tls-optional-on-lan](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-optional-on-lan))
+- [x] 45. Private networks such as a LAN, protected by a firewall, MAY use the Trusted Environment approach of depending on network security only. ([arch-security-consideration-tls-optional-on-lan](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-optional-on-lan))
+  - B (https://w3c.github.io/wot-security/)
 
 - [ ] 46. When secure transport over TCP is appropriate, then at least TLS 1.3 [RFC8446] SHOULD be used. ([arch-security-consideration-tls-1-3](https://www.w3.org/TR/wot-architecture11/#arch-security-consideration-tls-1-3))
 


### PR DESCRIPTION
## Description of Changes

Categorizes assertions 37 to 45 in the Architecture document.
TD Spec has a [Security Considerations section](https://w3c.github.io/wot-thing-description/#sec-security-consideration), but I think those assertions all belong to the [WoT Security and Privacy Guidelines](https://w3c.github.io/wot-security/) document.

## Related Issue

https://github.com/w3c/wot-thing-description/issues/2126

## Type of Change

[Editorial (non-normative)](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Editorial Label](https://img.shields.io/github/labels/w3c/wot-thing-description/Editorial).
