### PR TITLE
Stable URLs in Explainers

### DIFF
--- a/explainer/Explainer.md
+++ b/explainer/Explainer.md
@@ -5,7 +5,7 @@
 [//]: # "The W3C Web of Things [WoT] is intended to enable
 interoperability across IoT Platforms and application domains using Web technology."
 
-In the [WoT Architecture](https://w3c.github.io/wot-architecture/index.html),
+In the [WoT Architecture](https://www.w3.org/TR/2020/REC-wot-architecture-20200409/),
 a Thing is defined as an abstraction of an IoT device or service.
 The Thing Description (TD) provides descriptive metadata for a Thing.
 TDs supports interoperability between Things (and applications that use Things)
@@ -37,7 +37,7 @@ Each building block,
 identified in the WoT WG's charter,
 is concerned with addressing specific interoperability issues.
 
-![WoT Building Blocks](https://w3c.github.io/wot-architecture/images/wot-thing-with-scripting.png)
+![WoT Building Blocks](https://www.w3.org/TR/2020/REC-wot-architecture-20200409/images/servient/wot-thing-scripting.svg)
 
 TDs are a WoT building block that consolidates metadata related
 to several of different architectural aspects of Things.
@@ -211,36 +211,36 @@ conceptually interconvertible with JSON.
 ## What is inside the Thing Description (TD) specification
 
 The draft TD specification is
-[available for review](https://w3c.github.io/wot-thing-description/).
+[available for review](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/).
 
 This specification primarily defines the TD Information Model
 and the TD Serialization as JSON:
 
-- **[TD Information Model](https://w3c.github.io/wot-thing-description/#sec-vocabulary-definition)** (Section 5)
+- **[TD Information Model](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#sec-core-vocabulary-definition)** (Section 5)
 
   The Thing Description Information model serves as the conceptual basis
   for the serialization and processing of a Thing Description.
   It consists of the four vocabularies listed below:
 
-  - [**Core Vocabulary**](https://w3c.github.io/wot-thing-description/#sec-core-vocabulary-definition)
+  - [**Core Vocabulary**](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#sec-core-vocabulary-definition)
 
     TD Information Model's core vocabulary includes terms for:
 
-    - _[Thing](https://w3c.github.io/wot-thing-description/#thing)_,
-    - _[Interaction Affordance](https://w3c.github.io/wot-thing-description/#interactionaffordance)_,
-    - _[Form](https://w3c.github.io/wot-thing-description/#form)_,
-    - _[Version Information](https://w3c.github.io/wot-thing-description/#versioninfo)_,
-    - _[Expected Response](https://w3c.github.io/wot-thing-description/#expectedresponse)_
+    - _[Thing](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#thing)_,
+    - _[Interaction Affordance](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#interactionaffordance)_,
+    - _[Form](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#form)_,
+    - _[Version Information](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#versioninfo)_,
+    - _[Expected Response](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#expectedresponse)_
       (media type of response messages), and
-    - _[Multi Language](https://w3c.github.io/wot-thing-description/#multilanguage)_
+    - _[Multi Language](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#multilanguage)_
       (Container to provide human-readable text in different languages).
 
-  - [**Data Schema Vocabulary**](https://w3c.github.io/wot-thing-description/#sec-data-schema-vocabulary-definition)
+  - [**Data Schema Vocabulary**](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#dataschema)
     - Vocabulary for Data Schema definitions of
       both scalar and structured payload data.
-  - [**Security Vocabulary**](https://w3c.github.io/wot-thing-description/#sec-security-vocabulary-definition)
+  - [**Security Vocabulary**](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#sec-security-vocabulary-definition)
     - Vocabulary of well-established security mechanisms considered appropriate to be built-in in TD Information Model.
-  - [**Web Linking Vocabulary**](https://w3c.github.io/wot-thing-description/#sec-web-linking-vocabulary-definition)
+  - [**Web Linking Vocabulary**](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#link)
     - Vocabulary for web links exposed by a Thing.
     - The Web Linking Vocabulary, modeled after the CoRE Link format,
       is in its own namespace for modularity.
@@ -248,10 +248,10 @@ and the TD Serialization as JSON:
 The TD Information Model borrows two keywords from JSON-LD, `@context` and `@type`,
 as extension points in order to allow the use of semantic vocabularies and tools.
 
-- **[TD Serialization](https://w3c.github.io/wot-thing-description/#sec-td-serialization)** (Section 6)
+- **[TD Serialization](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#sec-td-serialization)** (Section 6)
   - Describes the serialization of instances of TD Information Model.
   - Serialization of TD is in JSON.
-  - There is an (informative) [JSON Schema](https://w3c.github.io/wot-thing-description/#json-schema-4-validation)
+  - There is an (informative) [JSON Schema](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#json-schema-for-validation)
     provided for TD serialization that can be used for validating TD instances.
 
 In light of the Open-World assumption used by RDF,
@@ -267,12 +267,12 @@ in TD specification.
 In particular,
 a Full Thing Description instance always at least contains an `@context` value
 at the
-[Thing](https://w3c.github.io/wot-thing-description/#sec-thing-as-a-whole-json) level.
+[Thing](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#sec-thing-as-a-whole-json) level.
 
 The Full Thing Description enables semantic processing,
 such as that supported by RDF tools.
 The TD specification also provides
-[guidelines](https://w3c.github.io/wot-thing-description/#note-jsonld11-processing)
+[guidelines](https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/#json-ld-ctx-usage)
 (in an Appendix) for transforming TD instances into a form
 adequate for feeding into such tools, i.e. RDF N-Triples.
 The TD is also aligned with the current JSON-LD 1.1 draft.
@@ -321,7 +321,7 @@ TD instances must use external vocabularies such as
 the [HTTP Vocabulary in RDF 1.0](https://www.w3.org/TR/HTTP-in-RDF10/)
 to identify methods and options for particular concrete protocols (such as HTTP).
 See more on the WoT WG Note
-[Web of Things (WoT) Protocol Binding Templates](https://w3c.github.io/wot-binding-templates/).
+[Web of Things (WoT) Protocol Binding Templates](https://www.w3.org/TR/2024/NOTE-wot-binding-templates-20240528/).
 
 The reason for this decision is to simplify the extension of the TD
 specification to additional concrete communication protocols in the future.
@@ -334,9 +334,9 @@ An explanation follows the example:
 ```json
 {
   "@context": [
-    "http://w3.org/ns/td",
+    "https://www.w3.org/2019/wot/td/v1",
     { "saref": "https://w3id.org/saref#" },
-    { "htv": "http://www.w3.org/2011/http#" }
+    { "htv": "https://www.w3.org/2011/http#" }
   ],
   "@type": ["Thing", "saref#LightingDevice"],
   "id": "urn:dev:wot:com:example:servient:lamp",
@@ -464,7 +464,7 @@ Implementations were built by
 Smart Things, ERCIM, Hitachi, Intel, Oracle, Panasonic, Fujitsu and Siemens.
 Some organizations built more than one implementation;
 in total 15 implementations were developed.
-The [`node-wot`](https://github.com/eclipse/thingweb.node-wot)
+The [`node-wot`](https://github.com/eclipse-thingweb/node-wot)
 implementation open-sourced by Siemens
 via the Eclipse Foundation is one of the most complete
 implementations and can be considered a "reference implementation".

--- a/explainer/Explainer11.md
+++ b/explainer/Explainer11.md
@@ -9,7 +9,7 @@ This is an updated version of the [Explainer for TD 1.0](Explainer.md).
 [//]: # "The W3C Web of Things [WoT] is intended to enable
 interoperability across IoT Platforms and application domains using Web technology."
 
-In the [WoT Architecture](https://w3c.github.io/wot-architecture/index.html),
+In the [WoT Architecture](https://www.w3.org/TR/wot-architecture11/),
 a Thing is defined as an abstraction of a physical IoT device such as a sensor (temperature, CO2, ...), an actuator (lamp, motor, ...), or a virtual entity (e.g., composition of one or more Things, weather service). The Thing Description (TD) provides descriptive metadata for a Thing's network interface.
 
 With a TD, clients are informed of the choices they can make when interacting with Things such reading a temperature value or switching on a lamp. This can drive applications in the same way that Web HTML pages allow users to
@@ -70,7 +70,7 @@ Based on such information a Thing Description can be designed in the following w
 }
 ```
 
-Before going into detail an important paradigm is explained that is defined by the [WoT Architecture](https://w3c.github.io/wot-architecture/index.html), namely about the interaction affordances **properties, actions**, and **events**.
+Before going into detail an important paradigm is explained that is defined by the [WoT Architecture](https://www.w3.org/TR/wot-architecture11/), namely about the interaction affordances **properties, actions**, and **events**.
 
 Each Thing and its data and functions offerings that is possible via the interface can be classified in those affordances. Sensor and/or parameter data are considered **properties**. Functions like on/off, dimming, etc. are considered **actions**. Notifications and data streams are considered **events**.
 
@@ -96,7 +96,7 @@ Now, by processing the above example TD, a client can obtain knowledge about the
 
 ## What can you do with a Thing Description (TD)?
 
-Based on the information in a TD, a WoT software stack such as that described in the [W3C Web of Things Scripting API](https://w3c.github.io/wot-scripting-api/) can interpret the TD content and automatically handle all the communication details. A developer working with the **properties, actions**, and **events** affordances does not need to deal with protocol specific details such as the HTTP method, the resource address, port number, etc.. The following video gives an insight about this aspect:
+Based on the information in a TD, a WoT software stack such as that described in the [W3C Web of Things Scripting API](https://www.w3.org/TR/wot-scripting-api/) can interpret the TD content and automatically handle all the communication details. A developer working with the **properties, actions**, and **events** affordances does not need to deal with protocol specific details such as the HTTP method, the resource address, port number, etc.. The following video gives an insight about this aspect:
 
 [![IMAGE ALT TEXT](http://img.youtube.com/vi/lt_P2BU8e3I/0.jpg)](http://www.youtube.com/watch?v=lt_P2BU8e3I "TD usage with a programming API")
 
@@ -104,7 +104,7 @@ This example also shows that TDs can be used to onboard Things into an IoT ecosy
 
 [![IMAGE ALT TEXT](http://img.youtube.com/vi/oAcYbJ6P9bU/0.jpg)](http://www.youtube.com/watch?v=oAcYbJ6P9bU "TD usage in Node-RED")
 
-TD also helps to manage IoT systems. An IoT system typically consists of a heterogenous set of devices provided by different vendors and based on different technologies and protocols (e.g. HTTP, MQTT, Modbus, etc). Directories can be used to manage the TDs (e.g., create, search, etc). [The W3C WoT Discovery](https://w3c.github.io/wot-discovery/) defines mechanisms for controlled distribution and access to TDs, including searchable directories in which TDs can be dynamically registered.
+TD also helps to manage IoT systems. An IoT system typically consists of a heterogenous set of devices provided by different vendors and based on different technologies and protocols (e.g. HTTP, MQTT, Modbus, etc). Directories can be used to manage the TDs (e.g., create, search, etc). [The W3C WoT Discovery](https://www.w3.org/TR/2023/REC-wot-discovery-20231205/) defines mechanisms for controlled distribution and access to TDs, including searchable directories in which TDs can be dynamically registered.
 
 ## What Other Features Support the Thing Description Specification?
 
@@ -112,7 +112,7 @@ Other features complementary to the TD, including Protocol Bindings, Context Ext
 
 ### Protocol Binding
 
-A Thing Description is not limited to HTTP based interfaces as shown in the example above. In general, WoT is a protocol agnostic approach and provides a common mechanism to define how specific protocols such as MQTT, HTTP, CoAP or Modbus can be mapped to the WoT’s interaction properties-action-event abstraction within the Thing Description `forms` definition. More details is provide in the [Protocol Binding section](https://w3c.github.io/wot-thing-description/#protocol-bindings).
+A Thing Description is not limited to HTTP based interfaces as shown in the example above. In general, WoT is a protocol agnostic approach and provides a common mechanism to define how specific protocols such as MQTT, HTTP, CoAP or Modbus can be mapped to the WoT’s interaction properties-action-event abstraction within the Thing Description `forms` definition. More details is provide in the [Protocol Binding section](https://www.w3.org/TR/2023/REC-wot-thing-description11-20231205/#protocol-bindings).
 
 ### TD Context Extensions
 
@@ -217,13 +217,13 @@ conceptually interconvertible with JSON.
 
 The main difference of this new specification from Thing Description 1.0 is that it includes the Thing Model concept (see above). This was only discussed in the Annex of the Thing Description 1.0 and was called Thing Description Template at that time.
 
-A new features is also possible to indicate that a Thing is following a specific profile such as the [W3C WoT Core Profile](https://w3c.github.io/wot-profile/).
+A new features is also possible to indicate that a Thing is following a specific profile such as the HTTP Basic Profile in [W3C WoT Profiles](https://www.w3.org/TR/wot-profile/).
 
 In general, TD 1.1 is backward compatible with implementations that follow version TD 1.0.
 
 The new minor version update is also used to redefine some features more clearly and to add additional examples to make it easier to understand.
 
-The complete change log with the new features and refinements can be found in the [change log section](https://w3c.github.io/wot-thing-description/#changes).
+The complete change log with the new features and refinements can be found in the [change log section](https://www.w3.org/TR/2023/REC-wot-thing-description11-20231205/#changes).
 
 ## Implementations
 


### PR DESCRIPTION
<!-- Changes to WoT documents follow the [asynchronous decision policy](https://github.com/w3c/wot/blob/main/policies/async-decision.md). Please fill below to speed up the process -->

## Description of Changes

<!-- Free-text summary of the changes made by the pull request -->

Explainers were using github.io links and unstable TD namespace.

## Related Issue

<!-- Put the issue number after # -->

Closes #2228

## Type of Change

<!-- Keep the correct line, remove the other and add the corresponding label if you are an editor. -->

<!-- In this case, once the label is added and approved by one Editor, after one week the PR can be merged. -->

- [Editorial (non-normative)](https://github.com/w3c/wot/blob/main/policies/async-decision.md#editorial-non-normative-changes) with label ![Editorial Label](https://img.shields.io/github/labels/w3c/wot-thing-description/Editorial).

