### PR TITLE
Fixes to JSON Schema to allow a single URI for the context value

### DIFF
--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -76,27 +76,27 @@
           "$ref": "#/definitions/thing-context-td-uri-temp"
         },
         {
-        "$comment": "Experimental context URI with other vocabularies after it",
-        "type": "array",
-        "items": [
-          {
-            "$ref": "#/definitions/thing-context-td-uri-temp"
-          }
-        ],
-        "additionalItems": {
-          "anyOf": [
+          "$comment": "Experimental context URI with other vocabularies after it",
+          "type": "array",
+          "items": [
             {
-              "$ref": "#/definitions/anyUri"
-            },
-            {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "$ref": "#/definitions/thing-context-td-uri-temp"
             }
-          ]
+          ],
+          "additionalItems": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/anyUri"
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
         }
-       }
       ]
     },
     "bcp47_string": {

--- a/validation/td-json-schema-validation.json
+++ b/validation/td-json-schema-validation.json
@@ -70,26 +70,34 @@
       "const": "https://www.w3.org/ns/wot-next/td"
     },
     "thing-context": {
-      "$comment": "Experimental context URI with other vocabularies after it",
-      "type": "array",
-      "items": [
+      "anyOf": [
         {
+          "$comment": "Only the experimental context URI",
           "$ref": "#/definitions/thing-context-td-uri-temp"
-        }
-      ],
-      "additionalItems": {
-        "anyOf": [
+        },
+        {
+        "$comment": "Experimental context URI with other vocabularies after it",
+        "type": "array",
+        "items": [
           {
-            "$ref": "#/definitions/anyUri"
-          },
-          {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "$ref": "#/definitions/thing-context-td-uri-temp"
           }
-        ]
-      }
+        ],
+        "additionalItems": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/anyUri"
+            },
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+       }
+      ]
     },
     "bcp47_string": {
       "type": "string",

--- a/validation/tm-json-schema-validation.json
+++ b/validation/tm-json-schema-validation.json
@@ -83,26 +83,34 @@
       "const": "https://www.w3.org/ns/wot-next/td"
     },
     "thing-context": {
-      "$comment": "Experimental context URI with other vocabularies after it",
-      "type": "array",
-      "items": [
+      "anyOf": [
         {
+          "$comment": "Only the experimental context URI",
           "$ref": "#/definitions/thing-context-td-uri-temp"
-        }
-      ],
-      "additionalItems": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/anyUri"
-          },
-          {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
+        },
+        {
+          "$comment": "Experimental context URI with other vocabularies after it",
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/thing-context-td-uri-temp"
             }
+          ],
+          "additionalItems": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/anyUri"
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
     },
     "bcp47_string": {
       "type": "string",


### PR DESCRIPTION
<!-- Changes to WoT documents follow the [asynchronous decision policy](https://github.com/w3c/wot/blob/main/policies/async-decision.md). Please fill below to speed up the process -->

## Description of Changes

<!-- Free-text summary of the changes made by the pull request -->

Reverting the problem caused in #2128 

## Related Issue

<!-- Put the issue number after # -->

Closes #2204 

## Type of Change


- [Editorial (non-normative)](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Editorial Label](https://img.shields.io/github/labels/w3c/wot-thing-description/Editorial).



