### PR TITLE
Add an event-related assertion of Architecture Document (11)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1957,8 +1957,13 @@
               EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs
               interested Consumers about state changes. However, a main difference of EventAffordances is that not every
               change of the associated resource needs to trigger an event message to be emitted, e.g., a critical
-              threshold for a numeric value. Furthermore, EventAffordances allow for more complex subscribing and
-              unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and
+              threshold for a numeric value.
+              <!-- arch-event-trigger -->
+              <span class="rfc2119-assertion" id="td-event-trigger"
+                >Events MAY be triggered through conditions that are not exposed as Properties.</span
+              >
+              Furthermore, EventAffordances allow for more complex subscribing and unsubscribing mechanisms via the
+              definition of <code>subscription</code>, <code>dataResponse</code>, and
               <code>cancellation</code> DataSchema definitions. Not all protocols might support these more advanced
               mechanisms, however, which is why in some scenarios, events may be very similar to observable
               PropertyAffordances. In these cases, the choice between a Property and a Event for modelling the

--- a/testing/assertions.csv
+++ b/testing/assertions.csv
@@ -122,6 +122,7 @@
 "td-event-objects_data","null","The type of the members data MUST be serialized as a JSON object."
 "td-event-objects_dataResponse","null","The type of the members dataResponse MUST be serialized as a JSON object."
 "td-event-objects_subscription","null","The type of the members subscription MUST be serialized as a JSON object."
+"td-event-trigger","null","Events MAY be triggered through conditions that are not exposed as Properties."
 "td-events","null","All name-value pairs of a Map of EventAffordance instances MUST be serialized as members of the JSON object that results from serializing the Map; the name of a pair MUST be serialized as a JSON string and the value of the pair, an instance of EventAffordance, MUST be serialized as a JSON object."
 "td-events_existence","null","Events offered by a Thing MUST be collected in the JSON-object based events member."
 "td-events_uniqueness","null","Events collected in the JSON-object based events member MUST have unique JSON names."

--- a/validation/td-validation.ttl
+++ b/validation/td-validation.ttl
@@ -539,6 +539,8 @@
           <p>
             EventAffordances are similar to observable PropertyAffordances in the sense that the Thing itself informs interested Consumers about state changes.
             However, a main difference of EventAffordances is that not every change of the associated resource needs to trigger an event message to be emitted, e.g., a critical threshold for a numeric value.
+            <!-- arch-event-trigger -->
+            <span class="rfc2119-assertion" id="td-event-trigger">Events MAY be triggered through conditions that are not exposed as Properties.</span>
         Furthermore, EventAffordances allow for more complex subscribing and unsubscribing mechanisms via the definition of <code>subscription</code>, <code>dataResponse</code>, and <code>cancellation</code> DataSchema definitions.
             Not all protocols might support these more advanced mechanisms, however, which is why in some scenarios, events may be very similar to observable PropertyAffordances.
             In these cases, the choice between a Property and a Event for modelling the Affordance should be made based on the semantics of the underlying resource; for example, if the state of the affordance is also supposed to be read or written by a Consumer, then a Property is most likely the appropriate choice.


### PR DESCRIPTION
## Description of Changes

Added a following new assertion from Architecture Document to [5.3.1.5 EventAffordance](https://w3c.github.io/wot-thing-description/#eventaffordance).
> Events MAY be triggered through conditions that are not exposed as Properties. 

## Related Issue

#2151 (11)

## Type of Change

- [Normative](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Normative Label](https://img.shields.io/github/labels/w3c/wot-thing-description/normative%20change)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-thing-description/pull/2187.html" title="Last updated on Feb 12, 2026, 12:27 AM UTC (7a22a46)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-thing-description/2187/0ad3902...k-toumura:7a22a46.html" title="Last updated on Feb 12, 2026, 12:27 AM UTC (7a22a46)">Diff</a>